### PR TITLE
feat: Add Custom Training by Python Script

### DIFF
--- a/google/cloud/aiplatform/__init__.py
+++ b/google/cloud/aiplatform/__init__.py
@@ -18,9 +18,8 @@
 from google.cloud.aiplatform import gapic
 
 from google.cloud.aiplatform import initializer
-from google.cloud.aiplatform import schema
-from google.cloud.aiplatform.models import Model
 from google.cloud.aiplatform.datasets import Dataset
+from google.cloud.aiplatform.models import Model
 from google.cloud.aiplatform.training_jobs import CustomTrainingJob
 
 """
@@ -32,4 +31,4 @@ aiplatform.init(project='my_project')
 init = initializer.global_config.init
 
 
-__all__ = ("gapic", "Model", "Dataset")
+__all__ = ("gapic", "CustomTrainingJob", "Model", "Dataset")

--- a/google/cloud/aiplatform/initializer.py
+++ b/google/cloud/aiplatform/initializer.py
@@ -77,15 +77,21 @@ class _Config:
         if self._project:
             return self._project
 
+        project_not_found_exception_str = (
+            "Unable to find your project. Please provide a project ID by:"
+            "\n- Passing a constructor argument"
+            "\n- Using aiplatform.init()"
+            "\n- Setting a GCP environment variable"
+        )
+
         try:
             _, project_id = google.auth.default()
         except GoogleAuthError:
-            raise GoogleAuthError(
-                "Unable to find your project. Please provide a project ID by:"
-                "\n- Passing a constructor argument"
-                "\n- Using aiplatform.init()"
-                "\n- Setting a GCP environment variable"
-            )
+            raise GoogleAuthError(project_not_found_exception_str)
+
+        if not project_id:
+            raise ValueError(project_not_found_exception_str)
+
         return project_id
 
     @property

--- a/google/cloud/aiplatform/schema.py
+++ b/google/cloud/aiplatform/schema.py
@@ -15,21 +15,16 @@
 # limitations under the License.
 #
 
-from google.cloud.aiplatform import gapic
-
-from google.cloud.aiplatform import initializer
-from google.cloud.aiplatform import schema
-from google.cloud.aiplatform.models import Model
-from google.cloud.aiplatform.datasets import Dataset
-from google.cloud.aiplatform.training_jobs import CustomTrainingJob
-
-"""
-Usage:
-from google.cloud import aiplatform
-
-aiplatform.init(project='my_project')
-"""
-init = initializer.global_config.init
+"""Namespaced AI Platform Schemas."""
 
 
-__all__ = ("gapic", "Model", "Dataset")
+class training_job:
+    class definition:
+        custom_task = "gs://google-cloud-aiplatform/schema/trainingjob/definition/custom_task_1.0.0.yaml"
+
+
+class dataset:
+    class metadata:
+        tabular = (
+            "gs://google-cloud-aiplatform/schema/dataset/metadata/tabular_1.0.0.yaml"
+        )

--- a/google/cloud/aiplatform/schema.py
+++ b/google/cloud/aiplatform/schema.py
@@ -16,6 +16,8 @@
 #
 
 """Namespaced AI Platform Schemas."""
+
+
 class training_job:
     class definition:
         custom_task = "gs://google-cloud-aiplatform/schema/trainingjob/definition/custom_task_1.0.0.yaml"

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -17,20 +17,69 @@
 
 import datetime
 import functools
+import logging
 import pathlib
 import shutil
 import subprocess
 import sys
 import tempfile
-from typing import Callable, Dict, Optional, Sequence
+import time
+from typing import Callable, Dict, List, Optional, Sequence
 
 
 from google.auth import credentials as auth_credentials
 from google.cloud.aiplatform import base
 from google.cloud.aiplatform import datasets
+from google.cloud.aiplatform import initializer
 from google.cloud.aiplatform import models
+from google.cloud.aiplatform import schema
+from google.cloud.aiplatform import utils
+from google.cloud.aiplatform_v1beta1 import AcceleratorType
+from google.cloud.aiplatform_v1beta1 import CustomJobSpec
+from google.cloud.aiplatform_v1beta1 import FractionSplit
+from google.cloud.aiplatform_v1beta1 import GcsDestination
+from google.cloud.aiplatform_v1beta1 import InputDataConfig
+from google.cloud.aiplatform_v1beta1 import JobServiceClient
+from google.cloud.aiplatform_v1beta1 import Model
+from google.cloud.aiplatform_v1beta1 import ModelContainerSpec
 from google.cloud.aiplatform_v1beta1 import PipelineServiceClient
+from google.cloud.aiplatform_v1beta1 import PipelineState
+from google.cloud.aiplatform_v1beta1 import TrainingPipeline
 from google.cloud import storage
+from google.protobuf import json_format
+from google.protobuf.struct_pb2 import Value
+from google.rpc import code_pb2
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+_LOGGER = logging.getLogger(__name__)
+
+_PIPELINE_COMPLETE_STATES = set(
+    [
+        PipelineState.PIPELINE_STATE_SUCCEEDED,
+        PipelineState.PIPELINE_STATE_FAILED,
+        PipelineState.PIPELINE_STATE_CANCELLED,
+        PipelineState.PIPELINE_STATE_PAUSED,
+    ]
+)
+
+
+def _timestamped_gcs_dir(root_gcs_path: str, dir_name_prefix: str) -> str:
+    """Composes a timestamped GCS directory.
+
+    Args:
+        root_gcs_path: GCS path to put the timestamped directory.
+        dir_name_prefix: Prefix to add the timestamped directory.
+    Returns:
+        Timestamped gcs directory path in root_gcs_path.
+    """
+    timestamp = datetime.datetime.now().isoformat(sep="-", timespec="milliseconds")
+    dir_name = "-".join([dir_name_prefix, timestamp])
+    if root_gcs_path.endswith("/"):
+        root_gcs_path = root_gcs_path[:-1]
+    gcs_path = "/".join([root_gcs_path, dir_name])
+    if not gcs_path.startswith("gs://"):
+        return "gs://" + gcs_path
+    return gcs_path
 
 
 def _timestamped_copy_to_gcs(
@@ -151,6 +200,9 @@ setup(
         "{python_executable} setup.py sdist --formats=gztar"
     )
 
+    # Module name that can be executed during training. ie. python -m
+    module_name = f"{_ROOT_MODULE}.{_TASK_MODULE_NAME}"
+
     def __init__(self, script_path: str, requirements: Optional[Sequence[str]] = None):
         """Initializes packager.
 
