### PR TITLE
feat: Added predefined splits to custom training jobs

### DIFF
--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -941,6 +941,7 @@ class CustomTrainingJob(_TrainingJob):
         training_fraction_split: float,
         validation_fraction_split: float,
         test_fraction_split: float,
+        predefined_split_column_name: Optional[str] = None,
     ) -> gca_training_pipeline.InputDataConfig:
         """Constructs a input data config to pass to the training pipeline.
             Override this to create a custom config
@@ -958,6 +959,16 @@ class CustomTrainingJob(_TrainingJob):
                 test_fraction_split (float):
                     The fraction of the input data that is to be
                     used to evaluate the Model. This is ignored if Dataset is not provided.
+                predefined_split_column_name (str):
+                    Optional. The key is a name of one of the Dataset's data
+                    columns. The value of the key (either the label's value or
+                    value in the column) must be one of {``training``,
+                    ``validation``, ``test``}, and it defines to which set the
+                    given piece of data is assigned. If for a piece of data the
+                    key is not present or has an invalid value, that piece is
+                    ignored by the pipeline.
+
+                    Supported only for tabular Datasets.
             """
 
         input_data_config = None
@@ -970,9 +981,16 @@ class CustomTrainingJob(_TrainingJob):
                 test_fraction=test_fraction_split,
             )
 
+            predefined_split = None
+            if predefined_split_column_name:
+                predefined_split = gca_training_pipeline.PredefinedSplit(
+                    key=predefined_split_column_name
+                )
+
             # create input data config
             input_data_config = gca_training_pipeline.InputDataConfig(
                 fraction_split=fraction_split,
+                predefined_split=predefined_split,
                 dataset_id=dataset.name,
                 gcs_destination=gca_io.GcsDestination(
                     output_uri_prefix=self._base_output_dir

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -118,7 +118,7 @@ class _TrainingJob(base.AiPlatformResourceNoun):
         validation_fraction_split: float,
         test_fraction_split: float,
         predefined_split_column_name: Optional[str],
-        gcs_destination: Optional[gca_io.GcsDestination],
+        gcs_destination_uri_prefix: Optional[str],
     ) -> gca_training_pipeline.InputDataConfig:
 
         """Constructs a input data config to pass to the training pipeline.
@@ -146,7 +146,7 @@ class _TrainingJob(base.AiPlatformResourceNoun):
                 ignored by the pipeline.
 
                 Supported only for tabular Datasets.
-            gcs_destination (~.io.GcsDestination):
+            gcs_destination_uri_prefix (str):
                 Optional. The Google Cloud Storage location.
 
                 The AI Platform environment variables representing Google
@@ -176,6 +176,13 @@ class _TrainingJob(base.AiPlatformResourceNoun):
                     key=predefined_split_column_name
                 )
 
+            # Create GCS destination
+            gcs_destination = None
+            if gcs_destination_uri_prefix:
+                gcs_destination = gca_io.GcsDestination(
+                    output_uri_prefix=gcs_destination_uri_prefix
+                )
+
             # create input data config
             input_data_config = gca_training_pipeline.InputDataConfig(
                 fraction_split=fraction_split,
@@ -196,7 +203,7 @@ class _TrainingJob(base.AiPlatformResourceNoun):
         test_fraction_split: float,
         predefined_split_column_name: Optional[str],
         model: Optional[gca_model.Model] = None,
-        gcs_destination: Optional[gca_io.GcsDestination] = None,
+        gcs_destination_uri_prefix: Optional[str] = None,
     ) -> Optional[models.Model]:
         """Runs the training job.
 
@@ -266,7 +273,7 @@ class _TrainingJob(base.AiPlatformResourceNoun):
                 resource ``name``
                 is populated. The Model is always uploaded into the Project
                 and Location in which this pipeline is.
-            gcs_destination (~.io.GcsDestination):
+            gcs_destination_uri_prefix (str):
                 Optional. The Google Cloud Storage location.
 
                 The AI Platform environment variables representing Google
@@ -289,7 +296,7 @@ class _TrainingJob(base.AiPlatformResourceNoun):
             validation_fraction_split=validation_fraction_split,
             test_fraction_split=test_fraction_split,
             predefined_split_column_name=predefined_split_column_name,
-            gcs_destination=gcs_destination,
+            gcs_destination_uri_prefix=gcs_destination_uri_prefix,
         )
 
         # create training pipeline
@@ -1178,9 +1185,7 @@ class CustomTrainingJob(_TrainingJob):
             test_fraction_split=test_fraction_split,
             predefined_split_column_name=predefined_split_column_name,
             model=managed_model,
-            gcs_destination=gca_io.GcsDestination(
-                output_uri_prefix=self._base_output_dir
-            ),
+            gcs_destination_uri_prefix=self._base_output_dir,
         )
 
         self._base_output_dir = None

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -157,9 +157,18 @@ class _TrainingJob(base.AiPlatformResourceNoun):
                 test_fraction=test_fraction_split,
             )
 
