### PR TITLE
Add initial helper util functions and tests

### DIFF
--- a/google/cloud/aiplatform/utils.py
+++ b/google/cloud/aiplatform/utils.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import re
+
+from typing import Optional
+from collections import namedtuple
+
+from google.cloud.aiplatform.initializer import singleton as state
+
+SUPPORTED_REGIONS = ("us-central1", "europe-west4", "asia-east1")
+PROD_API_ENDPOINT = "aiplatform.googleapis.com"
+RESOURCE_NAME_PATTERN = re.compile(
+    r"^projects\/(?P<project>[\w-]+)\/locations\/(?P<location>[\w-]+)\/(?P<resource>\w+)\/(?P<id>\d+)$"
+)
+
+Fields = namedtuple("Fields", ["project", "location", "resource", "id",])
+
+
+def _match_to_fields(match: re.Match) -> Fields:
+    """Normalize RegEx groups from resource name pattern Match to class Fields"""
+    if not match:
+        return None
+
+    return Fields(
+        project=match["project"],
+        location=match["location"],
+        resource=match["resource"],
+        id=match["id"],
+    )
+
+
+def validate_name(resource_name: str, resource_noun: Optional[str] = None) -> Fields:
+    """Validates and returns extracted fields from a fully-qualified resource name.
+    Returns None if name is invalid.
+
+        Args:
+            resource_name (str):
+                Required. A fully-qualified AI Platform (Unified) resource name
+
+            resource_noun (str):
+                A plural resource noun to validate the resource name against.
+                For example, you would pass "datasets" to validate 
+                "projects/123/locations/us-central1/datasets/456".
+
+        Returns:
+            fields (Fields):
+                A named tuple containing four extracted fields from a resource name:
+                project, location, resource, and id. These fields can be used for 
+                subsequent method calls in the SDK.
+    """
+    fields = _match_to_fields(RESOURCE_NAME_PATTERN.match(resource_name))
+
+    if not fields:
+        return None
+    if resource_noun and fields.resource != resource_noun:
+        return None
+
+    return fields
+
+
+def get_client_options(
+    location_override: Optional[str] = None, prediction_client: Optional[bool] = False
+) -> dict:
+    """Creates client_options for GAPIC service client using location and client type.
+
+    Args:
+        location_override (str):
+            Set this parameter to get client options for a location different
+            from location set by initializer. Must be a GCP region 
+            supported by AI Platform (Unified).
+
+        prediction_client (bool):
+            True if service client is a PredictionServiceClient, otherwise
+            defaults to False. This is used to provide a prediction-specific
+            API endpoint.
+
+    Returns:
+        clients_options (dict):
+            A dictionary containing client_options with one key, for example
+            { "api_endpoint": "us-central1-aiplatform.googleapis.com" } or
+            { "api_endpoint": "asia-east1-prediction-aiplatform.googleapis.com" }
+    """
+    if not (state.location or location_override):
+        raise ValueError(
+            "No location found. Provide or initialize SDK with a valid location."
+        )
+
+    region = state.location if not location_override else location_override
+    region = region.lower()
+    prediction = "prediction-" if prediction_client else ""
+
+    if region not in SUPPORTED_REGIONS:
+        raise ValueError(
+            f"Unsupported region for AI Platform, select from {SUPPORTED_REGIONS}"
+        )
+
+    client_options = {"api_endpoint": f"{region}-{prediction}{PROD_API_ENDPOINT}"}
+
+    return client_options

