### PR TITLE
feat: add support for distributed custom training

### DIFF
--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -653,6 +653,12 @@ class CustomTrainingJob(base.AiPlatformResourceNoun):
     ) -> Optional[models.Model]:
         """Runs the custom training job.
 
+        Distributed Training Support:
+        If replica count = 1 then one chief replica will be provisioned. If
+        replica_count > 1 the remainder will be provisioned as a worker replica pool.
+        ie: replica_count = 10 will result in 1 chief and 9 workers
+        All replicas have same machine_type, accelerator_type, and accelerator_count
+
         Data fraction splits:
         Any of ``training_fraction_split``, ``validation_fraction_split`` and
         ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
@@ -682,7 +688,9 @@ class CustomTrainingJob(base.AiPlatformResourceNoun):
             args (List[Unions[str, int, float]]):
                 Command line arguments to be passed to the Python script.
             replica_count (int):
-                The number of worker replicas.
+                The number of worker replicas. If replica count = 1 then one chief
+                replica will be provisioned. If replica_count > 1 the remainder will be
+                provisioned as a worker replica pool.
             machine_type (str):
                 The type of machine to use for training.
             accelerator_type (str):

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -346,7 +346,7 @@ class _MachineSpec(NamedTuple):
 
     spec = _MachineSpec(
                 replica_count=10,
-                machine_type='n1-standard-2',
+                machine_type='n1-standard-4',
                 accelerator_count=2,
                 accelerator_type='NVIDIA_TESLA_K80')
 
@@ -354,7 +354,7 @@ class _MachineSpec(NamedTuple):
     """
 
     replica_count: int = 0
-    machine_type: str = "n1-standard-2"
+    machine_type: str = "n1-standard-4"
     accelerator_count: int = 0
     accelerator_type: str = "ACCELERATOR_TYPE_UNSPECIFIED"
 
@@ -424,13 +424,13 @@ class _DistributedTrainingSpec(NamedTuple):
     dist_training_spec = _DistributedTrainingSpec(
         chief_spec = _MachineSpec(
                 replica_count=1,
-                machine_type='n1-standard-2',
+                machine_type='n1-standard-4',
                 accelerator_count=2,
                 accelerator_type='NVIDIA_TESLA_K80'
                 ),
         worker_spec = _MachineSpec(
                 replica_count=10,
-                machine_type='n1-standard-2',
+                machine_type='n1-standard-4',
                 accelerator_count=2,
                 accelerator_type='NVIDIA_TESLA_K80'
                 )
@@ -477,7 +477,7 @@ class _DistributedTrainingSpec(NamedTuple):
     def chief_worker_pool(
         cls,
         replica_count: int = 0,
-        machine_type: str = "n1-standard-2",
+        machine_type: str = "n1-standard-4",
         accelerator_count: int = 0,
         accelerator_type: str = "ACCELERATOR_TYPE_UNSPECIFIED",
     ) -> "_DistributedTrainingSpec":

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -988,7 +988,7 @@ class Test_MachineSpec:
         )
 
         true_spec_dict = {
-            "machineSpec": {"machineType": _TEST_MACHINE_TYPE,},
+            "machineSpec": {"machineType": _TEST_MACHINE_TYPE},
             "replicaCount": _TEST_REPLICA_COUNT,
         }
 
@@ -1001,15 +1001,6 @@ class Test_MachineSpec:
             accelerator_count=_TEST_ACCELERATOR_COUNT,
             accelerator_type=_TEST_INVALID_ACCELERATOR_TYPE,
         )
-
-        true_spec_dict = {
-            "machineSpec": {
-                "machineType": _TEST_MACHINE_TYPE,
-                "acceleratorType": _TEST_ACCELERATOR_TYPE,
-                "acceleratorCount": _TEST_ACCELERATOR_COUNT,
-            },
-            "replicaCount": _TEST_REPLICA_COUNT,
-        }
 
         with pytest.raises(ValueError):
             test_spec.spec_dict
@@ -1196,7 +1187,7 @@ class Test_DistributedTrainingSpec:
                 },
                 "replicaCount": 1,
             },
-            {"machineSpec": {"machineType": "n1-standard-2",}, "replicaCount": 0},
+            {"machineSpec": {"machineType": "n1-standard-2"}, "replicaCount": 0},
             {
                 "machineSpec": {
                     "machineType": _TEST_MACHINE_TYPE,

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -1187,7 +1187,7 @@ class Test_DistributedTrainingSpec:
                 },
                 "replicaCount": 1,
             },
-            {"machineSpec": {"machineType": "n1-standard-2"}, "replicaCount": 0},
+            {"machineSpec": {"machineType": "n1-standard-4"}, "replicaCount": 0},
             {
                 "machineSpec": {
                     "machineType": _TEST_MACHINE_TYPE,


### PR DESCRIPTION
Adds support for chief-worker distributed training to custom training. If replica_count > 1 the remainder as provisioned as workers

The _DistributedTrainingSpec can also support more custom provisioning. We will have a follow up PR after we consider how we want to expose more custom provisioning on the API surface.

Note: If library upgrades to 3.7 we should switch the Spec classes to dataclass.

Fixes [b/172369809](b/172369809) 🦕