+            # Create predefined split spec
+            predefined_split = None
+            if predefined_split_column_name:
+                predefined_split = gca_training_pipeline.PredefinedSplit(
+                    key=predefined_split_column_name
+                )
+
             # create input data config
             input_data_config = gca_training_pipeline.InputDataConfig(
-                fraction_split=fraction_split, dataset_id=dataset.name,
+                fraction_split=fraction_split,
+                predefined_split=predefined_split,
+                dataset_id=dataset.name,
             )
 
         return input_data_config
@@ -1023,7 +1032,6 @@ class CustomTrainingJob(_TrainingJob):
         return input_data_config
 
     # TODO(b/172365904) add filter split, training_pipeline.FilterSplit
-    # TODO(b/172366411) predefined filter split training_pipeline.PredfinedFilterSplit
     # TODO(b/172368070) add timestamp split, training_pipeline.TimestampSplit
     def run(
         self,
@@ -1331,6 +1339,7 @@ class AutoMLTabularTrainingJob(_TrainingJob):
         training_fraction_split: float = 0.8,
         validation_fraction_split: float = 0.1,
         test_fraction_split: float = 0.1,
+        predefined_split_column_name: Optional[str] = None,
         weight_column: Optional[str] = None,
         budget_milli_node_hours: int = 1000,
         model_display_name: Optional[str] = None,
@@ -1363,6 +1372,16 @@ class AutoMLTabularTrainingJob(_TrainingJob):
             test_fraction_split (float):
                 Required. The fraction of the input data that is to be
                 used to evaluate the Model. This is ignored if Dataset is not provided.
+            predefined_split_column_name (str):
+                Optional. The key is a name of one of the Dataset's data
+                columns. The value of the key (either the label's value or
+                value in the column) must be one of {``training``,
+                ``validation``, ``test``}, and it defines to which set the
+                given piece of data is assigned. If for a piece of data the
+                key is not present or has an invalid value, that piece is
+                ignored by the pipeline.
+
+                Supported only for tabular Datasets.                
             weight_column (str):
                 Optional. Name of the column that should be used as the weight column.
                 Higher values in this column give more importance to the row
@@ -1431,7 +1450,7 @@ class AutoMLTabularTrainingJob(_TrainingJob):
             training_fraction_split=training_fraction_split,
             validation_fraction_split=validation_fraction_split,
             test_fraction_split=test_fraction_split,
-            predefined_split_column_name=None,
+            predefined_split_column_name=predefined_split_column_name,
             model=model,
         )
 

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -117,6 +117,7 @@ class _TrainingJob(base.AiPlatformResourceNoun):
         training_fraction_split: float,
         validation_fraction_split: float,
         test_fraction_split: float,
+        predefined_split_column_name: Optional[str],
     ) -> gca_training_pipeline.InputDataConfig:
 
         """Constructs a input data config to pass to the training pipeline.
@@ -135,6 +136,16 @@ class _TrainingJob(base.AiPlatformResourceNoun):
             test_fraction_split (float):
                 The fraction of the input data that is to be
                 used to evaluate the Model. This is ignored if Dataset is not provided.
+            predefined_split_column_name (str):
+                Optional. The key is a name of one of the Dataset's data
+                columns. The value of the key (either the label's value or
+                value in the column) must be one of {``training``,
+                ``validation``, ``test``}, and it defines to which set the
+                given piece of data is assigned. If for a piece of data the
+                key is not present or has an invalid value, that piece is
+                ignored by the pipeline.
+
+                Supported only for tabular Datasets.
         """
 
         input_data_config = None
@@ -161,6 +172,7 @@ class _TrainingJob(base.AiPlatformResourceNoun):
         training_fraction_split: float,
         validation_fraction_split: float,
         test_fraction_split: float,
+        predefined_split_column_name: Optional[str],
         model: Optional[gca_model.Model] = None,
     ) -> Optional[models.Model]:
         """Runs the training job.
@@ -201,6 +213,16 @@ class _TrainingJob(base.AiPlatformResourceNoun):
             test_fraction_split (float):
                 The fraction of the input data that is to be
                 used to evaluate the Model. This is ignored if Dataset is not provided.
+            predefined_split_column_name (str):
+                Optional. The key is a name of one of the Dataset's data
+                columns. The value of the key (either the label's value or
+                value in the column) must be one of {``training``,
+                ``validation``, ``test``}, and it defines to which set the
+                given piece of data is assigned. If for a piece of data the
+                key is not present or has an invalid value, that piece is
+                ignored by the pipeline.
+
+                Supported only for tabular Datasets.                
             model (~.model.Model):
                 Optional. Describes the Model that may be uploaded (via
                 [ModelService.UploadMode][]) by this TrainingPipeline. The
@@ -231,6 +253,7 @@ class _TrainingJob(base.AiPlatformResourceNoun):
             training_fraction_split=training_fraction_split,
             validation_fraction_split=validation_fraction_split,
             test_fraction_split=test_fraction_split,
+            predefined_split_column_name=predefined_split_column_name,
         )
 
         # create training pipeline
@@ -941,7 +964,7 @@ class CustomTrainingJob(_TrainingJob):
         training_fraction_split: float,
         validation_fraction_split: float,
         test_fraction_split: float,
-        predefined_split_column_name: Optional[str] = None,
+        predefined_split_column_name: Optional[str],
     ) -> gca_training_pipeline.InputDataConfig:
         """Constructs a input data config to pass to the training pipeline.
             Override this to create a custom config
