### PR TITLE
feat: Refactor Dataset class to decouple from GCS and BQ logic

### DIFF
--- a/google/cloud/aiplatform/datasets.py
+++ b/google/cloud/aiplatform/datasets.py
@@ -24,7 +24,7 @@ from google.cloud.aiplatform import base
 from google.cloud.aiplatform import initializer
 from google.cloud.aiplatform import utils
 from google.cloud.aiplatform import schema
-from google.cloud.aiplatform.source_config import SourceConfig, DataImportable
+from google.cloud.aiplatform.data_source import DataSource, DataImportable, GCSNonTabularDataSource, GCSNonTabularImportDataSource
 
 from google.cloud.aiplatform_v1beta1 import GcsDestination
 from google.cloud.aiplatform_v1beta1 import ExportDataConfig
@@ -79,7 +79,7 @@ class Dataset(base.AiPlatformResourceNoun):
     def create(
         cls,
         display_name: str,
-        source: SourceConfig,
+        source: DataSource,
         request_metadata: Sequence[Tuple[str, str]] = (),
         labels: Optional[Dict] = None,
         project: Optional[str] = None,
@@ -132,15 +132,6 @@ class Dataset(base.AiPlatformResourceNoun):
                 Instantiated representation of the managed dataset resource.
         """
         utils.validate_display_name(display_name)
-
-        is_tabular_dataset_metadata = (
-            metadata_schema_uri == schema.dataset.metadata.tabular
-        )
-
-        if bool(bq_source) and not is_tabular_dataset_metadata:
-            raise ValueError(
-                "A tabular metadata_schema uri must be used when using a BigQuery source"
-            )
 
         api_client = cls._instantiate_client(location=location, credentials=credentials)
 

--- a/google/cloud/aiplatform/datasets.py
+++ b/google/cloud/aiplatform/datasets.py
@@ -23,12 +23,11 @@ from google.auth import credentials as auth_credentials
 from google.cloud.aiplatform import base
 from google.cloud.aiplatform import initializer
 from google.cloud.aiplatform import utils
-from google.cloud.aiplatform import schema
-from google.cloud.aiplatform.data_source import DataSource, DataImportable, GCSNonTabularDataSource, GCSNonTabularImportDataSource
+
+from google.cloud.aiplatform.data_source import DataSource, DataImportable
 
 from google.cloud.aiplatform_v1beta1 import GcsDestination
 from google.cloud.aiplatform_v1beta1 import ExportDataConfig
-from google.cloud.aiplatform_v1beta1 import ImportDataConfig
 from google.cloud.aiplatform_v1beta1 import Dataset as GapicDataset
 from google.cloud.aiplatform_v1beta1 import DatasetServiceClient
 
@@ -226,10 +225,7 @@ class Dataset(base.AiPlatformResourceNoun):
             parent=parent, dataset=gapic_dataset, metadata=request_metadata
         )
 
-    def import_data(
-        self,
-        source: DataImportable
-    ) -> "Dataset":
+    def import_data(self, source: DataImportable) -> "Dataset":
         """Upload data to existing managed dataset.
 
         Args:

--- a/google/cloud/aiplatform/source_config.py
+++ b/google/cloud/aiplatform/source_config.py
@@ -24,6 +24,10 @@ class SourceConfig(ABC):
 
 ## TODO: Move to a EmptySourceConfig file
 class EmptyNonTabularSourceConfig(SourceConfig):
+    """Class for a empty, non-tabular dataset schema that provides Dataset metadata
+    Used with Dataset.create(...) to create an empty, non-tabular dataset.
+    """
+
     def __init__(self, metadata_schema_uri: str):
         """TODO
 
@@ -48,6 +52,12 @@ class EmptyNonTabularSourceConfig(SourceConfig):
 
 ## TODO: Move to a BQSourceConfig file
 class BQTabularSourceConfig(SourceConfig):
+    """Class for a tabular dataset schema that provides Dataset metadata
+    
+    Used for data storaged on BigQuery.
+    When used with Dataset.create(...), the data will be imported to the dataset at creation time.
+    """
+
     def __init__(self, source_uri: str):
         # TODO: Add doc strings
 
@@ -91,7 +101,11 @@ class GCSSourceConfig(GCSSourceValidating, SourceConfig):
         return {"input_config": {"gcs_source": {"uri": self._source_uris}}}
 
 class GCSTabularSourceConfig(GCSSourceConfig):
-    """Class for GCS source_uri's for a tabular dataset schema that provides Dataset metadata"""
+    """Class for a tabular dataset schema that provides Dataset metadata. 
+    
+    Used for CSV files on Google Cloud Storage.
+    When used with Dataset.create(...), the data will be imported to the dataset at creation time.
+    """
 
     @property
     def metadata_schema_uri(self) -> str:
@@ -99,7 +113,9 @@ class GCSTabularSourceConfig(GCSSourceConfig):
         return schema.dataset.metadata.tabular
 
 class GCSNonTabularImportConfig(GCSSourceValidating, DataImportable):
-    """Class for GCS source_uri's for a non-tabular dataset schema that provides import config"""
+    """Class for a non-tabular dataset schema that provides import metadata. 
+    Used with Dataset.import_data(...) to import files from Google Cloud Storage to an existing dataset.
+    """
 
     def __init__(self, source_uris: [str], import_schema_uri: str, data_items_labels: Optional[Dict] = None):
         """TODO
@@ -146,7 +162,9 @@ class GCSNonTabularImportConfig(GCSSourceValidating, DataImportable):
             )
 
 class GCSNonTabularSourceConfig(GCSSourceConfig, GCSNonTabularImportConfig):
-    """Class for GCS source_uri's for a non-tabular dataset schema that provides Dataset metadata"""
+    """Class for a non-tabular dataset schema that provides Dataset metadata. 
+    Used with Dataset.create(...) to import files from Google Cloud Storage to the dataset at creation time.
+    """
 
     def __init__(self, source_uris: [str], metadata_schema_uri: str, import_schema_uri: str, data_items_labels: Optional[Dict] = None):
         """TODO

--- a/google/cloud/aiplatform/source_config.py
+++ b/google/cloud/aiplatform/source_config.py
@@ -1,0 +1,160 @@
+from typing import Optional, Dict
+from abc import ABC, abstractmethod
+from google.cloud.aiplatform import schema
+from google.cloud.aiplatform_v1beta1 import ImportDataConfig
+from google.cloud.aiplatform_v1beta1 import GcsSource
+
+class DataImportable(ABC):
+    """
+        An abstract class that provides import_data_config for importing data to an existing database
+    """
+
+    @property 
+    def import_data_config(self) -> ImportDataConfig:
+        raise NotImplementedError
+        
+class SourceConfig(ABC):
+    @property
+    def metadata_schema_uri(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def metadata(self) -> Dict:
+        raise NotImplementedError
+
+## TODO: Move to a EmptySourceConfig file
+class EmptyNonTabularSourceConfig(SourceConfig):
+    def __init__(self, metadata_schema_uri: str):
+        """TODO
+
+        Args:
+            metadata_schema_uri (str):
+                Required. Points to a YAML file stored on Google Cloud Storage
+                describing additional information about the Dataset. The schema
+                is defined as an OpenAPI 3.0.2 Schema Object. The schema files
+                that can be used here are found in gs://google-cloud-
+                aiplatform/schema/dataset/metadata/.
+        """
+
+        self._metadata_schema_uri = metadata_schema_uri
+        
+    @property
+    def metadata_schema_uri(self) -> str:
+        return self._metadata_schema_uri
+
+    @property
+    def metadata(self) -> Dict:
+        return {}
+
+## TODO: Move to a BQSourceConfig file
+class BQTabularSourceConfig(SourceConfig):
+    def __init__(self, source_uri: str):
+        # TODO: Add doc strings
+
+        # Perform validation of URI
+        if not (source_uri.startswith('bq://') or source_uri.startswith('bigquery://')):
+            raise ValueError(
+                "Expected source_uri to start with 'bq://' or 'bigquery://'"
+            )
+
+        self._source_uri = source_uri        
+
+    @property
+    def metadata_schema_uri(self) -> str:
+        # Always return tabular as BQ only supports tabular
+        return schema.dataset.metadata.tabular
+
+    @property
+    def metadata(self) -> Dict:
+        return {"input_config": {"bigquery_source": {"uri": self._source_uri}}}
+
+## TODO: Move to a GCSSourceConfig file
+# Do not instantiate this abstract class
+class GCSSourceConfig(SourceConfig):
+    def __init__(self, source_uris: [str]):
+        # TODO: Add doc strings
+
+        # Perform validation of URI's
+        if not all([uri.startswith('gs://') for uri in source_uris]):
+            raise ValueError(
+                "Expected alls URI's in source_uris to start with 'gs://'"
+            )
+
+        self._source_uris = source_uris
+        
+    @property
+    def metadata(self) -> Dict:
+        return {"input_config": {"gcs_source": {"uri": self._source_uris}}}
+
+class GCSTabularSourceConfig(GCSSourceConfig):
+    @property
+    def metadata_schema_uri(self) -> str:
+        # Always return tabular as this config only supports tabular
+        return schema.dataset.metadata.tabular
+
+class GCSNonTabularSourceConfig(GCSSourceConfig, DataImportable):
+    def __init__(self, source_uris: [str], metadata_schema_uri: str, import_schema_uri: str, data_items_labels: Optional[Dict] = None):
+        """TODO
+
+        Args:
+            source_uris (Sequence[str]):
+                Required. Google Cloud Storage URI(-s) to the
+                input file(s). May contain wildcards. For more
+                information on wildcards, see
+                https://cloud.google.com/storage/docs/gsutil/addlhelp/WildcardNames.
+            metadata_schema_uri (str):
+                Required. Points to a YAML file stored on Google Cloud Storage
+                describing additional information about the Dataset. The schema
+                is defined as an OpenAPI 3.0.2 Schema Object. The schema files
+                that can be used here are found in gs://google-cloud-
+                aiplatform/schema/dataset/metadata/.
+            import_schema_uri (str):
+                Required. Points to a YAML file stored on Google Cloud
+                Storage describing the import format. Validation will be
+                done against the schema. The schema is defined as an
+                `OpenAPI 3.0.2 Schema
+                Object <https://tinyurl.com/y538mdwt>`__.
+            data_item_labels: (Optional[Dict]) = None
+                Labels that will be applied to newly imported DataItems. If
+                an identical DataItem as one being imported already exists
+                in the Dataset, then these labels will be appended to these
+                of the already existing one, and if labels with identical
+                key is imported before, the old label value will be
+                overwritten. If two DataItems are identical in the same
+                import data operation, the labels will be combined and if
+                key collision happens in this case, one of the values will
+                be picked randomly. Two DataItems are considered identical
+                if their content bytes are identical (e.g. image bytes or
+                pdf bytes). These labels will be overridden by Annotation
+                labels specified inside index file refenced by
+                [import_schema_uri][google.cloud.aiplatform.v1beta1.ImportDataConfig.import_schema_uri],
+                e.g. jsonl file.
+        """
+
+        if metadata_schema_uri == schema.dataset.metadata.tabular:
+            raise ValueError(
+                "Expected non-tabular metadata schema uri. For tabular metadata schema, use GCSTabularSourceConfig"
+            )
+        
+        GCSSourceConfig.__init__(self, source_uris)
+        self._metadata_schema_uri = metadata_schema_uri
+        self._import_schema_uri = import_schema_uri
+        self._data_items_labels = data_items_labels
+
+    @property
+    def metadata_schema_uri(self) -> str:
+        # Always return tabular as this config only supports tabular
+        return self._metadata_schema_uri
+
+    @property
+    def metadata(self) -> Dict:
+        # Non-tabular datasets shouldn't have any metadata set
+        return {}
+
+    @property 
+    def import_data_config(self) -> ImportDataConfig:
+        return ImportDataConfig(
+                gcs_source=GcsSource(uris=self._source_uris),
+                import_schema_uri=self._import_schema_uri,
+                data_item_labels=self._data_items_labels,
+            )

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -30,7 +30,7 @@ from google.cloud import aiplatform
 from google.cloud.aiplatform import Dataset
 from google.cloud.aiplatform import initializer
 from google.cloud.aiplatform import schema
-from google.cloud.aiplatform.source_config import BQTabularSourceConfig, GCSNonTabularSourceConfig, EmptyNonTabularSourceConfig
+from google.cloud.aiplatform.source_config import BQTabularSourceConfig, GCSNonTabularSourceConfig, EmptyNonTabularSourceConfig, GCSNonTabularImportConfig
 
 from google.cloud.aiplatform_v1beta1 import GcsSource
 from google.cloud.aiplatform_v1beta1 import GcsDestination
@@ -246,7 +246,7 @@ class TestDataset:
         my_dataset = Dataset(dataset_name=_TEST_NAME)
 
         my_dataset.import_data(
-            source=GCSNonTabularSourceConfig(source_uris=[_TEST_SOURCE_URI_GCS], metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR, import_schema_uri=_TEST_IMPORT_SCHEMA_URI, data_items_labels=_TEST_DATA_LABEL_ITEMS) # TODO: Remove metadata_schema_uri as import step doesn't need it
+            source=GCSNonTabularImportConfig(source_uris=[_TEST_SOURCE_URI_GCS], import_schema_uri=_TEST_IMPORT_SCHEMA_URI, data_items_labels=_TEST_DATA_LABEL_ITEMS)
         )
 
         expected_import_config = ImportDataConfig(

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -30,7 +30,12 @@ from google.cloud import aiplatform
 from google.cloud.aiplatform import Dataset
 from google.cloud.aiplatform import initializer
 from google.cloud.aiplatform import schema
-from google.cloud.aiplatform.data_source import BQTabularDataSource, GCSNonTabularDataSource, EmptyNonTabularDataSource, GCSNonTabularImportDataSource
+from google.cloud.aiplatform.data_source import (
+    BQTabularDataSource,
+    GCSNonTabularDataSource,
+    EmptyNonTabularDataSource,
+    GCSNonTabularImportDataSource,
+)
 
 from google.cloud.aiplatform_v1beta1 import GcsSource
 from google.cloud.aiplatform_v1beta1 import GcsDestination
@@ -170,8 +175,8 @@ class TestDataset:
         Dataset.create(
             display_name=_TEST_DISPLAY_NAME,
             source=EmptyNonTabularDataSource(
-                    metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR
-                ),
+                metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR
+            ),
             labels=_TEST_LABEL,
         )
 
@@ -192,9 +197,7 @@ class TestDataset:
 
         Dataset.create(
             display_name=_TEST_DISPLAY_NAME,
-            source=BQTabularDataSource(
-                source_uri=_TEST_SOURCE_URI_BQ
-            ),
+            source=BQTabularDataSource(source_uri=_TEST_SOURCE_URI_BQ),
             labels=_TEST_LABEL,
         )
 
@@ -216,11 +219,12 @@ class TestDataset:
         my_dataset = Dataset.create(
             display_name=_TEST_DISPLAY_NAME,
             source=GCSNonTabularDataSource(
-                source_uris=[_TEST_SOURCE_URI_GCS], 
-                metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR, 
-                import_schema_uri=_TEST_IMPORT_SCHEMA_URI, 
-                data_items_labels=_TEST_DATA_LABEL_ITEMS),
-            labels=_TEST_LABEL            
+                source_uris=[_TEST_SOURCE_URI_GCS],
+                metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR,
+                import_schema_uri=_TEST_IMPORT_SCHEMA_URI,
+                data_items_labels=_TEST_DATA_LABEL_ITEMS,
+            ),
+            labels=_TEST_LABEL,
         )
 
         expected_dataset = GapicDataset(
@@ -255,9 +259,10 @@ class TestDataset:
 
         my_dataset.import_data(
             source=GCSNonTabularImportDataSource(
-                source_uris=[_TEST_SOURCE_URI_GCS], 
-                import_schema_uri=_TEST_IMPORT_SCHEMA_URI, 
-                data_items_labels=_TEST_DATA_LABEL_ITEMS)
+                source_uris=[_TEST_SOURCE_URI_GCS],
+                import_schema_uri=_TEST_IMPORT_SCHEMA_URI,
+                data_items_labels=_TEST_DATA_LABEL_ITEMS,
+            )
         )
 
         expected_import_config = ImportDataConfig(

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -30,6 +30,7 @@ from google.cloud import aiplatform
 from google.cloud.aiplatform import Dataset
 from google.cloud.aiplatform import initializer
 from google.cloud.aiplatform import schema
+from google.cloud.aiplatform.source_config import BQTabularSourceConfig, GCSNonTabularSourceConfig, EmptyNonTabularSourceConfig
 
 from google.cloud.aiplatform_v1beta1 import GcsSource
 from google.cloud.aiplatform_v1beta1 import GcsDestination
@@ -168,7 +169,7 @@ class TestDataset:
 
         Dataset.create(
             display_name=_TEST_DISPLAY_NAME,
-            metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR,
+            source=EmptyNonTabularSourceConfig(metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR),
             labels=_TEST_LABEL,
         )
 
@@ -189,8 +190,7 @@ class TestDataset:
 
         Dataset.create(
             display_name=_TEST_DISPLAY_NAME,
-            metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_TABULAR,
-            bq_source=_TEST_SOURCE_URI_BQ,
+            source=BQTabularSourceConfig(source_uri=_TEST_SOURCE_URI_BQ),
             labels=_TEST_LABEL,
         )
 
@@ -211,11 +211,8 @@ class TestDataset:
 
         my_dataset = Dataset.create(
             display_name=_TEST_DISPLAY_NAME,
-            gcs_source=_TEST_SOURCE_URI_GCS,
-            labels=_TEST_LABEL,
-            metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR,
-            import_schema_uri=_TEST_IMPORT_SCHEMA_URI,
-            data_items_labels=_TEST_DATA_LABEL_ITEMS,
+            source=GCSNonTabularSourceConfig(source_uris=[_TEST_SOURCE_URI_GCS], metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR, import_schema_uri=_TEST_IMPORT_SCHEMA_URI, data_items_labels=_TEST_DATA_LABEL_ITEMS),
+            labels=_TEST_LABEL            
         )
 
         expected_dataset = GapicDataset(
@@ -249,9 +246,7 @@ class TestDataset:
         my_dataset = Dataset(dataset_name=_TEST_NAME)
 
         my_dataset.import_data(
-            gcs_source=_TEST_SOURCE_URI_GCS,
-            import_schema_uri=_TEST_IMPORT_SCHEMA_URI,
-            data_items_labels=_TEST_DATA_LABEL_ITEMS,
+            source=GCSNonTabularSourceConfig(source_uris=[_TEST_SOURCE_URI_GCS], metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR, import_schema_uri=_TEST_IMPORT_SCHEMA_URI, data_items_labels=_TEST_DATA_LABEL_ITEMS) # TODO: Remove metadata_schema_uri as import step doesn't need it
         )
 
         expected_import_config = ImportDataConfig(

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -169,7 +169,9 @@ class TestDataset:
 
         Dataset.create(
             display_name=_TEST_DISPLAY_NAME,
-            source=EmptyNonTabularSourceConfig(metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR),
+            source=EmptyNonTabularSourceConfig(
+                    metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR
+                ),
             labels=_TEST_LABEL,
         )
 
@@ -190,7 +192,9 @@ class TestDataset:
 
         Dataset.create(
             display_name=_TEST_DISPLAY_NAME,
-            source=BQTabularSourceConfig(source_uri=_TEST_SOURCE_URI_BQ),
+            source=BQTabularSourceConfig(
+                source_uri=_TEST_SOURCE_URI_BQ
+            ),
             labels=_TEST_LABEL,
         )
 
@@ -211,7 +215,11 @@ class TestDataset:
 
         my_dataset = Dataset.create(
             display_name=_TEST_DISPLAY_NAME,
-            source=GCSNonTabularSourceConfig(source_uris=[_TEST_SOURCE_URI_GCS], metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR, import_schema_uri=_TEST_IMPORT_SCHEMA_URI, data_items_labels=_TEST_DATA_LABEL_ITEMS),
+            source=GCSNonTabularSourceConfig(
+                source_uris=[_TEST_SOURCE_URI_GCS], 
+                metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR, 
+                import_schema_uri=_TEST_IMPORT_SCHEMA_URI, 
+                data_items_labels=_TEST_DATA_LABEL_ITEMS),
             labels=_TEST_LABEL            
         )
 
@@ -246,7 +254,10 @@ class TestDataset:
         my_dataset = Dataset(dataset_name=_TEST_NAME)
 
         my_dataset.import_data(
-            source=GCSNonTabularImportConfig(source_uris=[_TEST_SOURCE_URI_GCS], import_schema_uri=_TEST_IMPORT_SCHEMA_URI, data_items_labels=_TEST_DATA_LABEL_ITEMS)
+            source=GCSNonTabularImportConfig(
+                source_uris=[_TEST_SOURCE_URI_GCS], 
+                import_schema_uri=_TEST_IMPORT_SCHEMA_URI, 
+                data_items_labels=_TEST_DATA_LABEL_ITEMS)
         )
 
         expected_import_config = ImportDataConfig(

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -30,7 +30,7 @@ from google.cloud import aiplatform
 from google.cloud.aiplatform import Dataset
 from google.cloud.aiplatform import initializer
 from google.cloud.aiplatform import schema
-from google.cloud.aiplatform.source_config import BQTabularSourceConfig, GCSNonTabularSourceConfig, EmptyNonTabularSourceConfig, GCSNonTabularImportConfig
+from google.cloud.aiplatform.data_source import BQTabularDataSource, GCSNonTabularDataSource, EmptyNonTabularDataSource, GCSNonTabularImportDataSource
 
 from google.cloud.aiplatform_v1beta1 import GcsSource
 from google.cloud.aiplatform_v1beta1 import GcsDestination
@@ -169,7 +169,7 @@ class TestDataset:
 
         Dataset.create(
             display_name=_TEST_DISPLAY_NAME,
-            source=EmptyNonTabularSourceConfig(
+            source=EmptyNonTabularDataSource(
                     metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR
                 ),
             labels=_TEST_LABEL,
@@ -192,7 +192,7 @@ class TestDataset:
 
         Dataset.create(
             display_name=_TEST_DISPLAY_NAME,
-            source=BQTabularSourceConfig(
+            source=BQTabularDataSource(
                 source_uri=_TEST_SOURCE_URI_BQ
             ),
             labels=_TEST_LABEL,
@@ -215,7 +215,7 @@ class TestDataset:
 
         my_dataset = Dataset.create(
             display_name=_TEST_DISPLAY_NAME,
-            source=GCSNonTabularSourceConfig(
+            source=GCSNonTabularDataSource(
                 source_uris=[_TEST_SOURCE_URI_GCS], 
                 metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR, 
                 import_schema_uri=_TEST_IMPORT_SCHEMA_URI, 
@@ -254,7 +254,7 @@ class TestDataset:
         my_dataset = Dataset(dataset_name=_TEST_NAME)
 
         my_dataset.import_data(
-            source=GCSNonTabularImportConfig(
+            source=GCSNonTabularImportDataSource(
                 source_uris=[_TEST_SOURCE_URI_GCS], 
                 import_schema_uri=_TEST_IMPORT_SCHEMA_URI, 
                 data_items_labels=_TEST_DATA_LABEL_ITEMS)


### PR DESCRIPTION
Design proposal here: [Model Builder SDK Dataset Source Refactor Proposal](https://docs.google.com/document/d/1_KoOm42mdjHp-X_QSgMWWCAYji5Tdl_9SYQ6RakJoas/edit?usp=sharing)

The text below is pretty much the same as the proposal, with some more details on things that are WIP.

## Problem
Due to idiosyncrasies in how the underlying Gapic API and services treat BQ and GCS inputs, there are many pitfalls for creating a Dataset using `Dataset.create`.

```
    @classmethod
    def create(
        cls,
        display_name: str,
        metadata_schema_uri: str,
        gcs_source: Optional[Sequence[str]] = None,
        bq_source: Optional[str] = None,
        import_schema_uri: Optional[str] = None,
        metadata: Sequence[Tuple[str, str]] = (),
        labels: Optional[Dict] = None,
        data_items_labels: Optional[Dict] = None,
        project: Optional[str] = None,
        location: Optional[str] = None,
        credentials: Optional[auth_credentials.Credentials] = None,
    ) -> "Dataset":
```

Here is a taste of the current valid/invalid parameter combinations for creating a Dataset:
| metadata_schema_uri | gcs_source | bq_source | import_schema_uri | data_items_labels | Is this valid?                                                  |
|---------------------|------------|-----------|-------------------|-------------------|-----------------------------------------------------------------|
| tabular             | present    | None      | present           | present           | No, tabular doesn't use import_schema_uri and data_items_labels |
| tabular             | None       | present   | present           | present           | No, tabular doesn't use import_schema_uri and data_item_labels  |
| non-tabular         | present    | None      | present           | present           | Yes                                                             |
| tabular             | None       | present   | None              | None              | Yes                                                             |
| non-tabular         | *          | present   | *                 | *                 | No, BQ only works with tabular                                  |
| *                   | present    | present   | *                 | *                 | No, BQ and GCS cannot both be set at the same time              |
| non-tabular         | present    | None      | None              | None              | No, import_schema_uri is required for GCS source                |
| non-tabular         | None       | None      | None              | None              | Yes, nothing is imported to this newly created dataset          |
| text         | present       | None      | None              | image_classification_multi_label              | No, text is not compatible with image_classification_multi_label         

Sure, we can include documentation to tell the user but IMO it's not a great user experience when there are so many potential pitfalls. Many of the invalid states also fail silently or fail later on during the model training step. This ambiguity doesn't seem to be what the EAFP principle was intended for.

We could also write  a large amount of initialization-time checks, but they'd be tougher to maintain and debug then the alternative way proposed below. That also wouldn't solve problems with coupling and extensibility.

## Proposal
Instead of having a bunch of loosely-typed and sometimes optional parameters, I propose that we encapsulate this logic into a few classes.
The 4 classes (`EmptyNonTabularSourceConfig`, `BQTabularSourceConfig`, `GCSTabularSourceConfig` and `GCSNonTabularSourceConfig`) encapsulate the GCS/BQ specific logic and **guarantees** that if a user passes in the right types to one of these, a valid Dataset can be created.

Note: It's possible to combine `GCSTabularSourceConfig` and `GCSNonTabularSourceConfig` if people prefer that. It'll just mean that there needs to be validation to make sure `import_schema_uri = None` and `data_items_labels = None` when `metadata_schema_uri = tabular`

For example, `BQTabularSourceConfig` for BigQuery tabular datasets has this signature, only taking in the parameter it needs:

```
class BQTabularSourceConfig(SourceConfig):
    def __init__(self, source_uri: str):
        ... validation for URI done here ...
```

The new `Dataset.create` signature would thus look like:
```
@classmethod
    def create(
        cls,
        display_name: str,
        source: SourceConfig,
        request_metadata: Sequence[Tuple[str, str]] = (),
        labels: Optional[Dict] = None,
        project: Optional[str] = None,
        location: Optional[str] = None,
        credentials: Optional[auth_credentials.Credentials] = None,
    ) -> "Dataset":
```

It may seem like we're adding a 4 new user-facing classes and increasing complexity but the fact is that this complexity in parameter combinations already exists in Dataset.create(...) as can be seen in the above table. It is just currently hidden behind Optional's.

Since this is Python, the type system will only check that the number of parameters are correct. However, this is still an improvement since the function signature tells the user exactly what are valid combinations. If users use something like MyPy for static type checking, they will get additional type safety. 

## Additional benefits
- Decoupling: This PR removes GCS and BQ implementation details from Dataset's `create` and `import_data` functions, resulting in cleaner logic, since it all gets encapsulated into the SourceConfig implementation details. One example is the logic to check that GCS URI's start with "gs://".
- Extensibility: Inheriting the `SourceConfig` abstract class makes it extensible to other source types besides GCS and BQ.

## How would this work with subclassing Dataset to create datatype specific subclasses?
- Without this proposal, just creating subclasses of Dataset makes things easier for users but leaves a few problems:
  - Unless we make `Dataset.create` completely private, users will still be able to call the problematic `Dataset.create` function.
  - Even if we make it private, the SDK devs will still have to deal with the problematic `Dataset.create` function.
  - Without decoupling GCS and BQ logic from Datasets, that logic is scattered everywhere in the Datasets.py codebase, making things hard to change. In the future, it'll also be tough to extend to other datatypes that don't directly leverage GCS and BQ.

With this proposal, it's still easy to create subclasses. Here's an example:

```
class ImageDataset(Dataset):
    @classmethod
    def create(
        cls,
        display_name: str,
        gcs_source_uris: [str],
        import_schema_uri: str, 
        data_items_labels: Optional[Dict] = None,
        request_metadata: Sequence[Tuple[str, str]] = (),
        labels: Optional[Dict] = None,
        project: Optional[str] = None,
        location: Optional[str] = None,
        credentials: Optional[auth_credentials.Credentials] = None,
    ) -> "Dataset":
        # TODO: Add validation to check that the `import_schema_uri` is valid for an image dataset
        source = GCSNonTabularSourceConfig(source_uris=gcs_source_uris, metadata_schema_uri=schema.dataset.metadata.image, import_schema_uri=import_schema_uri, data_items_labels=data_items_labels)
        GCSSourceConfig.__init__(self, display_name=display_name, source=source)
```

## Further recommended refactoring
To completely decouple `Dataset` from GCS, we'd have to remove the dependency on GCSDestination. This can be done as part of `(b/171311614): Add support for BiqQuery export path`.

## WIP
- Add all doc strings.
- Move SourceConfig implementations to their own files and folder structure.
- Add unit-tests for new classes.
- Find a better name than `SourceConfig`