### PR TITLE
feat: Added optional model args for custom training

### DIFF
--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1106,16 +1106,20 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
             health_route=serving_container_health_route,
         )
 
+        model_predict_schemata = None
+        if any([instance_schema_uri, parameters_schema_uri, prediction_schema_uri,]):
+            model_predict_schemata = gca_model.PredictSchemata(
+                instance_schema_uri=instance_schema_uri,
+                parameters_schema_uri=parameters_schema_uri,
+                prediction_schema_uri=prediction_schema_uri,
+            )
+
         managed_model = gca_model.Model(
             display_name=display_name,
             description=description,
             artifact_uri=artifact_uri,
             container_spec=container_spec,
-            predict_schemata=gca_model.PredictSchemata(
-                instance_schema_uri=instance_schema_uri,
-                parameters_schema_uri=parameters_schema_uri,
-                prediction_schema_uri=prediction_schema_uri,
-            ),
+            predict_schemata=model_predict_schemata,
         )
 
         lro = api_client.upload_model(

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1107,7 +1107,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
         )
 
         model_predict_schemata = None
-        if any([instance_schema_uri, parameters_schema_uri, prediction_schema_uri,]):
+        if any([instance_schema_uri, parameters_schema_uri, prediction_schema_uri]):
             model_predict_schemata = gca_model.PredictSchemata(
                 instance_schema_uri=instance_schema_uri,
                 parameters_schema_uri=parameters_schema_uri,

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -38,6 +38,7 @@ from google.cloud.aiplatform import utils
 from google.cloud.aiplatform_v1beta1.services.pipeline_service import (
     client as pipeline_service_client,
 )
+from google.cloud.aiplatform_v1beta1.types import env_var
 from google.cloud.aiplatform_v1beta1.types import (
     accelerator_type as gca_accelerator_type,
 )
@@ -47,7 +48,6 @@ from google.cloud.aiplatform_v1beta1.types import pipeline_state as gca_pipeline
 from google.cloud.aiplatform_v1beta1.types import (
     training_pipeline as gca_training_pipeline,
 )
-from google.cloud.aiplatform_v1beta1.types import env_var
 
 from google.cloud import storage
 from google.protobuf import json_format

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -923,7 +923,6 @@ class CustomTrainingJob(_TrainingJob):
     in Cloud AI Platform Training.
     """
 
-    # TODO(b/172365796) add remainder of model optional arguments
     def __init__(
         self,
         display_name: str,
@@ -933,6 +932,8 @@ class CustomTrainingJob(_TrainingJob):
         model_serving_container_image_uri: Optional[str] = None,
         model_serving_container_predict_route: Optional[str] = None,
         model_serving_container_health_route: Optional[str] = None,
+        model_etag: Optional[str] = None,
+        model_labels: Optional[Sequence[gca_model.model.Model.LabelsEntry]] = None,
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
@@ -987,6 +988,20 @@ class CustomTrainingJob(_TrainingJob):
                 send health check requests to the container, and which must be supported
                 by it. If not specified a standard HTTP path will be used by AI
                 Platform.
+            model_etag (str):
+                Used to perform consistent read-modify-write
+                updates. If not set, a blind "overwrite" update
+                happens.
+            model_labels (Sequence[~.model.Model.LabelsEntry]):
+                The labels with user-defined metadata to
+                organize your Models.
+                Label keys and values can be no longer than 64
+                characters (Unicode codepoints), can only
+                contain lowercase letters, numeric characters,
+                underscores and dashes. International characters
+                are allowed.
+                See https://goo.gl/xmQnxf for more information
+                and examples of labels.                 
             project (str):
                 Project to run training in. Overrides project set in aiplatform.init.
             location (str):
@@ -1014,6 +1029,8 @@ class CustomTrainingJob(_TrainingJob):
         self._model_serving_container_health_route = (
             model_serving_container_health_route
         )
+        self._model_etag = model_etag
+        self._model_labels = model_labels
 
         self._script_path = script_path
         self._staging_bucket = (
@@ -1160,7 +1177,10 @@ class CustomTrainingJob(_TrainingJob):
             )
 
             managed_model = gca_model.Model(
-                display_name=model_display_name, container_spec=container_spec
+                display_name=model_display_name, 
+                container_spec=container_spec,
+                etag=self._model_etag,
+                labels=self._model_labels
             )
 
         # make and copy package

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -932,6 +932,10 @@ class CustomTrainingJob(_TrainingJob):
         model_serving_container_image_uri: Optional[str] = None,
         model_serving_container_predict_route: Optional[str] = None,
         model_serving_container_health_route: Optional[str] = None,
+        model_serving_container_command: Optional[Sequence[str]]=None,
+        model_serving_container_args: Optional[Sequence[str]]=None,
+        model_serving_container_environment_variables: Optional[Sequence[str]]=None,
+        model_serving_container_ports: Optional[Sequence[int]]=None,
         model_description: Optional[str] = None,
         model_instance_schema_uri: Optional[str] = None,
         model_parameters_schema_uri: Optional[str] = None,
@@ -991,6 +995,32 @@ class CustomTrainingJob(_TrainingJob):
                 send health check requests to the container, and which must be supported
                 by it. If not specified a standard HTTP path will be used by AI
                 Platform.
+            model_serving_container_command: Optional[Sequence[str]]=None,
+                The command with which the container is run. Not executed within a
+                shell. The Docker image's ENTRYPOINT is used if this is not provided.
+                Variable references $(VAR_NAME) are expanded using the container's
+                environment. If a variable cannot be resolved, the reference in the
+                input string will be unchanged. The $(VAR_NAME) syntax can be escaped
+                with a double $$, ie: $$(VAR_NAME). Escaped references will never be
+                expanded, regardless of whether the variable exists or not.
+            model_serving_container_args: Optional[Sequence[str]]=None,
+                The arguments to the command. The Docker image's CMD is used if this is
+                not provided. Variable references $(VAR_NAME) are expanded using the
+                container's environment. If a variable cannot be resolved, the reference
+                in the input string will be unchanged. The $(VAR_NAME) syntax can be
+                escaped with a double $$, ie: $$(VAR_NAME). Escaped references will
+                never be expanded, regardless of whether the variable exists or not.
+            model_serving_container_environment_variables: Optional[Dict[str, str]]=None,
+                The environment variables that are to be present in the container.
+                Should be a dictionary where keys are environment variable names
+                and values are environment variable values for those names.
+            model_serving_container_ports: Optional[Sequence[int]]=None,
+                Declaration of ports that are exposed by the container. This field is
+                primarily informational, it gives AI Platform information about the
+                network connections the container uses. Listing or not a port here has
+                no impact on whether the port is actually exposed, any port listening on
+                the default "0.0.0.0" address inside a container will be accessible from
+                the network.                
             model_description (str):
                 The description of the Model.                
             model_instance_schema_uri (str):
@@ -1076,6 +1106,11 @@ class CustomTrainingJob(_TrainingJob):
         self._model_serving_container_health_route = (
             model_serving_container_health_route
         )
+
+        self._model_serving_container_command = model_serving_container_command
+        self._model_serving_container_args = model_serving_container_args
+        self._model_serving_container_environment_variables = model_serving_container_environment_variables
+        self._model_serving_container_ports = model_serving_container_ports
 
         self._model_description = model_description
         self._model_predict_schemata = gca_model.PredictSchemata(
@@ -1225,6 +1260,10 @@ class CustomTrainingJob(_TrainingJob):
 
             container_spec = gca_model.ModelContainerSpec(
                 image_uri=self._model_serving_container_image_uri,
+                command=self._model_serving_container_command,
+                args=self._model_serving_container_args,
+                env=self._model_serving_container_environment_variables,
+                ports=self._model_serving_container_ports,
                 predict_route=self._model_serving_container_predict_route,
                 health_route=self._model_serving_container_health_route,
             )

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -932,7 +932,6 @@ class CustomTrainingJob(_TrainingJob):
         model_serving_container_image_uri: Optional[str] = None,
         model_serving_container_predict_route: Optional[str] = None,
         model_serving_container_health_route: Optional[str] = None,
-        model_etag: Optional[str] = None,
         model_labels: Optional[Sequence[gca_model.model.Model.LabelsEntry]] = None,
         project: Optional[str] = None,
         location: Optional[str] = None,
@@ -988,10 +987,6 @@ class CustomTrainingJob(_TrainingJob):
                 send health check requests to the container, and which must be supported
                 by it. If not specified a standard HTTP path will be used by AI
                 Platform.
-            model_etag (str):
-                Used to perform consistent read-modify-write
-                updates. If not set, a blind "overwrite" update
-                happens.
             model_labels (Sequence[~.model.Model.LabelsEntry]):
                 The labels with user-defined metadata to
                 organize your Models.
@@ -1029,7 +1024,6 @@ class CustomTrainingJob(_TrainingJob):
         self._model_serving_container_health_route = (
             model_serving_container_health_route
         )
-        self._model_etag = model_etag
         self._model_labels = model_labels
 
         self._script_path = script_path
@@ -1179,7 +1173,6 @@ class CustomTrainingJob(_TrainingJob):
             managed_model = gca_model.Model(
                 display_name=model_display_name, 
                 container_spec=container_spec,
-                etag=self._model_etag,
                 labels=self._model_labels
             )
 

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -986,7 +986,7 @@ class CustomTrainingJob(_TrainingJob):
                 If the training produces a managed AI Platform Model, the URI of the
                 Model serving container suitable for serving the model produced by the
                 training script.
-            model_serving_container_predict_route (str):.
+            model_serving_container_predict_route (str):
                 If the training produces a managed AI Platform Model, An HTTP path to
                 send prediction requests to the container, and which must be supported
                 by it. If not specified a default HTTP path will be used by AI Platform.
@@ -995,7 +995,7 @@ class CustomTrainingJob(_TrainingJob):
                 send health check requests to the container, and which must be supported
                 by it. If not specified a standard HTTP path will be used by AI
                 Platform.
-            model_serving_container_command: Optional[Sequence[str]]=None,
+            model_serving_container_command (Sequence[str]),
                 The command with which the container is run. Not executed within a
                 shell. The Docker image's ENTRYPOINT is used if this is not provided.
                 Variable references $(VAR_NAME) are expanded using the container's
@@ -1003,18 +1003,18 @@ class CustomTrainingJob(_TrainingJob):
                 input string will be unchanged. The $(VAR_NAME) syntax can be escaped
                 with a double $$, ie: $$(VAR_NAME). Escaped references will never be
                 expanded, regardless of whether the variable exists or not.
-            model_serving_container_args: Optional[Sequence[str]]=None,
+            model_serving_container_args (Sequence[str]),
                 The arguments to the command. The Docker image's CMD is used if this is
                 not provided. Variable references $(VAR_NAME) are expanded using the
                 container's environment. If a variable cannot be resolved, the reference
                 in the input string will be unchanged. The $(VAR_NAME) syntax can be
                 escaped with a double $$, ie: $$(VAR_NAME). Escaped references will
                 never be expanded, regardless of whether the variable exists or not.
-            model_serving_container_environment_variables: Optional[Dict[str, str]]=None,
+            model_serving_container_environment_variables (Dict[str, str]),
                 The environment variables that are to be present in the container.
                 Should be a dictionary where keys are environment variable names
                 and values are environment variable values for those names.
-            model_serving_container_ports: Optional[Sequence[int]]=None,
+            model_serving_container_ports (Sequence[int]),
                 Declaration of ports that are exposed by the container. This field is
                 primarily informational, it gives AI Platform information about the
                 network connections the container uses. Listing or not a port here has

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -932,6 +932,7 @@ class CustomTrainingJob(_TrainingJob):
         model_serving_container_image_uri: Optional[str] = None,
         model_serving_container_predict_route: Optional[str] = None,
         model_serving_container_health_route: Optional[str] = None,
+        model_description: Optional[str] = None,
         model_instance_schema_uri: Optional[str] = None,
         model_parameters_schema_uri: Optional[str] = None,
         model_prediction_schema_uri: Optional[str] = None,
@@ -990,6 +991,8 @@ class CustomTrainingJob(_TrainingJob):
                 send health check requests to the container, and which must be supported
                 by it. If not specified a standard HTTP path will be used by AI
                 Platform.
+            model_description (str):
+                The description of the Model.                
             model_instance_schema_uri (str):
                 Optional. Points to a YAML file stored on Google Cloud
                 Storage describing the format of a single instance, which
@@ -1073,12 +1076,14 @@ class CustomTrainingJob(_TrainingJob):
         self._model_serving_container_health_route = (
             model_serving_container_health_route
         )
-        self._model_labels = model_labels
+
+        self._model_description = model_description
         self._model_predict_schemata = gca_model.PredictSchemata(
-            instance_schema_uri=self.model_instance_schema_uri,
-            parameters_schema_uri=self.model_parameters_schema_uri,
-            prediction_schema_uri=self.model_prediction_schema_uri,
+            instance_schema_uri=model_instance_schema_uri,
+            parameters_schema_uri=model_parameters_schema_uri,
+            prediction_schema_uri=model_prediction_schema_uri,
         )
+        self._model_labels = model_labels
 
         self._script_path = script_path
         self._staging_bucket = (
@@ -1225,7 +1230,8 @@ class CustomTrainingJob(_TrainingJob):
             )
 
             managed_model = gca_model.Model(
-                display_name=model_display_name, 
+                display_name=model_display_name,
+                description=self._model_description,
                 predict_schemata=self._model_predict_schemata,
                 container_spec=container_spec,
                 labels=self._model_labels

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -995,7 +995,7 @@ class CustomTrainingJob(_TrainingJob):
                 send health check requests to the container, and which must be supported
                 by it. If not specified a standard HTTP path will be used by AI
                 Platform.
-            model_serving_container_command (Sequence[str]),
+            model_serving_container_command (Sequence[str]):
                 The command with which the container is run. Not executed within a
                 shell. The Docker image's ENTRYPOINT is used if this is not provided.
                 Variable references $(VAR_NAME) are expanded using the container's
@@ -1003,18 +1003,18 @@ class CustomTrainingJob(_TrainingJob):
                 input string will be unchanged. The $(VAR_NAME) syntax can be escaped
                 with a double $$, ie: $$(VAR_NAME). Escaped references will never be
                 expanded, regardless of whether the variable exists or not.
-            model_serving_container_args (Sequence[str]),
+            model_serving_container_args (Sequence[str]):
                 The arguments to the command. The Docker image's CMD is used if this is
                 not provided. Variable references $(VAR_NAME) are expanded using the
                 container's environment. If a variable cannot be resolved, the reference
                 in the input string will be unchanged. The $(VAR_NAME) syntax can be
                 escaped with a double $$, ie: $$(VAR_NAME). Escaped references will
                 never be expanded, regardless of whether the variable exists or not.
-            model_serving_container_environment_variables (Dict[str, str]),
+            model_serving_container_environment_variables (Dict[str, str]):
                 The environment variables that are to be present in the container.
                 Should be a dictionary where keys are environment variable names
                 and values are environment variable values for those names.
-            model_serving_container_ports (Sequence[int]),
+            model_serving_container_ports (Sequence[int]):
                 Declaration of ports that are exposed by the container. This field is
                 primarily informational, it gives AI Platform information about the
                 network connections the container uses. Listing or not a port here has
@@ -1089,22 +1089,6 @@ class CustomTrainingJob(_TrainingJob):
 
         self._container_uri = container_uri
         self._requirements = requirements
-        self._model_serving_container_image_uri = model_serving_container_image_uri
-        self._model_serving_container_predict_route = (
-            model_serving_container_predict_route
-        )
-        self._model_serving_container_health_route = (
-            model_serving_container_health_route
-        )
-
-        self._model_serving_container_command = model_serving_container_command
-        self._model_serving_container_args = model_serving_container_args
-        self._model_serving_container_environment_variables = (
-            model_serving_container_environment_variables
-        )
-        self._model_serving_container_ports = model_serving_container_ports
-
-        self._model_description = model_description
 
         model_predict_schemata = None
         if any(
@@ -1270,7 +1254,7 @@ class CustomTrainingJob(_TrainingJob):
             raise RuntimeError("Custom Training has already run.")
 
         # if args needed for model is incomplete
-        if model_display_name and not self._model_serving_container_image_uri:
+        if model_display_name and not self._managed_model.container_spec.image_uri:
             raise RuntimeError(
                 """model_display_name was provided but
                 model_serving_container_image_uri was not provided when this

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -1279,6 +1279,8 @@ class CustomTrainingJob(_TrainingJob):
         if model_display_name:
             utils.validate_display_name(model_display_name)
             managed_model.display_name = model_display_name
+        else:
+            managed_model = None
 
         return self._run(
             python_packager=python_packager,

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -941,7 +941,6 @@ class CustomTrainingJob(_TrainingJob):
         model_instance_schema_uri: Optional[str] = None,
         model_parameters_schema_uri: Optional[str] = None,
         model_prediction_schema_uri: Optional[str] = None,
-        model_labels: Optional[Sequence[gca_model.Model.LabelsEntry]] = None,
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
@@ -1070,16 +1069,6 @@ class CustomTrainingJob(_TrainingJob):
                 and probably different, including the URI scheme, than the
                 one given on input. The output URI will point to a location
                 where the user only has a read access.
-            model_labels (Sequence[~.model.Model.LabelsEntry]):
-                The labels with user-defined metadata to
-                organize your Models.
-                Label keys and values can be no longer than 64
-                characters (Unicode codepoints), can only
-                contain lowercase letters, numeric characters,
-                underscores and dashes. International characters
-                are allowed.
-                See https://goo.gl/xmQnxf for more information
-                and examples of labels.
             project (str):
                 Project to run training in. Overrides project set in aiplatform.init.
             location (str):
@@ -1121,7 +1110,6 @@ class CustomTrainingJob(_TrainingJob):
             parameters_schema_uri=model_parameters_schema_uri,
             prediction_schema_uri=model_prediction_schema_uri,
         )
-        self._model_labels = model_labels
 
         self._script_path = script_path
         self._staging_bucket = (
@@ -1269,10 +1257,11 @@ class CustomTrainingJob(_TrainingJob):
                     env_var.EnvVar(name=str(key), value=str(value))
                     for key, value in self._model_serving_container_environment_variables.items()
                 ]
-            
+
             if self._model_serving_container_ports:
                 ports = [
-                    gca_model.Port(container_port=port) for port in self._model_serving_container_ports
+                    gca_model.Port(container_port=port)
+                    for port in self._model_serving_container_ports
                 ]
 
             container_spec = gca_model.ModelContainerSpec(
@@ -1290,7 +1279,6 @@ class CustomTrainingJob(_TrainingJob):
                 description=self._model_description,
                 predict_schemata=self._model_predict_schemata,
                 container_spec=container_spec,
-                labels=self._model_labels,
             )
 
         # make and copy package

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -928,14 +928,14 @@ class CustomTrainingJob(_TrainingJob):
         display_name: str,
         script_path: str,
         container_uri: str,
-        requirements: Optional[Sequence[str]] = None,        
+        requirements: Optional[Sequence[str]] = None,
         model_serving_container_image_uri: Optional[str] = None,
         model_serving_container_predict_route: Optional[str] = None,
         model_serving_container_health_route: Optional[str] = None,
-        model_serving_container_command: Optional[Sequence[str]]=None,
-        model_serving_container_args: Optional[Sequence[str]]=None,
-        model_serving_container_environment_variables: Optional[Sequence[str]]=None,
-        model_serving_container_ports: Optional[Sequence[int]]=None,
+        model_serving_container_command: Optional[Sequence[str]] = None,
+        model_serving_container_args: Optional[Sequence[str]] = None,
+        model_serving_container_environment_variables: Optional[Sequence[str]] = None,
+        model_serving_container_ports: Optional[Sequence[int]] = None,
         model_description: Optional[str] = None,
         model_instance_schema_uri: Optional[str] = None,
         model_parameters_schema_uri: Optional[str] = None,
@@ -1020,9 +1020,9 @@ class CustomTrainingJob(_TrainingJob):
                 network connections the container uses. Listing or not a port here has
                 no impact on whether the port is actually exposed, any port listening on
                 the default "0.0.0.0" address inside a container will be accessible from
-                the network.                
+                the network.
             model_description (str):
-                The description of the Model.                
+                The description of the Model.
             model_instance_schema_uri (str):
                 Optional. Points to a YAML file stored on Google Cloud
                 Storage describing the format of a single instance, which
@@ -1078,7 +1078,7 @@ class CustomTrainingJob(_TrainingJob):
                 underscores and dashes. International characters
                 are allowed.
                 See https://goo.gl/xmQnxf for more information
-                and examples of labels.                 
+                and examples of labels.
             project (str):
                 Project to run training in. Overrides project set in aiplatform.init.
             location (str):
@@ -1109,7 +1109,9 @@ class CustomTrainingJob(_TrainingJob):
 
         self._model_serving_container_command = model_serving_container_command
         self._model_serving_container_args = model_serving_container_args
-        self._model_serving_container_environment_variables = model_serving_container_environment_variables
+        self._model_serving_container_environment_variables = (
+            model_serving_container_environment_variables
+        )
         self._model_serving_container_ports = model_serving_container_ports
 
         self._model_description = model_description
@@ -1273,7 +1275,7 @@ class CustomTrainingJob(_TrainingJob):
                 description=self._model_description,
                 predict_schemata=self._model_predict_schemata,
                 container_spec=container_spec,
-                labels=self._model_labels
+                labels=self._model_labels,
             )
 
         # make and copy package

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -1106,11 +1106,19 @@ class CustomTrainingJob(_TrainingJob):
 
         self._model_description = model_description
 
