### PR TITLE
fix: Added client check for a tabular dataset when using pre-defined splits

### DIFF
--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -172,15 +172,17 @@ class _TrainingJob(base.AiPlatformResourceNoun):
             # Create predefined split spec
             predefined_split = None
             if predefined_split_column_name:
-                schema_uri = dataset._gca_resource.metadata_schema_uri
-                if schema_uri == schema.dataset.metadata.tabular:
-                    predefined_split = gca_training_pipeline.PredefinedSplit(
-                        key=predefined_split_column_name
-                    )
-                else:
+                if (
+                    dataset._gca_resource.metadata_schema_uri
+                    != schema.dataset.metadata.tabular
+                ):
                     raise ValueError(
                         "A pre-defined split may only be used with a tabular Dataset"
                     )
+
+                predefined_split = gca_training_pipeline.PredefinedSplit(
+                    key=predefined_split_column_name
+                )
 
             # Create GCS destination
             gcs_destination = None

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -172,9 +172,15 @@ class _TrainingJob(base.AiPlatformResourceNoun):
             # Create predefined split spec
             predefined_split = None
             if predefined_split_column_name:
-                predefined_split = gca_training_pipeline.PredefinedSplit(
-                    key=predefined_split_column_name
-                )
+                schema_uri = dataset._gca_resource.metadata_schema_uri
+                if schema_uri == schema.dataset.metadata.tabular:
+                    predefined_split = gca_training_pipeline.PredefinedSplit(
+                        key=predefined_split_column_name
+                    )
+                else:
+                    raise ValueError(
+                        "A pre-defined split may only be used with a tabular Dataset"
+                    )
 
             # Create GCS destination
             gcs_destination = None

--- a/tests/unit/aiplatform/test_automl_tabular_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_tabular_training_jobs.py
@@ -166,7 +166,10 @@ class TestAutoMLTabularTrainingJob:
         return ds
 
     def test_run_call_pipeline_service_create(
-        self, mock_pipeline_service_create, mock_dataset_tabular, mock_model_service_get,
+        self,
+        mock_pipeline_service_create,
+        mock_dataset_tabular,
+        mock_model_service_get,
     ):
         aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
 
@@ -234,7 +237,10 @@ class TestAutoMLTabularTrainingJob:
         assert job.state == gca_pipeline_state.PipelineState.PIPELINE_STATE_SUCCEEDED
 
     def test_run_call_pipeline_if_no_model_display_name(
-        self, mock_pipeline_service_create, mock_dataset_tabular, mock_model_service_get,
+        self,
+        mock_pipeline_service_create,
+        mock_dataset_tabular,
+        mock_model_service_get,
     ):
         aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
 
@@ -285,7 +291,10 @@ class TestAutoMLTabularTrainingJob:
         )
 
     def test_run_called_predefined_split_nontabular_raises(
-        self, mock_pipeline_service_create, mock_dataset_nontabular, mock_model_service_get,
+        self,
+        mock_pipeline_service_create,
+        mock_dataset_nontabular,
+        mock_model_service_get,
     ):
         aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
 
@@ -306,11 +315,14 @@ class TestAutoMLTabularTrainingJob:
                 training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
                 validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
                 test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
-                predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
+                predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
             )
-            
+
     def test_run_called_twice_raises(
-        self, mock_pipeline_service_create, mock_dataset_tabular, mock_model_service_get,
+        self,
+        mock_pipeline_service_create,
+        mock_dataset_tabular,
+        mock_model_service_get,
     ):
         aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
 
@@ -390,7 +402,9 @@ class TestAutoMLTabularTrainingJob:
         assert model_from_job._gca_resource is mock_model_service_get.return_value
 
     def test_run_returns_none_if_no_model_to_upload(
-        self, mock_pipeline_service_create_with_no_model_to_upload, mock_dataset_tabular,
+        self,
+        mock_pipeline_service_create_with_no_model_to_upload,
+        mock_dataset_tabular,
     ):
         aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
 
@@ -415,7 +429,9 @@ class TestAutoMLTabularTrainingJob:
         assert model is None
 
     def test_get_model_raises_if_no_model_to_upload(
-        self, mock_pipeline_service_create_with_no_model_to_upload, mock_dataset_tabular,
+        self,
+        mock_pipeline_service_create_with_no_model_to_upload,
+        mock_dataset_tabular,
     ):
         aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
 

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -45,6 +45,8 @@ from google.cloud.aiplatform_v1beta1.types import pipeline_state as gca_pipeline
 from google.cloud.aiplatform_v1beta1.types import (
     training_pipeline as gca_training_pipeline,
 )
+from google.cloud.aiplatform_v1beta1 import Dataset as GapicDataset
+
 from google.cloud import storage
 from google.protobuf import json_format
 from google.protobuf import struct_pb2
@@ -62,7 +64,10 @@ print('hello world')
 """
 _TEST_REQUIREMENTS = ["pandas", "numpy", "tensorflow"]
 
+_TEST_DATASET_DISPLAY_NAME = "test-dataset-display-name"
+_TEST_DATASET_NAME = "test-dataset-name"
 _TEST_DISPLAY_NAME = "test-display-name"
+_TEST_METADATA_SCHEMA_URI_TABULAR = schema.dataset.metadata.tabular
 _TEST_TRAINING_CONTAINER_IMAGE = "gcr.io/test-training/container:image"
 _TEST_SERVING_CONTAINER_IMAGE = "gcr.io/test-serving/container:image"
 _TEST_SERVING_CONTAINER_PREDICTION_ROUTE = "predict"
@@ -387,6 +392,13 @@ class TestCustomTrainingJob:
     def mock_dataset(self):
         ds = mock.MagicMock(datasets.Dataset)
         ds.name = _TEST_DATASET_NAME
+        ds._gca_resource = GapicDataset(
+            display_name=_TEST_DATASET_DISPLAY_NAME,
+            metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_TABULAR,
+            labels={},
+            name=_TEST_DATASET_NAME,
+            metadata={},
+        )
         return ds
 
     def test_run_call_pipeline_service_create(


### PR DESCRIPTION
According to the yaml file, pre-defined splits can only be used with a tabular dataset. A ValueError is now raised if that's not the case.

fixes: https://b.corp.google.com/issues/174495379