### PR TITLE
chore: alpha

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import os
 import setuptools  # type: ignore
 
 name = "google-cloud-aiplatform"
-version = "0.3.1"
+version = "0.3.1-alpha"
 description = "Cloud AI Platform API client library"
 
 package_root = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import os
 import setuptools  # type: ignore
 
 name = "google-cloud-aiplatform"
-version = "0.3.1-alpha"
+version = "0.4.0a1"
 description = "Cloud AI Platform API client library"
 
 package_root = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
This makes the mb-release package show up as version `0.4.0a1`, and allows the user to revert to the public package with `pip install google-cloud-aiplatform==0.3.1`.