-        model_predict_schemata = gca_model.PredictSchemata(
-            instance_schema_uri=model_instance_schema_uri,
-            parameters_schema_uri=model_parameters_schema_uri,
-            prediction_schema_uri=model_prediction_schema_uri,
-        )
+        model_predict_schemata = None
+        if any(
+            [
+                model_instance_schema_uri,
+                model_parameters_schema_uri,
+                model_prediction_schema_uri,
+            ]
+        ):
+            model_predict_schemata = gca_model.PredictSchemata(
+                instance_schema_uri=model_instance_schema_uri,
+                parameters_schema_uri=model_parameters_schema_uri,
+                prediction_schema_uri=model_prediction_schema_uri,
+            )
 
         # Create the container spec
         env = None

--- a/tests/unit/aiplatform/test_models.py
+++ b/tests/unit/aiplatform/test_models.py
@@ -293,11 +293,6 @@ class TestModel:
                 display_name=_TEST_MODEL_NAME,
                 artifact_uri=_TEST_ARTIFACT_URI,
                 container_spec=container_spec,
-                predict_schemata=gca_model.PredictSchemata(
-                    instance_schema_uri=None,
-                    parameters_schema_uri=None,
-                    prediction_schema_uri=None,
-                ),
             )
 
             api_client_mock.upload_model.assert_called_once_with(
@@ -429,11 +424,6 @@ class TestModel:
                 display_name=_TEST_MODEL_NAME,
                 artifact_uri=_TEST_ARTIFACT_URI,
                 container_spec=container_spec,
-                predict_schemata=gca_model.PredictSchemata(
-                    instance_schema_uri=None,
-                    parameters_schema_uri=None,
-                    prediction_schema_uri=None,
-                ),
             )
 
             api_client_mock.upload_model.assert_called_once_with(
@@ -485,11 +475,6 @@ class TestModel:
                 display_name=_TEST_MODEL_NAME,
                 artifact_uri=_TEST_ARTIFACT_URI,
                 container_spec=container_spec,
-                predict_schemata=gca_model.PredictSchemata(
-                    instance_schema_uri=None,
-                    parameters_schema_uri=None,
-                    prediction_schema_uri=None,
-                ),
             )
 
             api_client_mock.upload_model.assert_called_once_with(

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -758,12 +758,7 @@ class TestCustomTrainingJob:
 
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
-            container_spec=true_container_spec,
-            predict_schemata=gca_model.PredictSchemata(
-                instance_schema_uri=None,
-                parameters_schema_uri=None,
-                prediction_schema_uri=None,
-            ),
+            container_spec=true_container_spec
         )
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -757,8 +757,7 @@ class TestCustomTrainingJob:
         )
 
         true_managed_model = gca_model.Model(
-            display_name=_TEST_MODEL_DISPLAY_NAME,
-            container_spec=true_container_spec
+            display_name=_TEST_MODEL_DISPLAY_NAME, container_spec=true_container_spec
         )
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -87,6 +87,15 @@ _TEST_VALIDATION_FRACTION_SPLIT = 0.2
 _TEST_TEST_FRACTION_SPLIT = 0.2
 _TEST_PREDEFINED_SPLIT_COLUMN_NAME = "split"
 