@@ -1015,6 +1038,7 @@ class CustomTrainingJob(_TrainingJob):
         training_fraction_split: float = 0.8,
         validation_fraction_split: float = 0.1,
         test_fraction_split: float = 0.1,
+        predefined_split_column_name: Optional[str] = None,
     ) -> Optional[models.Model]:
         """Runs the custom training job.
 
@@ -1073,6 +1097,16 @@ class CustomTrainingJob(_TrainingJob):
             test_fraction_split (float):
                 The fraction of the input data that is to be
                 used to evaluate the Model. This is ignored if Dataset is not provided.
+            predefined_split_column_name (str):
+                Optional. The key is a name of one of the Dataset's data
+                columns. The value of the key (either the label's value or
+                value in the column) must be one of {``training``,
+                ``validation``, ``test``}, and it defines to which set the
+                given piece of data is assigned. If for a piece of data the
+                key is not present or has an invalid value, that piece is
+                ignored by the pipeline.
+
+                Supported only for tabular Datasets.
 
         Returns:
             model: The trained AI Platform Model resource or None if training did not
@@ -1171,6 +1205,7 @@ class CustomTrainingJob(_TrainingJob):
             training_fraction_split=training_fraction_split,
             validation_fraction_split=validation_fraction_split,
             test_fraction_split=test_fraction_split,
+            predefined_split_column_name=predefined_split_column_name,
             model=managed_model,
         )
 
@@ -1396,6 +1431,7 @@ class AutoMLTabularTrainingJob(_TrainingJob):
             training_fraction_split=training_fraction_split,
             validation_fraction_split=validation_fraction_split,
             test_fraction_split=test_fraction_split,
+            predefined_split_column_name=None,
             model=model,
         )
 

--- a/tests/unit/aiplatform/test_automl_tabular_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_tabular_training_jobs.py
@@ -67,6 +67,7 @@ _TEST_MODEL_DISPLAY_NAME = "model-display-name"
 _TEST_TRAINING_FRACTION_SPLIT = 0.6
 _TEST_VALIDATION_FRACTION_SPLIT = 0.2
 _TEST_TEST_FRACTION_SPLIT = 0.2
+_TEST_PREDEFINED_SPLIT_COLUMN_NAME = "split"
 
 _TEST_OUTPUT_PYTHON_PACKAGE_PATH = "gs://test/ouput/python/trainer.tar.gz"
 
@@ -160,6 +161,7 @@ class TestAutoMLTabularTrainingJob:
             training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
             validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
             test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
+            predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
             weight_column=_TEST_TRAINING_WEIGHT_COLUMN,
             budget_milli_node_hours=_TEST_TRAINING_BUDGET_MILLI_NODE_HOURS,
             disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
@@ -174,7 +176,11 @@ class TestAutoMLTabularTrainingJob:
         true_managed_model = gca_model.Model(display_name=_TEST_MODEL_DISPLAY_NAME)
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split, dataset_id=mock_dataset.name,
+            fraction_split=true_fraction_split,
+            predefined_split=gca_training_pipeline.PredefinedSplit(
+                key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
+            ),
+            dataset_id=mock_dataset.name,
         )
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -80,6 +80,7 @@ _TEST_MODEL_DISPLAY_NAME = "model-display-name"
 _TEST_TRAINING_FRACTION_SPLIT = 0.6
 _TEST_VALIDATION_FRACTION_SPLIT = 0.2
 _TEST_TEST_FRACTION_SPLIT = 0.2
+_TEST_PREDEFINED_SPLIT_COLUMN_NAME = "split"
 
 _TEST_OUTPUT_PYTHON_PACKAGE_PATH = "gs://test/ouput/python/trainer.tar.gz"
 
@@ -418,6 +419,7 @@ class TestCustomTrainingJob:
             training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
             validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
             test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
+            predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
         )
 
         mock_python_package_to_gcs.assert_called_once_with(

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -419,7 +419,7 @@ class TestCustomTrainingJob:
             training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
             validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
             test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
-            predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
+            predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
         )
 
         mock_python_package_to_gcs.assert_called_once_with(
@@ -463,6 +463,9 @@ class TestCustomTrainingJob:
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
             fraction_split=true_fraction_split,
+            predefined_split=gca_training_pipeline.PredefinedSplit(
+                key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
+            ),
             dataset_id=mock_dataset.name,
             gcs_destination=gca_io.GcsDestination(
                 output_uri_prefix=_TEST_BASE_OUTPUT_DIR


### PR DESCRIPTION
This adds predefined splits to custom training jobs.

Fixes https://b.corp.google.com/issues/172366411

## Tasks
- [x] P0 is to get this field supported in custom training. We can allow the service to raise an exception if a non-tabular dataset is passed.
- [ ] P1 to add additional client side validation to ensure the dataset is tabular. <- May do this in a subsequent PR
- [x] Add unit test coverage

## How was this tested
Unit-tested by checking the expected Gapic input data config is created.