### PR TITLE
feat: add schema namespace

### DIFF
--- a/google/cloud/aiplatform/__init__.py
+++ b/google/cloud/aiplatform/__init__.py
@@ -19,7 +19,4 @@ from google.cloud.aiplatform import gapic
 from google.cloud.aiplatform import schema
 
 
-__all__ = (
-	gapic,
-	schema
-)
+__all__ = (gapic, schema)

--- a/google/cloud/aiplatform/schema/__init__.py
+++ b/google/cloud/aiplatform/schema/__init__.py
@@ -15,4 +15,11 @@
 # limitations under the License.
 
 
-from google.cloud.aiplatform.v1beta1.schema import *
+from google.cloud.aiplatform.v1beta1.schema import predict
+from google.cloud.aiplatform.v1beta1.schema import trainingjob
+
+
+__all__ = (
+    "predict",
+    "trainingjob",
+)

--- a/google/cloud/aiplatform/schema/__init__.py
+++ b/google/cloud/aiplatform/schema/__init__.py
@@ -13,13 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-
-from google.cloud.aiplatform import gapic
-from google.cloud.aiplatform import schema
 
 
-__all__ = (
-	gapic,
-	schema
-)
+from google.cloud.aiplatform.v1beta1.schema import *

--- a/google/cloud/aiplatform/v1beta1/schema/__init__.py
+++ b/google/cloud/aiplatform/v1beta1/schema/__init__.py
@@ -13,13 +13,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-from google.cloud.aiplatform import gapic
-from google.cloud.aiplatform import schema
+
+from google.cloud.aiplatform.v1beta1.schema import predict
+from google.cloud.aiplatform.v1beta1.schema import trainingjob
 
 
 __all__ = (
-	gapic,
-	schema
+    "predict",
+    "trainingjob",
 )

--- a/google/cloud/aiplatform/v1beta1/schema/predict/__init__.py
+++ b/google/cloud/aiplatform/v1beta1/schema/predict/__init__.py
@@ -13,13 +13,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-from google.cloud.aiplatform import gapic
-from google.cloud.aiplatform import schema
 
+from google.cloud.aiplatform.v1beta1.schema.predict import instance
+from google.cloud.aiplatform.v1beta1.schema.predict import params
+from google.cloud.aiplatform.v1beta1.schema.predict import prediction
 
 __all__ = (
-	gapic,
-	schema
+    "instance",
+    "params",
+    "prediction",
 )