+_TEST_MODEL_INSTANCE_SCHEMA_URI = "instance_schema_uri.yaml"
+_TEST_MODEL_PARAMETERS_SCHEMA_URI = "parameters_schema_uri.yaml"
+_TEST_MODEL_PREDICTION_SCHEMA_URI = "prediction_schema_uri.yaml"
+_TEST_MODEL_SERVING_CONTAINER_COMMAND = ["test_command"]
+_TEST_MODEL_SERVING_CONTAINER_ARGS = ["test_args"]
+_TEST_MODEL_SERVING_CONTAINER_ENVIRONMENT_VARIABLES = ["test_env_variables"]
+_TEST_MODEL_SERVING_CONTAINER_PORTS = [1234]
+_TEST_MODEL_DESCRIPTION = "test description"
+
 _TEST_OUTPUT_PYTHON_PACKAGE_PATH = "gs://test/ouput/python/trainer.tar.gz"
 
 _TEST_MODEL_NAME = "projects/my-project/locations/us-central1/models/12345"
@@ -426,6 +435,9 @@ class TestCustomTrainingJob:
             model_serving_container_image_uri=_TEST_SERVING_CONTAINER_IMAGE,
             model_serving_container_predict_route=_TEST_SERVING_CONTAINER_PREDICTION_ROUTE,
             model_serving_container_health_route=_TEST_SERVING_CONTAINER_HEALTH_ROUTE,