--- a/tests/unit/aiplatform/test_utils.py
+++ b/tests/unit/aiplatform/test_utils.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import pytest
+from uuid import uuid4
+from random import choice
+from random import randint
+from importlib import reload
+from string import ascii_letters
+
+from google.cloud import aiplatform as aip
+from google.cloud.aiplatform.utils import Fields
+from google.cloud.aiplatform.utils import validate_name
+from google.cloud.aiplatform.utils import get_client_options
+
+
+@pytest.mark.parametrize(
+    "resource_name, expected",
+    [
+        ("projects/123456/locations/us-central1/datasets/987654", True),
+        ("projects/857392/locations/us-central1/trainingPipelines/347292", True),
+        ("projects/acme-co-proj-1/locations/us-central1/datasets/123456", True),
+        ("projects/acme-co-proj-1/locations/us-central1/datasets/abcdef", False),
+        ("project/123456/locations/us-central1/datasets/987654", False),
+        ("project//locations//datasets/987654", False),
+        ("locations/europe-west4/datasets/987654", False),
+        ("987654", False),
+    ],
+)
+def test_validate_name(resource_name: str, expected: bool):
+    # Given a resource name and expected validity, test validate_name()
+    assert expected == bool(validate_name(resource_name))
+
+
+@pytest.fixture
+def generated_resource_fields():
+    generated_fields = Fields(
+        project=str(uuid4()),
+        location=str(uuid4()),
+        resource="".join(choice(ascii_letters) for i in range(10)),  # 10 random letters
+        id=str(randint(0, 100000)),
+    )
+
+    yield generated_fields
+
+
+@pytest.fixture
+def generated_resource_name(generated_resource_fields: Fields):
+    name = (
+        f"projects/{generated_resource_fields.project}/"
+        f"locations/{generated_resource_fields.location}"
+        f"/{generated_resource_fields.resource}/{generated_resource_fields.id}"
+    )
+
+    yield name
+
+
+def test_validate_name_with_extracted_fields(
+    generated_resource_name: str, generated_resource_fields: Fields
+):
+    """Verify fields extracted from resource name match the original fields"""
+
+    assert (
+        validate_name(resource_name=generated_resource_name)
+        == generated_resource_fields
+    )
+
+
+@pytest.mark.parametrize(
+    "resource_name, resource_noun, expected",
+    [
+        # Expects pattern "projects/.../locations/.../datasets/..."
+        ("projects/123456/locations/us-central1/datasets/987654", "datasets", True),
+        # Expects pattern "projects/.../locations/.../batchPredictionJobs/..."
+        (
+            "projects/857392/locations/us-central1/trainingPipelines/347292",
+            "batchPredictionJobs",
+            False,
+        ),
+    ],
+)
+def test_validate_name_with_resource_noun(
+    resource_name: str, resource_noun: str, expected: bool
+):
+    assert (
+        bool(validate_name(resource_name=resource_name, resource_noun=resource_noun))
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "init_location, location_override, prediction, expected_endpoint",
+    [
+        ("us-central1", None, False, "us-central1-aiplatform.googleapis.com"),
+        (
+            "us-central1",
+            "europe-west4",
+            False,
+            "europe-west4-aiplatform.googleapis.com",
+        ),
+        ("asia-east1", None, False, "asia-east1-aiplatform.googleapis.com"),
+        ("asia-east1", None, True, "asia-east1-prediction-aiplatform.googleapis.com"),
+    ],
+)
+def test_get_client_options(
+    init_location: str, location_override: str, prediction: bool, expected_endpoint: str
+):
+    reload(aip)  # Reload aiplatform module to reset initializer settings
+    aip.init(location=init_location)
+
+    assert get_client_options(
+        location_override=location_override, prediction_client=prediction
+    ) == {"api_endpoint": expected_endpoint}
+
+
+def test_get_client_options_with_invalid_region():
+    with pytest.raises(ValueError):
+        reload(aip)
+        aip.init(location="us-west4")
+        get_client_options()  # Throws ValueError due to unsupported region


### PR DESCRIPTION
Creates a `utils.py` module containing two helper functions:

1. `get_client_options` — Returns a `client_options` dict based on location set by intializer or override and whether the client is for prediction .

```
from google.cloud import aiplatform as aip
from google.cloud.aiplatform.utils import get_client_options

aip.init(location="europe-west4")
get_client_options()  # { "api_endpoint": "europe-west4-aiplatform.googleapis.com" }
```

2. `validate_name` — Validates an fully-qualified AI Platform resource name and returns the contained values as properties of a tuple subclass.

```
from google.cloud.aiplatform.utils import validate_name

dataset_name = "projects/acme-co/locations/us-central1/datasets/123456"
fields = validate_name(dataset_name)
fields.project  # "acme-co"
fields.location  # "us-central1"
fields.resource  # "datasets"
fields.id  # "123456"
```

Please take a look at the tests for more usage.