@@ -254,7 +306,9 @@ setup(
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             source_distribution_path = self.make_package(tmpdirname)
-            return copy_method(source_distribution_path)
+            output_location = copy_method(source_distribution_path)
+            _LOGGER.info("Training script copied to:\n%s." % output_location)
+            return output_location
 
     def package_and_copy_to_gcs(
         self,
@@ -281,46 +335,474 @@ setup(
         )
         return self.package_and_copy(copy_method=copy_method)
 
-    @property
-    def module_name(self) -> str:
-        """Module name that can be executed during training. ie. python -m"""
-        return f"{self._ROOT_MODULE}.{self._TASK_MODULE_NAME}"
 
+# TODO(b/172368325) add scheduling, custom_job.Scheduling
+class CustomTrainingJob(base.AiPlatformResourceNoun):
+    """Class to launch a Custom Training Job in AI Platform using a script.
 
-class TrainingJob(base.AiPlatformResourceNoun):
+    Takes a training implementation as a python script and executes that script
+    in Cloud AI Platform Training. 
+    """
 
     client_class = PipelineServiceClient
     _is_client_prediction_client = False
 
+    # TODO(b/172365796) add remainder of model optional arguments
     def __init__(
         self,
         display_name: str,
         script_path: str,
         container_uri: str,
+        requirements: Optional[Sequence[str]] = None,
+        model_serving_container_image_uri: Optional[str] = None,
+        model_serving_container_predict_route: Optional[str] = None,
+        model_serving_container_health_route: Optional[str] = None,
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         staging_bucket: Optional[str] = None,
     ):
-        pass
+        """Constructs a Custom Training Job from a Python script.
 
+        job = aiplatform.CustomTrainingJob(
+            display_name='test-train',
+            script_path='test_script.py',
+            requirements=['pandas', 'numpy'],
+            container_uri='gcr.io/cloud-aiplatform/training/tf-cpu.2-2:latest',
+            model_serving_container_image_uri='gcr.io/my-trainer/serving:1',
+            model_serving_container_predict_route='predict',
+            model_serving_container_health_route='metadata)
+
+        Usage with Dataset:
+
+        ds = aiplatform.Dataset(
+            'projects/my-project/locations/us-central1/datasets/12345')
+        
+        job.run(ds, replica_count=1, model_display_name='my-trained-model')
+
+        Usage without Dataset:
+        
+        job.run(replica_count=1, model_display_name='my-trained-model)
+
+
+        TODO(b/169782082) add documentation about traning utilities        
+        To ensure your model gets saved in AI Platform, write your saved model to
+        os.environ["AIP_MODEL_DIR"] in your provided training script.
+
+
+        Args:
+            display_name (str):
+                Required. The user-defined name of this TrainingPipeline.
+            script_path (str): Required. Local path to training script.
+            container_uri (str): 
+                Required: Uri of the training container image in the GCR.
+            requirements (Sequence[str]):
+                List of python packages dependencies of script.
+            project (str): 
+                Optional project to retrieve model from. If not set, project set in
+                aiplatform.init will be used.
+            location (str):
+                Optional location to retrieve model from. If not set, location set in
+                aiplatform.init will be used.
+            credentials (auth_credentials.Credentials):
+                Optional credentials to use to retrieve the model.
+            model_serving_container_image_uri (str):
+                If the training produces a managed AI Platform Model, the URI of the
+                Model serving container suitable for serving the model produced by the
+                training script.
+            model_serving_container_predict_route (str):.
+                If the training produces a managed AI Platform Model, An HTTP path to
+                send prediction requests to the container, and which must be supported
+                by it. If not specified a default HTTP path will be used by AI Platform.
+            model_serving_container_health_route (str):
+                If the training produces a managed AI Platform Model, an HTTP path to
+                send health check requests to the container, and which must be supported
+                by it. If not specified a standard HTTP path will be used by AI
+                Platform.
+            project (str):
+                Project to run training in. Overrides project set in aiplatform.init.
+            location (str):
+                Location to run training in. Overrides location set in aiplatform.init.
+            credentials (auth_credentials.Credentials):
+                Custom credentials to use to run call training service. Overrides
+                credentials set in aiplatform.init.
+            staging_bucket (str):
+                Bucket used to stage source and training artifacts. Overrides
+                staging_bucket set in aiplatform.init.  
+        """
+        super().__init__(project=project, location=location, credentials=credentials)
+        self._display_name = display_name
+        self._script_path = script_path
+        self._container_uri = container_uri
+        self._requirements = requirements
+        self._staging_bucket = staging_bucket
+        self._project = project
+        self._credentials = credentials
+        self._model_serving_container_image_uri = model_serving_container_image_uri
+        self._model_serving_container_predict_route = (
+            model_serving_container_predict_route
+        )
+        self._model_serving_container_health_route = (
+            model_serving_container_health_route
+        )
+        self._gca_resource = None
+
+    # TODO(b/172365904) add filter split, training_pipline.FilterSplit
+    # TODO(b/172366411) predefined filter split training_pipeline.PredfinedFilterSplit
+    # TODO(b/172368070) add timestamp split, training_pipeline.TimestampSplit
     def run(
         self,
-        dataset: Optional[datasets.Dataset],
-        output_dir: Optional[str] = None,
+        dataset: Optional[datasets.Dataset] = None,
+        model_display_name: Optional[str] = None,
+        base_output_dir: Optional[str] = None,
         args: Optional[Dict[str, str]] = None,
-        replica_count=0,
-        machine_type="n1-standard-4",
-        accelerator_type=None,
-        accelerator_count=0,
-        spec_yaml_path: Optional[str] = None,
-    ) -> models.Model:
-        pass
+        replica_count: str = 0,
+        machine_type: str = "n1-standard-4",
+        accelerator_type: str = "ACCELERATOR_TYPE_UNSPECIFIED",
+        accelerator_count: int = 0,
+        training_fraction_split: float = 0.8,
+        validation_fraction_split: float = 0.1,
+        test_fraction_split: float = 0.1,
+    ) -> Optional[models.Model]:
+        """Runs the custom training job.
+
+        Data fraction splits:
+        Any of ``training_fraction_split``, ``validation_fraction_split`` and
+        ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
+        the provided ones sum to less than 1, the remainder is assigned to sets as
+        decided by AI Platform.If none of the fractions are set, by default roughly 80%
+        of data will be used for training, 10% for validation, and 10% for test.
+
+        Args:
+            dataset (aiplatform.Dataset):
+                AI Platform to fit this training against. Custom training script should
+                retrieve datasets through passed in environement variables uris:
+                
+                os.environ["AIP_TRAINING_DATA_URI"]
+                os.environ["AIP_VALIDATION_DATA_URI"]
+                os.environ["AIP_TEST_DATA_URI"]
+
+                Additionally the dataset format is passed in as:
+                
+                os.environ["AIP_DATA_FORMAT"]
+            model_display_name (str):
+                If the script produces a managed AI Platform Model. The display name of
+                the Model. The name can be up to 128 characters long and can be consist
+                of any UTF-8 characters.
+            base_output_dir (str):
+                GCS output directory of job. If not provided a 
+                timestamped directory in the staging directory will be used.
+            args (Dict[str, str]):
+                Key-value pair or command line arguments to be passed to the Python
+                script.
+            replica_count (int):
+                The number of worker replicas.
+            accelerator_type (str):
+                Hardware accelerator type. One of ACCELERATOR_TYPE_UNSPECIFIED,
+                NVIDIA_TESLA_K80, NVIDIA_TESLA_P100, NVIDIA_TESLA_V100, NVIDIA_TESLA_P4,
+                NVIDIA_TESLA_T4, TPU_V2, TPU_V3
+            accelerator_count (int):
+                The number of accelerators to attach to a worker replica.
+            training_fraction_split (float):
+                The fraction of the input data that is to be
+                used to train the Model.
+            validation_fraction_split (float):
+                The fraction of the input data that is to be
+                used to validate the Model.
+            test_fraction_split (float):
+                The fraction of the input data that is to be
+                used to evaluate the Model.
+
+        Returns:
+            model: The trained AI Platform Model resource or None if training did not
+                produce an AI Platform Model.
+
+        Raises:
+            RuntimeError if Training job has already been run, staging_bucket has not
+                been set, or model_display_name was provided but required arguments
+                were not provided in constructor.
+            NotImplementedError more then one replica.
+            ValueError if accelerator type is not valid.
+        """
+
+        def format_args(args: Dict[str, str]) -> List[str]:
+            """Formats key-value arguments.
+
+            Args:
+                args (Dict[str, str]):
+                    Required: key-value pair or arguments.
+            Returns:
+                arg_string: List of formated arguments.
+            """
+            return [f"--{key}={value}" for key, value in args.items()]
+
+        if self._has_run:
+            raise RuntimeError("Custom Training has already run.")
+
+        # TODO(b/172369809) Add support for distributed training.
+        if replica_count > 1:
+            raise NotImplementedError("Distributed training not supported.")
+
+        # validate accelerator type
+        if accelerator_type not in AcceleratorType._member_names_:
+            raise ValueError(
+                f"accelerator_type {accelerator_type} invalid. "
+                f"Choose one of {AcceleratorType._member_names_}"
+            )
+
+        staging_bucket = (
+            self._staging_bucket or initializer.global_config.staging_bucket
+        )
+
+        if not staging_bucket:
+            raise RuntimeError(
+                "staging_bucket should be set in TrainingJob constructor or "
+                "set using aiplatform.init(staging_bucket='gs://my-bucket'"
+            )
+
+        # if args need for model is incomplete
+        # TODO (b/162273530) lift requirement for predict/health route when
+        # validation lifted and move these args down
+        if model_display_name and not all(
+            [
+                self._model_serving_container_image_uri,
+                self._model_serving_container_predict_route,
+                self._model_serving_container_health_route,
+            ]
+        ):
+
+            raise RuntimeError(
+                """model_display_name was provided but 
+                model_serving_container_image_uri,
+                model_serving_container_predict_route, and
+                model_serving_container_health_route were not provided when this 
+                custom pipeline was constructed.
+                """
+            )
+
+        # make and copy package
+        python_packager = _TrainingScriptPythonPackager(
+            script_path=self._script_path, requirements=self._requirements
+        )
+
+        package_gcs_uri = python_packager.package_and_copy_to_gcs(
+            gcs_staging_dir=staging_bucket,
+            project=self._project or initializer.global_config.project,
+            credentials=self._credentials or initializer.global_config.credentials,
+        )
+
+        # default directory if not given
+        base_output_dir = base_output_dir or _timestamped_gcs_dir(
+            staging_bucket, "aiplatform-custom-training"
+        )
+
+        # create worker pool spec
+        worker_pool_spec = {
+            "replicaCount": replica_count,
+            "machineSpec": {"machineType": machine_type},
+            "pythonPackageSpec": {
+                "executorImageUri": self._container_uri,
+                "pythonModule": python_packager.module_name,
+                "packageUris": [package_gcs_uri],
+            },
+        }
+
+        accelerator_enum = getattr(AcceleratorType, accelerator_type)
+
+        if accelerator_enum != AcceleratorType.ACCELERATOR_TYPE_UNSPECIFIED:
+            worker_pool_spec["machineSpec"]["acceleratorType"] = accelerator_type
+            worker_pool_spec["machineSpec"]["acceleratorCount"] = accelerator_count
+
+        if args:
+            worker_pool_spec["pythonPackageSpec"]["args"] = format_args(args)
+
+        managed_model = None
+        # create model payload
+        if model_display_name:
+
+            container_spec = ModelContainerSpec(
+                image_uri=self._model_serving_container_image_uri,
+                predict_route=self._model_serving_container_predict_route,
+                health_route=self._model_serving_container_health_route,
+            )
+
+            managed_model = Model(
+                display_name=model_display_name, container_spec=container_spec
+            )
+
+        input_data_config = None
+        if dataset:
+            # Create fraction split spec
+            fraction_split = FractionSplit(
+                training_fraction=training_fraction_split,
+                validation_fraction=validation_fraction_split,
+                test_fraction=test_fraction_split,
+            )
+
+            # create input data config
+            input_data_config = InputDataConfig(
+                fraction_split=fraction_split,
+                dataset_id=dataset.name,
+                gcs_destination=GcsDestination(output_uri_prefix=base_output_dir),
+            )
+
+        # create training pipeline
+        training_pipeline = TrainingPipeline(
+            display_name=self._display_name,
+            training_task_definition=schema.training_job.definition.custom_task,
+            training_task_inputs=json_format.ParseDict(
+                {
+                    "workerPoolSpecs": [worker_pool_spec],
+                    "baseOutputDirectory": {"output_uri_prefix": base_output_dir},
+                },
+                Value(),
+            ),
+            model_to_upload=managed_model,
+            input_data_config=input_data_config,
+        )
+
+        training_pipeline = self.api_client.create_training_pipeline(
+            parent=initializer.global_config.common_location_path(
+                self.project, self.location
+            ),
+            training_pipeline=training_pipeline,
+        )
+
+        self._gca_resource = training_pipeline
+
+        _LOGGER.info("View Training:\n%s" % self._dashboard_uri())
+        _LOGGER.info("Training Output directory:\n%s " % base_output_dir)
+
+        model = self._get_model()
+
+        if model is None:
+            _LOGGER.warn(
+                "Training did not produce a Managed Model returning None. "
+                + self._model_upload_fail_string
+            )
+        return model
+
+    def _sync_gca_resource(self):
+        """Helper method to sync the local gca_source against the service."""
+        self._gca_resource = self.api_client.get_training_pipeline(
+            name=self.resource_name
+        )
+
+    def _block_until_complete(self):
+        """Helper method to block and check on job until complete."""
+
+        # Used these numbers so failures surface fast
+        wait = 5  # start at five seconds
+        max_wait = 60 * 5  # 5 minute wait
+        multiplier = 2  # scale wait by 2 every iteration
+
+        while self.state not in _PIPELINE_COMPLETE_STATES:
+            self._sync_gca_resource()
+            time.sleep(wait)
+            _LOGGER.info(
+                "Training %s current state:\n%s"
+                % (self._gca_resource.name, self._gca_resource.state)
+            )
+            wait = min(wait * multiplier, max_wait)
+
+        self._raise_failure()
+
+        if self._gca_resource.model_to_upload and not self.is_failed:
+            _LOGGER.info(
+                "Model available at %s" % self._gca_resource.model_to_upload.name
+            )
+
+    def _raise_failure(self):
+        """Helper method to raise failure if TrainingPipeline fails.
+
+        Raises:
+            RuntimeError: If training failed."""
+        if self._gca_resource.error.code != code_pb2.OK:
+            raise RuntimeError("Training failed with:\n%s" % self._gca_resource.error)
+
+    def _get_model(self) -> Optional[models.Model]:
+        """Helper method to get and instantiate the Model to Upload.
+
+        Returns:
+            model: AI Platform Model if training succeeded and produced an AI Platform
+                Model. None otherwise.
+
+        Raises:
+            RuntimeError if Training failed.
+        """
+        self._block_until_complete()
+
+        if self.is_failed:
+            raise RuntimeError(
+                f"Training Pipeline {self.resource_name} failed. No model available."
+            )
+
+        if not self._gca_resource.model_to_upload:
+            return None
+
+        if self._gca_resource.model_to_upload.name:
+            fields = utils.extract_fields_from_resource_name(
+                self._gca_resource.model_to_upload.name
+            )
+            return models.Model(
+                fields.id, project=fields.project, location=fields.location
+            )
+
+    @property
+    def _model_upload_fail_string(self) -> str:
+        """Helper property for model upload failure."""
+        return (
+            f"Training Pipeline {self.resource_name} is not configured to upload a "
+            "Model. Create the Training Pipeline with "
+            "model_serving_container_image_uri and model_display_name passed in. "
+            "Ensure that your training script saves to model to "
+            "os.environ['AIP_MODEL_DIR']."
+        )
+
+    def get_model(self) -> Optional[models.Model]:
+        """AI Platform Model produced by this training, if one was produced.
+
+        Returns:
+            model: AI Platform Model produced by this training or None if a model was
+                not produced by this training.  
+        """
+        self._assert_has_run()
+        if not self._gca_resource.model_to_upload:
+            raise RuntimeError(self._model_upload_fail_string)
+
+        return self._get_model()
+
+    @property
+    def _has_run(self) -> bool:
+        """Helper property to check if this training job has been run."""
+        return self._gca_resource is not None
+
+    def _assert_has_run(self):
+        """Helper method to assert that this training has run."""
+        if not self._has_run:
+            raise RuntimeError(
+                "TrainingPipeline has not been launched. You must run this"
+                " TrainingPipeline using TrainingPipeline.run. "
+            )
+
+    @property
+    def state(self) -> PipelineState:
+        """Current training state."""
+        self._assert_has_run()
+        return self._gca_resource.state
+
+    @property
+    def is_failed(self) -> bool:
+        """Returns True if training has failed. False otherwise."""
+        self._assert_has_run()
+        return self.state == PipelineState.PIPELINE_STATE_FAILED
+
+    def _dashboard_uri(self) -> str:
+        """Helper method to compose the dashboard uri where training can be viewed."""
+        fields = utils.extract_fields_from_resource_name(self.resource_name)
+        url = f"https://console.cloud.google.com/ai/platform/locations/{fields.location}/training/{fields.id}?project={fields.project}"
+        return url
 
 
-class CustomTrainingJob(TrainingJob):
-    pass
-
-
-class AutoMLTablesTrainingJob(TrainingJob):
+class AutoMLTablesTrainingJob(base.AiPlatformResourceNoun):
     pass

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -704,7 +704,7 @@ class CustomTrainingJob(base.AiPlatformResourceNoun):
 
         self._raise_failure()
 
-        if self._gca_resource.model_to_upload and not self.is_failed:
+        if self._gca_resource.model_to_upload and not self.has_failed:
             _LOGGER.info(
                 "Model available at %s" % self._gca_resource.model_to_upload.name
             )
@@ -729,7 +729,7 @@ class CustomTrainingJob(base.AiPlatformResourceNoun):
         """
         self._block_until_complete()
 
-        if self.is_failed:
+        if self.has_failed:
             raise RuntimeError(
                 f"Training Pipeline {self.resource_name} failed. No model available."
             )
@@ -789,7 +789,7 @@ class CustomTrainingJob(base.AiPlatformResourceNoun):
         return self._gca_resource.state
 
     @property
-    def is_failed(self) -> bool:
+    def has_failed(self) -> bool:
         """Returns True if training has failed. False otherwise."""
         self._assert_has_run()
         return self.state == gca_pipeline_state.PipelineState.PIPELINE_STATE_FAILED

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -35,11 +35,9 @@ from google.cloud.aiplatform import models
 from google.cloud.aiplatform import schema
 from google.cloud.aiplatform import utils
 from google.cloud.aiplatform_v1beta1 import AcceleratorType
-from google.cloud.aiplatform_v1beta1 import CustomJobSpec
 from google.cloud.aiplatform_v1beta1 import FractionSplit
 from google.cloud.aiplatform_v1beta1 import GcsDestination
 from google.cloud.aiplatform_v1beta1 import InputDataConfig
-from google.cloud.aiplatform_v1beta1 import JobServiceClient
 from google.cloud.aiplatform_v1beta1 import Model
 from google.cloud.aiplatform_v1beta1 import ModelContainerSpec
 from google.cloud.aiplatform_v1beta1 import PipelineServiceClient
@@ -341,7 +339,7 @@ class CustomTrainingJob(base.AiPlatformResourceNoun):
     """Class to launch a Custom Training Job in AI Platform using a script.
 
     Takes a training implementation as a python script and executes that script
-    in Cloud AI Platform Training. 
+    in Cloud AI Platform Training.
     """
 
     client_class = PipelineServiceClient
@@ -377,15 +375,15 @@ class CustomTrainingJob(base.AiPlatformResourceNoun):
 
         ds = aiplatform.Dataset(
             'projects/my-project/locations/us-central1/datasets/12345')
-        
+
         job.run(ds, replica_count=1, model_display_name='my-trained-model')
 
         Usage without Dataset:
-        
+
         job.run(replica_count=1, model_display_name='my-trained-model)
 
 
-        TODO(b/169782082) add documentation about traning utilities        
+        TODO(b/169782082) add documentation about traning utilities
         To ensure your model gets saved in AI Platform, write your saved model to
         os.environ["AIP_MODEL_DIR"] in your provided training script.
 
@@ -394,11 +392,11 @@ class CustomTrainingJob(base.AiPlatformResourceNoun):
             display_name (str):
                 Required. The user-defined name of this TrainingPipeline.
             script_path (str): Required. Local path to training script.
-            container_uri (str): 
+            container_uri (str):
                 Required: Uri of the training container image in the GCR.
             requirements (Sequence[str]):
                 List of python packages dependencies of script.
-            project (str): 
+            project (str):
                 Optional project to retrieve model from. If not set, project set in
                 aiplatform.init will be used.
             location (str):
@@ -428,7 +426,7 @@ class CustomTrainingJob(base.AiPlatformResourceNoun):
                 credentials set in aiplatform.init.
             staging_bucket (str):
                 Bucket used to stage source and training artifacts. Overrides
-                staging_bucket set in aiplatform.init.  
+                staging_bucket set in aiplatform.init.
         """
         super().__init__(project=project, location=location, credentials=credentials)
         self._display_name = display_name
@@ -477,20 +475,20 @@ class CustomTrainingJob(base.AiPlatformResourceNoun):
             dataset (aiplatform.Dataset):
                 AI Platform to fit this training against. Custom training script should
                 retrieve datasets through passed in environement variables uris:
-                
+
                 os.environ["AIP_TRAINING_DATA_URI"]
                 os.environ["AIP_VALIDATION_DATA_URI"]
                 os.environ["AIP_TEST_DATA_URI"]
 
                 Additionally the dataset format is passed in as:
-                
+
                 os.environ["AIP_DATA_FORMAT"]
             model_display_name (str):
                 If the script produces a managed AI Platform Model. The display name of
                 the Model. The name can be up to 128 characters long and can be consist
                 of any UTF-8 characters.
             base_output_dir (str):
-                GCS output directory of job. If not provided a 
+                GCS output directory of job. If not provided a
                 timestamped directory in the staging directory will be used.
             args (Dict[str, str]):
                 Key-value pair or command line arguments to be passed to the Python
@@ -572,10 +570,10 @@ class CustomTrainingJob(base.AiPlatformResourceNoun):
         ):
 
             raise RuntimeError(
-                """model_display_name was provided but 
+                """model_display_name was provided but
                 model_serving_container_image_uri,
                 model_serving_container_predict_route, and
-                model_serving_container_health_route were not provided when this 
+                model_serving_container_health_route were not provided when this
                 custom pipeline was constructed.
                 """
             )
@@ -764,7 +762,7 @@ class CustomTrainingJob(base.AiPlatformResourceNoun):
 
         Returns:
             model: AI Platform Model produced by this training or None if a model was
-                not produced by this training.  
+                not produced by this training.
         """
         self._assert_has_run()
         if not self._gca_resource.model_to_upload:

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -24,7 +24,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import Callable, Dict, List, Optional, Sequence, Union
+from typing import Callable, List, Optional, Sequence, Union
 
 
 from google.auth import credentials as auth_credentials

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -119,6 +119,7 @@ class TestDataset:
             yield export_data_mock
 
     def test_init_dataset(self, get_dataset_mock):
+        aiplatform.init(project=_TEST_PROJECT)
         Dataset(dataset_name=_TEST_NAME)
         get_dataset_mock.assert_called_once_with(name=_TEST_NAME)
 

--- a/tests/unit/aiplatform/test_lro.py
+++ b/tests/unit/aiplatform/test_lro.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from importlib import reload
+from unittest import mock
+
 
 from google.api_core import operation
+from google.cloud import aiplatform
 from google.cloud.aiplatform import base
+from google.cloud.aiplatform import initializer
 from google.cloud.aiplatform import lro
 from google.cloud.aiplatform_v1beta1.services.model_service.client import (
     ModelServiceClient,
@@ -26,6 +30,18 @@ from google.protobuf import struct_pb2 as struct
 
 
 TEST_OPERATION_NAME = "test/operation"
+_TEST_PROJECT = "test-project"
+
+
+def setup_module(module):
+    reload(initializer)
+    reload(aiplatform)
+    aiplatform.init(project=_TEST_PROJECT)
+
+
+def teardown_module(module):
+    reload(initializer)
+    reload(aiplatform)
 
 
 class AiPlatformResourceNounImpl(base.AiPlatformResourceNoun):

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -727,7 +727,7 @@ class TestCustomTrainingJob:
         )
 
         with pytest.raises(RuntimeError):
-            model = job.get_model()
+            job.get_model()
 
     def test_run_raises_if_pipeline_fails(
         self,
@@ -759,7 +759,7 @@ class TestCustomTrainingJob:
             )
 
         with pytest.raises(RuntimeError):
-            model = job.get_model()
+            job.get_model()
 
     def test_raises_before_run_is_called(
         self, mock_pipeline_service_create, mock_python_package_to_gcs

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -13,11 +13,28 @@ from importlib import reload
 from unittest.mock import patch
 
 from google.cloud import aiplatform
+from google.cloud.aiplatform.datasets import Dataset
+from google.cloud.aiplatform import schema
+from google.cloud.aiplatform import training_jobs
 from google.cloud.aiplatform.training_jobs import _timestamped_copy_to_gcs
 from google.cloud.aiplatform.training_jobs import _get_python_executable
 from google.cloud.aiplatform.training_jobs import _TrainingScriptPythonPackager
+from google.cloud.aiplatform_v1beta1 import FractionSplit
+from google.cloud.aiplatform_v1beta1 import GcsDestination
+from google.cloud.aiplatform_v1beta1 import InputDataConfig
+from google.cloud.aiplatform_v1beta1 import Model
+from google.cloud.aiplatform_v1beta1 import ModelContainerSpec
+from google.cloud.aiplatform_v1beta1 import ModelServiceClient
+from google.cloud.aiplatform_v1beta1 import PipelineServiceClient
+from google.cloud.aiplatform_v1beta1 import PipelineState
+from google.cloud.aiplatform_v1beta1 import TrainingPipeline
+
 from google.cloud.aiplatform import initializer
 from google.cloud import storage
+
+from google.protobuf import json_format
+from google.protobuf.struct_pb2 import Value
+
 
 _TEST_BUCKET_NAME = "test-bucket"
 _TEST_GCS_PATH_WITHOUT_BUCKET = "path/to/folder"
@@ -30,6 +47,33 @@ _TEST_PYTHON_SOURCE = """
 print('hello world')
 """
 _TEST_REQUIREMENTS = ["pandas", "numpy", "tensorflow"]
+
+_TEST_DISPLAY_NAME = "test-display-name"
+_TEST_TRAINING_CONTAINER_IMAGE = "gcr.io/test-training/container:image"
+_TEST_SERVING_CONTAINER_IMAGE = "gcr.io/test-serving/container:image"
+_TEST_SERVING_CONTAINER_PREDICTION_ROUTE = "predict"
+_TEST_SERVING_CONTAINER_HEALTH_ROUTE = "metadata"
+
+_TEST_DATASET_NAME = "test-dataset-name"
+_TEST_BASE_OUTPUT_DIR = "gs://test-base-output-dir"
+_TEST_RUN_ARGS = {"test": "arg", "foo": 1}
+_TEST_REPLICA_COUNT = 1
+_TEST_MACHINE_TYPE = "n1-standard-4"
+_TEST_ACCELERATOR_TYPE = "NVIDIA_TESLA_K80"
+_TEST_INVALID_ACCELERATOR_TYPE = "NVIDIA_DOES_NOT_EXIST"
+_TEST_ACCELERATOR_COUNT = 1
+_TEST_MODEL_DISPLAY_NAME = "model-display-name"
+_TEST_TRAINING_FRACTION_SPLIT = 0.6
+_TEST_VALIDATION_FRACTION_SPLIT = 0.2
+_TEST_TEST_FRACTION_SPLIT = 0.2
+
+_TEST_OUTPUT_PYTHON_PACKAGE_PATH = "gs://test/ouput/python/trainer.tar.gz"
+
+_TEST_MODEL_NAME = "projects/my-project/locations/us-central1/models/12345"
+
+_TEST_PIPELINE_RESOURCE_NAME = (
+    "projects/my-project/locations/us-central1/trainingPipeline/12345"
+)
 
 
 def local_copy_method(path):
@@ -246,3 +290,519 @@ class TestTrainingScriptPythonPackager:
 
         assert gcs_path.endswith("-aiplatform_custom_trainer_script-0.1.tar.gz")
         assert gcs_path.startswith(f"gs://{_TEST_BUCKET_NAME}")
+
+
+class TestCustomTrainingJob:
+    def setup_method(self):
+        reload(initializer)
+        reload(aiplatform)
+        with open(_TEST_LOCAL_SCRIPT_FILE_NAME, "w") as fp:
+            fp.write(_TEST_PYTHON_SOURCE)
+
+    def teardown_method(self):
+        pathlib.Path(_TEST_LOCAL_SCRIPT_FILE_NAME).unlink()
+
+    @pytest.fixture
+    def mock_pipeline_service_create(self):
+        with mock.patch.object(
+            PipelineServiceClient, "create_training_pipeline"
+        ) as mock_create_training_pipeline:
+            mock_create_training_pipeline.return_value = TrainingPipeline(
+                name=_TEST_PIPELINE_RESOURCE_NAME,
+                state=PipelineState.PIPELINE_STATE_SUCCEEDED,
+                model_to_upload=Model(name=_TEST_MODEL_NAME),
+            )
+            yield mock_create_training_pipeline
+
+    @pytest.fixture
+    def mock_pipeline_service_create_with_no_model_to_upload(self):
+        with mock.patch.object(
+            PipelineServiceClient, "create_training_pipeline"
+        ) as mock_create_training_pipeline:
+            mock_create_training_pipeline.return_value = TrainingPipeline(
+                name=_TEST_PIPELINE_RESOURCE_NAME,
+                state=PipelineState.PIPELINE_STATE_SUCCEEDED,
+            )
+            yield mock_create_training_pipeline
+
+    @pytest.fixture
+    def mock_pipeline_service_create_and_get_with_fail(self):
+        with mock.patch.object(
+            PipelineServiceClient, "create_training_pipeline"
+        ) as mock_create_training_pipeline:
+            mock_create_training_pipeline.return_value = TrainingPipeline(
+                name=_TEST_PIPELINE_RESOURCE_NAME,
+                state=PipelineState.PIPELINE_STATE_RUNNING,
+            )
+
+            with mock.patch.object(
+                PipelineServiceClient, "get_training_pipeline"
+            ) as mock_get_training_pipeline:
+                mock_get_training_pipeline.return_value = TrainingPipeline(
+                    name=_TEST_PIPELINE_RESOURCE_NAME,
+                    state=PipelineState.PIPELINE_STATE_FAILED,
+                )
+
+                yield mock_create_training_pipeline, mock_get_training_pipeline
+
+    @pytest.fixture
+    def mock_model_service_get(self):
+        with mock.patch.object(ModelServiceClient, "get_model") as mock_get_model:
+            mock_get_model.return_value = Model()
+            yield mock_get_model
+
+    @pytest.fixture
+    def mock_python_package_to_gcs(self):
+        with mock.patch.object(
+            _TrainingScriptPythonPackager, "package_and_copy_to_gcs"
+        ) as mock_package_to_copy_gcs:
+            mock_package_to_copy_gcs.return_value = _TEST_OUTPUT_PYTHON_PACKAGE_PATH
+            yield mock_package_to_copy_gcs
+
+    @pytest.fixture
+    def mock_dataset(self):
+        ds = mock.MagicMock(Dataset)
+        ds.name = _TEST_DATASET_NAME
+        return ds
+
+    def test_run_call_pipeline_service_create(
+        self,
+        mock_pipeline_service_create,
+        mock_python_package_to_gcs,
+        mock_dataset,
+        mock_model_service_get,
+    ):
+        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+
+        job = training_jobs.CustomTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            script_path=_TEST_LOCAL_SCRIPT_FILE_NAME,
+            container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
+            model_serving_container_image_uri=_TEST_SERVING_CONTAINER_IMAGE,
+            model_serving_container_predict_route=_TEST_SERVING_CONTAINER_PREDICTION_ROUTE,
+            model_serving_container_health_route=_TEST_SERVING_CONTAINER_HEALTH_ROUTE,
+        )
+
+        model_from_job = job.run(
+            dataset=mock_dataset,
+            base_output_dir=_TEST_BASE_OUTPUT_DIR,
+            args=_TEST_RUN_ARGS,
+            replica_count=1,
+            machine_type=_TEST_MACHINE_TYPE,
+            accelerator_type=_TEST_ACCELERATOR_TYPE,
+            accelerator_count=_TEST_ACCELERATOR_COUNT,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
+            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
+            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
+        )
+
+        mock_python_package_to_gcs.assert_called_once_with(
+            gcs_staging_dir=_TEST_BUCKET_NAME,
+            project=_TEST_PROJECT,
+            credentials=initializer.global_config.credentials,
+        )
+
+        true_args = ["--test=arg", "--foo=1"]
+
+        true_worker_pool_spec = {
+            "replicaCount": _TEST_REPLICA_COUNT,
+            "machineSpec": {
+                "machineType": _TEST_MACHINE_TYPE,
+                "acceleratorType": _TEST_ACCELERATOR_TYPE,
+                "acceleratorCount": _TEST_ACCELERATOR_COUNT,
+            },
+            "pythonPackageSpec": {
+                "executorImageUri": _TEST_TRAINING_CONTAINER_IMAGE,
+                "pythonModule": _TrainingScriptPythonPackager.module_name,
+                "packageUris": [_TEST_OUTPUT_PYTHON_PACKAGE_PATH],
+                "args": true_args,
+            },
+        }
+
+        true_fraction_split = FractionSplit(
+            training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
+            validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
+            test_fraction=_TEST_TEST_FRACTION_SPLIT,
+        )
+
+        true_container_spec = ModelContainerSpec(
+            image_uri=_TEST_SERVING_CONTAINER_IMAGE,
+            predict_route=_TEST_SERVING_CONTAINER_PREDICTION_ROUTE,
+            health_route=_TEST_SERVING_CONTAINER_HEALTH_ROUTE,
+        )
+
+        true_managed_model = Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME, container_spec=true_container_spec
+        )
+
+        true_input_data_config = InputDataConfig(
+            fraction_split=true_fraction_split,
+            dataset_id=mock_dataset.name,
+            gcs_destination=GcsDestination(output_uri_prefix=_TEST_BASE_OUTPUT_DIR),
+        )
+
+        true_training_pipeline = TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.custom_task,
+            training_task_inputs=json_format.ParseDict(
+                {
+                    "workerPoolSpecs": [true_worker_pool_spec],
+                    "baseOutputDirectory": {"output_uri_prefix": _TEST_BASE_OUTPUT_DIR},
+                },
+                Value(),
+            ),
+            model_to_upload=true_managed_model,
+            input_data_config=true_input_data_config,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )
+
+        assert job._gca_resource is mock_pipeline_service_create.return_value
+
+        mock_model_service_get.assert_called_once_with(name=_TEST_MODEL_NAME)
+
+        assert model_from_job._gca_resource is mock_model_service_get.return_value
+
+        assert job.get_model()._gca_resource is mock_model_service_get.return_value
+
+        assert not job.is_failed
+
+        assert job.state == PipelineState.PIPELINE_STATE_SUCCEEDED
+
+    def test_run_called_twice_raises(
+        self,
+        mock_pipeline_service_create,
+        mock_python_package_to_gcs,
+        mock_dataset,
+        mock_model_service_get,
+    ):
+        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+
+        job = training_jobs.CustomTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            script_path=_TEST_LOCAL_SCRIPT_FILE_NAME,
+            container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
+            model_serving_container_image_uri=_TEST_SERVING_CONTAINER_IMAGE,
+            model_serving_container_predict_route=_TEST_SERVING_CONTAINER_PREDICTION_ROUTE,
+            model_serving_container_health_route=_TEST_SERVING_CONTAINER_HEALTH_ROUTE,
+        )
+
+        job.run(
+            dataset=mock_dataset,
+            base_output_dir=_TEST_BASE_OUTPUT_DIR,
+            args=_TEST_RUN_ARGS,
+            replica_count=1,
+            machine_type=_TEST_MACHINE_TYPE,
+            accelerator_type=_TEST_ACCELERATOR_TYPE,
+            accelerator_count=_TEST_ACCELERATOR_COUNT,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
+            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
+            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
+        )
+
+        with pytest.raises(RuntimeError):
+            job.run(
+                dataset=mock_dataset,
+                base_output_dir=_TEST_BASE_OUTPUT_DIR,
+                args=_TEST_RUN_ARGS,
+                replica_count=1,
+                machine_type=_TEST_MACHINE_TYPE,
+                accelerator_type=_TEST_ACCELERATOR_TYPE,
+                accelerator_count=_TEST_ACCELERATOR_COUNT,
+                model_display_name=_TEST_MODEL_DISPLAY_NAME,
+                training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
+                validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
+                test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
+            )
+
+    def test_run_with_invalid_accelerator_type_raises(
+        self,
+        mock_pipeline_service_create,
+        mock_python_package_to_gcs,
+        mock_dataset,
+        mock_model_service_get,
+    ):
+        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+
+        job = training_jobs.CustomTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            script_path=_TEST_LOCAL_SCRIPT_FILE_NAME,
+            container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
+            model_serving_container_image_uri=_TEST_SERVING_CONTAINER_IMAGE,
+            model_serving_container_predict_route=_TEST_SERVING_CONTAINER_PREDICTION_ROUTE,
+            model_serving_container_health_route=_TEST_SERVING_CONTAINER_HEALTH_ROUTE,
+        )
+
+        with pytest.raises(ValueError):
+            job.run(
+                dataset=mock_dataset,
+                base_output_dir=_TEST_BASE_OUTPUT_DIR,
+                args=_TEST_RUN_ARGS,
+                replica_count=1,
+                machine_type=_TEST_MACHINE_TYPE,
+                accelerator_type=_TEST_INVALID_ACCELERATOR_TYPE,
+                accelerator_count=_TEST_ACCELERATOR_COUNT,
+                model_display_name=_TEST_MODEL_DISPLAY_NAME,
+                training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
+                validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
+                test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
+            )
+
+    def test_run_with_incomplete_model_info_raises_with_model_to_upload(
+        self,
+        mock_pipeline_service_create,
+        mock_python_package_to_gcs,
+        mock_dataset,
+        mock_model_service_get,
+    ):
+        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+
+        job = training_jobs.CustomTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            script_path=_TEST_LOCAL_SCRIPT_FILE_NAME,
+            container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
+        )
+
+        with pytest.raises(RuntimeError):
+            job.run(
+                dataset=mock_dataset,
+                base_output_dir=_TEST_BASE_OUTPUT_DIR,
+                args=_TEST_RUN_ARGS,
+                replica_count=1,
+                machine_type=_TEST_MACHINE_TYPE,
+                accelerator_type=_TEST_ACCELERATOR_TYPE,
+                accelerator_count=_TEST_ACCELERATOR_COUNT,
+                model_display_name=_TEST_MODEL_DISPLAY_NAME,
+                training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
+                validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
+                test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
+            )
+
+    def test_run_call_pipeline_service_create_with_no_dataset(
+        self,
+        mock_pipeline_service_create,
+        mock_python_package_to_gcs,
+        mock_model_service_get,
+    ):
+        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+
+        job = training_jobs.CustomTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            script_path=_TEST_LOCAL_SCRIPT_FILE_NAME,
+            container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
+            model_serving_container_image_uri=_TEST_SERVING_CONTAINER_IMAGE,
+            model_serving_container_predict_route=_TEST_SERVING_CONTAINER_PREDICTION_ROUTE,
+            model_serving_container_health_route=_TEST_SERVING_CONTAINER_HEALTH_ROUTE,
+        )
+
+        model_from_job = job.run(
+            base_output_dir=_TEST_BASE_OUTPUT_DIR,
+            args=_TEST_RUN_ARGS,
+            replica_count=1,
+            machine_type=_TEST_MACHINE_TYPE,
+            accelerator_type=_TEST_ACCELERATOR_TYPE,
+            accelerator_count=_TEST_ACCELERATOR_COUNT,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
+            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
+            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
+        )
+
+        mock_python_package_to_gcs.assert_called_once_with(
+            gcs_staging_dir=_TEST_BUCKET_NAME,
+            project=_TEST_PROJECT,
+            credentials=initializer.global_config.credentials,
+        )
+
+        true_args = ["--test=arg", "--foo=1"]
+
+        true_worker_pool_spec = {
+            "replicaCount": _TEST_REPLICA_COUNT,
+            "machineSpec": {
+                "machineType": _TEST_MACHINE_TYPE,
+                "acceleratorType": _TEST_ACCELERATOR_TYPE,
+                "acceleratorCount": _TEST_ACCELERATOR_COUNT,
+            },
+            "pythonPackageSpec": {
+                "executorImageUri": _TEST_TRAINING_CONTAINER_IMAGE,
+                "pythonModule": _TrainingScriptPythonPackager.module_name,
+                "packageUris": [_TEST_OUTPUT_PYTHON_PACKAGE_PATH],
+                "args": true_args,
+            },
+        }
+
+        true_container_spec = ModelContainerSpec(
+            image_uri=_TEST_SERVING_CONTAINER_IMAGE,
+            predict_route=_TEST_SERVING_CONTAINER_PREDICTION_ROUTE,
+            health_route=_TEST_SERVING_CONTAINER_HEALTH_ROUTE,
+        )
+
+        true_managed_model = Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME, container_spec=true_container_spec
+        )
+
+        true_training_pipeline = TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.custom_task,
+            training_task_inputs=json_format.ParseDict(
+                {
+                    "workerPoolSpecs": [true_worker_pool_spec],
+                    "baseOutputDirectory": {"output_uri_prefix": _TEST_BASE_OUTPUT_DIR},
+                },
+                Value(),
+            ),
+            model_to_upload=true_managed_model,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )
+
+        assert job._gca_resource is mock_pipeline_service_create.return_value
+
+        mock_model_service_get.assert_called_once_with(name=_TEST_MODEL_NAME)
+
+        assert model_from_job._gca_resource is mock_model_service_get.return_value
+
+    def test_run_returns_none_if_no_model_to_upload(
+        self,
+        mock_pipeline_service_create_with_no_model_to_upload,
+        mock_python_package_to_gcs,
+        mock_dataset,
+    ):
+        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+
+        job = training_jobs.CustomTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            script_path=_TEST_LOCAL_SCRIPT_FILE_NAME,
+            container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
+        )
+
+        model = job.run(
+            dataset=mock_dataset,
+            base_output_dir=_TEST_BASE_OUTPUT_DIR,
+            args=_TEST_RUN_ARGS,
+            replica_count=1,
+            machine_type=_TEST_MACHINE_TYPE,
+            accelerator_type=_TEST_ACCELERATOR_TYPE,
+            accelerator_count=_TEST_ACCELERATOR_COUNT,
+            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
+            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
+            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
+        )
+
+        assert model is None
+
+    def test_get_model_raises_if_no_model_to_upload(
+        self,
+        mock_pipeline_service_create_with_no_model_to_upload,
+        mock_python_package_to_gcs,
+        mock_dataset,
+    ):
+        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+
+        job = training_jobs.CustomTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            script_path=_TEST_LOCAL_SCRIPT_FILE_NAME,
+            container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
+        )
+
+        job.run(
+            dataset=mock_dataset,
+            base_output_dir=_TEST_BASE_OUTPUT_DIR,
+            args=_TEST_RUN_ARGS,
+            replica_count=1,
+            machine_type=_TEST_MACHINE_TYPE,
+            accelerator_type=_TEST_ACCELERATOR_TYPE,
+            accelerator_count=_TEST_ACCELERATOR_COUNT,
+            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
+            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
+            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
+        )
+
+        with pytest.raises(RuntimeError):
+            model = job.get_model()
+
+    def test_run_raises_if_pipeline_fails(
+        self,
+        mock_pipeline_service_create_and_get_with_fail,
+        mock_python_package_to_gcs,
+        mock_dataset,
+    ):
+
+        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+
+        job = training_jobs.CustomTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            script_path=_TEST_LOCAL_SCRIPT_FILE_NAME,
+            container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
+        )
+
+        with pytest.raises(RuntimeError):
+            job.run(
+                dataset=mock_dataset,
+                base_output_dir=_TEST_BASE_OUTPUT_DIR,
+                args=_TEST_RUN_ARGS,
+                replica_count=1,
+                machine_type=_TEST_MACHINE_TYPE,
+                accelerator_type=_TEST_ACCELERATOR_TYPE,
+                accelerator_count=_TEST_ACCELERATOR_COUNT,
+                training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
+                validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
+                test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
+            )
+
+        with pytest.raises(RuntimeError):
+            model = job.get_model()
+
+    def test_raises_before_run_is_called(
+        self, mock_pipeline_service_create, mock_python_package_to_gcs
+    ):
+        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+
+        job = training_jobs.CustomTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            script_path=_TEST_LOCAL_SCRIPT_FILE_NAME,
+            container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
+            model_serving_container_image_uri=_TEST_SERVING_CONTAINER_IMAGE,
+            model_serving_container_predict_route=_TEST_SERVING_CONTAINER_PREDICTION_ROUTE,
+            model_serving_container_health_route=_TEST_SERVING_CONTAINER_HEALTH_ROUTE,
+        )
+
+        with pytest.raises(RuntimeError):
+            job.get_model()
+
+        with pytest.raises(RuntimeError):
+            job.is_failed
+
+        with pytest.raises(RuntimeError):
+            job.state
+
+    def test_run_raises_if_no_staging_bucket(self):
+
+        aiplatform.init(project=_TEST_PROJECT)
+
+        job = training_jobs.CustomTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            script_path=_TEST_LOCAL_SCRIPT_FILE_NAME,
+            container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
+        )
+
+        with pytest.raises(RuntimeError):
+            job.run(
+                base_output_dir=_TEST_BASE_OUTPUT_DIR,
+                args=_TEST_RUN_ARGS,
+                replica_count=1,
+                machine_type=_TEST_MACHINE_TYPE,
+                accelerator_type=_TEST_ACCELERATOR_TYPE,
+                accelerator_count=_TEST_ACCELERATOR_COUNT,
+                training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
+                validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
+                test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
+            )

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -494,7 +494,7 @@ class TestCustomTrainingJob:
 
         assert job.get_model()._gca_resource is mock_model_service_get.return_value
 
-        assert not job.is_failed
+        assert not job.has_failed
 
         assert job.state == gca_pipeline_state.PipelineState.PIPELINE_STATE_SUCCEEDED
 
@@ -804,7 +804,7 @@ class TestCustomTrainingJob:
             job.get_model()
 
         with pytest.raises(RuntimeError):
-            job.is_failed
+            job.has_failed
 
         with pytest.raises(RuntimeError):
             job.state


### PR DESCRIPTION
Adds CustomTrainingJob Class.

The current implementation splits the constructing of the CustomTrainingJob and running of the Job. Note that no Custom Training service resource is created when the object is constructed. It is created at the `run` call. Which can lead to issues if the correct args were not passed in during construction. This mainly is an issue for model serving args as we require the model serving environment definitions at construction time, which should make sense because it's tightly coupled to the script provided at construction time. An alternative is to move this to the run call.

An additional alternative is to add all constructor and run args to the constructor. And only have the model accessible through the get_model API:

```python
job = CustomTrainingJob('test_script.py', ...)  # launch job here
my_model = job.get_model()
```  

Instead of the current flow:

```python
job = CustomTrainingJob('test_script.py', ...)
model = job.run(my_dataset, ...)
```


Fixes [b/169779290](b/169779290) 🦕