+            model_instance_schema_uri=_TEST_MODEL_INSTANCE_SCHEMA_URI,
+            model_parameters_schema_uri=_TEST_MODEL_PARAMETERS_SCHEMA_URI,
+            model_prediction_schema_uri=_TEST_MODEL_PREDICTION_SCHEMA_URI,
         )
 
         model_from_job = job.run(
@@ -483,7 +495,13 @@ class TestCustomTrainingJob:
         )
 
         true_managed_model = gca_model.Model(
-            display_name=_TEST_MODEL_DISPLAY_NAME, container_spec=true_container_spec
+            display_name=_TEST_MODEL_DISPLAY_NAME, 
+            container_spec=true_container_spec,
+            predict_schemata=gca_model.PredictSchemata(
+                instance_schema_uri=_TEST_MODEL_INSTANCE_SCHEMA_URI,
+                parameters_schema_uri=_TEST_MODEL_PARAMETERS_SCHEMA_URI,
+                prediction_schema_uri=_TEST_MODEL_PREDICTION_SCHEMA_URI,
+            ),
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
@@ -665,6 +683,9 @@ class TestCustomTrainingJob:
             model_serving_container_image_uri=_TEST_SERVING_CONTAINER_IMAGE,
             model_serving_container_predict_route=_TEST_SERVING_CONTAINER_PREDICTION_ROUTE,
             model_serving_container_health_route=_TEST_SERVING_CONTAINER_HEALTH_ROUTE,
+            model_instance_schema_uri=_TEST_MODEL_INSTANCE_SCHEMA_URI,
+            model_parameters_schema_uri=_TEST_MODEL_PARAMETERS_SCHEMA_URI,
+            model_prediction_schema_uri=_TEST_MODEL_PREDICTION_SCHEMA_URI,
         )
 
         model_from_job = job.run(
@@ -714,7 +735,13 @@ class TestCustomTrainingJob:
         )
 
         true_managed_model = gca_model.Model(
-            display_name=_TEST_MODEL_DISPLAY_NAME, container_spec=true_container_spec
+            display_name=_TEST_MODEL_DISPLAY_NAME, 
+            container_spec=true_container_spec,
+            predict_schemata=gca_model.PredictSchemata(
+                instance_schema_uri=_TEST_MODEL_INSTANCE_SCHEMA_URI,
+                parameters_schema_uri=_TEST_MODEL_PARAMETERS_SCHEMA_URI,
+                prediction_schema_uri=_TEST_MODEL_PREDICTION_SCHEMA_URI,
+            ),
         )
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
@@ -899,6 +926,9 @@ class TestCustomTrainingJob:
             model_serving_container_image_uri=_TEST_SERVING_CONTAINER_IMAGE,
             model_serving_container_predict_route=_TEST_SERVING_CONTAINER_PREDICTION_ROUTE,
             model_serving_container_health_route=_TEST_SERVING_CONTAINER_HEALTH_ROUTE,