--- a/google/cloud/aiplatform/v1beta1/schema/predict/instance/__init__.py
+++ b/google/cloud/aiplatform/v1beta1/schema/predict/instance/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 from google.cloud.aiplatform.helpers import _decorators
-import google.cloud.aiplatform.v1beta1.schema.predict.instance_v1beta1.types as pkg
+from google.cloud.aiplatform.v1beta1.schema.predict.instance_v1beta1 import types as pkg
 
 from google.cloud.aiplatform.v1beta1.schema.predict.instance_v1beta1.types.image_classification import (
     ImageClassificationPredictionInstance,

--- a/google/cloud/aiplatform/v1beta1/schema/predict/params/__init__.py
+++ b/google/cloud/aiplatform/v1beta1/schema/predict/params/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 from google.cloud.aiplatform.helpers import _decorators
-import google.cloud.aiplatform.v1beta1.schema.predict.params_v1beta1.types as pkg
+from google.cloud.aiplatform.v1beta1.schema.predict.params_v1beta1 import types as pkg
 
 from google.cloud.aiplatform.v1beta1.schema.predict.params_v1beta1.types.image_classification import (
     ImageClassificationPredictionParams,

--- a/google/cloud/aiplatform/v1beta1/schema/predict/prediction/__init__.py
+++ b/google/cloud/aiplatform/v1beta1/schema/predict/prediction/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 from google.cloud.aiplatform.helpers import _decorators
-import google.cloud.aiplatform.v1beta1.schema.predict.prediction_v1beta1.types as pkg
+from google.cloud.aiplatform.v1beta1.schema.predict.prediction_v1beta1 import types as pkg
 
 from google.cloud.aiplatform.v1beta1.schema.predict.prediction_v1beta1.types.classification import (
     ClassificationPredictionResult,

--- a/google/cloud/aiplatform/v1beta1/schema/predict/prediction/__init__.py
+++ b/google/cloud/aiplatform/v1beta1/schema/predict/prediction/__init__.py
@@ -15,7 +15,9 @@
 # limitations under the License.
 #
 from google.cloud.aiplatform.helpers import _decorators
-from google.cloud.aiplatform.v1beta1.schema.predict.prediction_v1beta1 import types as pkg
+from google.cloud.aiplatform.v1beta1.schema.predict.prediction_v1beta1 import (
+    types as pkg,
+)
 
 from google.cloud.aiplatform.v1beta1.schema.predict.prediction_v1beta1.types.classification import (
     ClassificationPredictionResult,

--- a/google/cloud/aiplatform/v1beta1/schema/trainingjob/__init__.py
+++ b/google/cloud/aiplatform/v1beta1/schema/trainingjob/__init__.py
@@ -13,13 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-from google.cloud.aiplatform import gapic
-from google.cloud.aiplatform import schema
 
+from google.cloud.aiplatform.v1beta1.schema.trainingjob import definition
 
 __all__ = (
-	gapic,
-	schema
+    "definition",
 )

--- a/google/cloud/aiplatform/v1beta1/schema/trainingjob/__init__.py
+++ b/google/cloud/aiplatform/v1beta1/schema/trainingjob/__init__.py
@@ -17,6 +17,4 @@
 
 from google.cloud.aiplatform.v1beta1.schema.trainingjob import definition
 
-__all__ = (
-    "definition",
-)
+__all__ = ("definition",)

--- a/google/cloud/aiplatform/v1beta1/schema/trainingjob/definition/__init__.py
+++ b/google/cloud/aiplatform/v1beta1/schema/trainingjob/definition/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 from google.cloud.aiplatform.helpers import _decorators
-import google.cloud.aiplatform.v1beta1.schema.trainingjob.definition_v1beta1.types as pkg
+from google.cloud.aiplatform.v1beta1.schema.trainingjob.definition_v1beta1 import types as pkg
 
 from google.cloud.aiplatform.v1beta1.schema.trainingjob.definition_v1beta1.types.automl_forecasting import (
     AutoMlForecasting,

--- a/google/cloud/aiplatform/v1beta1/schema/trainingjob/definition/__init__.py
+++ b/google/cloud/aiplatform/v1beta1/schema/trainingjob/definition/__init__.py
@@ -15,7 +15,9 @@
 # limitations under the License.
 #
 from google.cloud.aiplatform.helpers import _decorators
-from google.cloud.aiplatform.v1beta1.schema.trainingjob.definition_v1beta1 import types as pkg
+from google.cloud.aiplatform.v1beta1.schema.trainingjob.definition_v1beta1 import (
+    types as pkg,
+)
 
 from google.cloud.aiplatform.v1beta1.schema.trainingjob.definition_v1beta1.types.automl_forecasting import (
     AutoMlForecasting,

--- a/samples/snippets/create_training_pipeline_image_classification_sample.py
+++ b/samples/snippets/create_training_pipeline_image_classification_sample.py
@@ -14,8 +14,7 @@
 
 # [START aiplatform_create_training_pipeline_image_classification_sample]
 from google.cloud import aiplatform
-from google.cloud.aiplatform.v1beta1.schema.trainingjob import definition
-ModelType = definition.AutoMlImageClassificationInputs().ModelType
+from google.cloud.aiplatform.schema import trainingjob
 
 
 def create_training_pipeline_image_classification_sample(
@@ -32,9 +31,9 @@ def create_training_pipeline_image_classification_sample(
     # This client only needs to be created once, and can be reused for multiple requests.
     client = aiplatform.gapic.PipelineServiceClient(client_options=client_options)
 
-    icn_training_inputs = definition.AutoMlImageClassificationInputs(
+    icn_training_inputs = trainingjob.definition.AutoMlImageClassificationInputs(
         multi_label=True,
-        model_type=ModelType.CLOUD,
+        model_type=trainingjob.definition.AutoMlImageClassificationInputs.ModelType.CLOUD,
         budget_milli_node_hours=8000,
         disable_early_stopping=False
     )

--- a/samples/snippets/predict_image_classification_sample.py
+++ b/samples/snippets/predict_image_classification_sample.py
@@ -16,9 +16,7 @@
 import base64
 
 from google.cloud import aiplatform
-from google.cloud.aiplatform.v1beta1.schema.predict import instance
-from google.cloud.aiplatform.v1beta1.schema.predict import params
-from google.cloud.aiplatform.v1beta1.schema.predict import prediction
+from google.cloud.aiplatform.schema import predict
 
 
 def predict_image_classification_sample(
@@ -39,13 +37,13 @@ def predict_image_classification_sample(
     # The format of each instance should conform to the deployed model's prediction input schema.
     encoded_content = base64.b64encode(file_content).decode("utf-8")
 
-    instance_obj = instance.ImageClassificationPredictionInstance(
+    instance_obj = predict.instance.ImageClassificationPredictionInstance(
         content=encoded_content)
 
     instance_val = instance_obj.to_value()
     instances = [instance_val]
 
-    params_obj = params.ImageClassificationPredictionParams(
+    params_obj = predict.params.ImageClassificationPredictionParams(
         confidence_threshold=0.5, max_predictions=5)
 
     endpoint = client.endpoint_path(
@@ -59,7 +57,7 @@ def predict_image_classification_sample(
     # See gs://google-cloud-aiplatform/schema/predict/prediction/classification.yaml for the format of the predictions.
     predictions = response.predictions
     for prediction_ in predictions:
-        prediction_obj = prediction.ClassificationPredictionResult.from_map(prediction_)
+        prediction_obj = predict.prediction.ClassificationPredictionResult.from_map(prediction_)
         print(prediction_obj)
 
 


### PR DESCRIPTION
Allow access to the schema modules with the following imports:
```
from google.cloud.aiplatform.schema import trainingjob
from google.cloud.aiplatform.schema import predict
```

Each schema module has its own submodules such as `trainingjob.definition` and `predict.params`.