+            model_instance_schema_uri=_TEST_MODEL_INSTANCE_SCHEMA_URI,
+            model_parameters_schema_uri=_TEST_MODEL_PARAMETERS_SCHEMA_URI,
+            model_prediction_schema_uri=_TEST_MODEL_PREDICTION_SCHEMA_URI,
         )
 
         model_from_job = job.run(
@@ -971,7 +1001,13 @@ class TestCustomTrainingJob:
         )
 
         true_managed_model = gca_model.Model(
-            display_name=_TEST_MODEL_DISPLAY_NAME, container_spec=true_container_spec
+            display_name=_TEST_MODEL_DISPLAY_NAME, 
+            container_spec=true_container_spec,
+            predict_schemata=gca_model.PredictSchemata(
+                instance_schema_uri=_TEST_MODEL_INSTANCE_SCHEMA_URI,
+                parameters_schema_uri=_TEST_MODEL_PARAMETERS_SCHEMA_URI,
+                prediction_schema_uri=_TEST_MODEL_PREDICTION_SCHEMA_URI,
+            ),
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -103,6 +103,7 @@ _TEST_MODEL_DESCRIPTION = "test description"
 _TEST_OUTPUT_PYTHON_PACKAGE_PATH = "gs://test/ouput/python/trainer.tar.gz"
 
 _TEST_MODEL_NAME = "projects/my-project/locations/us-central1/models/12345"
+_TEST_MODEL_LABELS = {"label_key": "label_value"}
 
 _TEST_PIPELINE_RESOURCE_NAME = (
     "projects/my-project/locations/us-central1/trainingPipeline/12345"
@@ -445,7 +446,8 @@ class TestCustomTrainingJob:
             model_serving_container_command=_TEST_MODEL_SERVING_CONTAINER_COMMAND,
             model_serving_container_args=_TEST_MODEL_SERVING_CONTAINER_ARGS,
             model_serving_container_environment_variables=_TEST_MODEL_SERVING_CONTAINER_ENVIRONMENT_VARIABLES,
-            model_serving_container_ports=_TEST_MODEL_SERVING_CONTAINER_PORTS
+            model_serving_container_ports=_TEST_MODEL_SERVING_CONTAINER_PORTS,
+            model_description=_TEST_MODEL_DESCRIPTION,
         )
 
         model_from_job = job.run(
@@ -497,15 +499,15 @@ class TestCustomTrainingJob:
         )
 
         env = [
-                env_var.EnvVar(name=str(key), value=str(value))
-                for key, value in _TEST_MODEL_SERVING_CONTAINER_ENVIRONMENT_VARIABLES.items()
-            ]
+            env_var.EnvVar(name=str(key), value=str(value))
+            for key, value in _TEST_MODEL_SERVING_CONTAINER_ENVIRONMENT_VARIABLES.items()
+        ]
 
         ports = [
             gca_model.Port(container_port=port)
             for port in _TEST_MODEL_SERVING_CONTAINER_PORTS
         ]
-        
+
         true_container_spec = gca_model.ModelContainerSpec(
             image_uri=_TEST_SERVING_CONTAINER_IMAGE,
             predict_route=_TEST_SERVING_CONTAINER_PREDICTION_ROUTE,
@@ -517,7 +519,8 @@ class TestCustomTrainingJob:
         )
 
         true_managed_model = gca_model.Model(
-            display_name=_TEST_MODEL_DISPLAY_NAME, 
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            description=_TEST_MODEL_DESCRIPTION,
             container_spec=true_container_spec,
             predict_schemata=gca_model.PredictSchemata(
                 instance_schema_uri=_TEST_MODEL_INSTANCE_SCHEMA_URI,
@@ -754,7 +757,7 @@ class TestCustomTrainingJob:
         )
 
         true_managed_model = gca_model.Model(
-            display_name=_TEST_MODEL_DISPLAY_NAME, 
+            display_name=_TEST_MODEL_DISPLAY_NAME,
             container_spec=true_container_spec,
             predict_schemata=gca_model.PredictSchemata(
                 instance_schema_uri=None,
@@ -1020,7 +1023,7 @@ class TestCustomTrainingJob:
         )
 
         true_managed_model = gca_model.Model(
-            display_name=_TEST_MODEL_DISPLAY_NAME, 
+            display_name=_TEST_MODEL_DISPLAY_NAME,
             container_spec=true_container_spec,
             predict_schemata=gca_model.PredictSchemata(
                 instance_schema_uri=_TEST_MODEL_INSTANCE_SCHEMA_URI,


### PR DESCRIPTION
Added optional args to `CustomTrainingJob.init`:

```
        model_serving_container_command: Optional[Sequence[str]] = None,
        model_serving_container_args: Optional[Sequence[str]] = None,
        model_serving_container_environment_variables: Optional[Dict[str, str]] = None,
        model_serving_container_ports: Optional[Sequence[int]] = None,
        model_description: Optional[str] = None,
        model_instance_schema_uri: Optional[str] = None,
        model_parameters_schema_uri: Optional[str] = None,
        model_prediction_schema_uri: Optional[str] = None,
```

Fixes https://b.corp.google.com/issues/172365796

## TODO
- [x] Added unit test
