### PR TITLE
feat: Added CustomTrainingJob.get

### DIFF
--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -454,8 +454,15 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
 
         return self._gca_resource.state
 
+    def get_model(self, sync=True) -> Optional[models.Model]:
+        self._assert_has_run()
+        if not self._gca_resource.model_to_upload:
+            raise RuntimeError(self._model_upload_fail_string)
+
+        return self._force_get_model(sync=sync)
+
     @base.optional_sync()
-    def get_model(self, sync: bool = True,) -> Optional[models.Model]:
+    def _force_get_model(self, sync: bool = True) -> Optional[models.Model]:
         """AI Platform Model produced by this training, if one was produced.
 
         Args:
@@ -468,12 +475,12 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
             model: AI Platform Model produced by this training or None if a model was
                 not produced by this training.
         """
-        self._assert_has_run()
+        model = self._get_model()
 
-        if not self._gca_resource.model_to_upload:
+        if model is None:
             raise RuntimeError(self._model_upload_fail_string)
 
-        return self._get_model()
+        return model
 
     def _get_model(self) -> Optional[models.Model]:
         """Helper method to get and instantiate the Model to Upload.

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -454,6 +454,26 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
 
         return self._gca_resource.state
 
+    @classmethod
+    @abc.abstractmethod
+    def get(
+        cls,
+        resource_name: str,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+        credentials: Optional[auth_credentials.Credentials] = None,
+    ):
+        """Get training job for the given resource_name.
+
+        Raises:
+            ValueError: If the retrieved training job's training task definition 
+                doesn't match the training job class type.
+
+        Returns:
+            An AI Platform Training Job
+        """
+        pass
+
     def get_model(self) -> Optional[models.Model]:
         """AI Platform Model produced by this training, if one was produced.
 
@@ -1979,11 +1999,21 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
     @classmethod
     def get(
         cls,
-        training_job_name: str,
+        resource_name: str,
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
     ):
+        """Get CustomTrainingJob for the given resource_name.
+
+        Raises:
+            ValueError: If the retrieved training job's training task definition 
+                doesn't match the custom training task definition.
+
+        Returns:
+            An AI Platform Training Job
+        """
+
         # Create job with dummy parameters
         # These parameters won't be used as user can not run the job again.
         # If they try, an exception will be raised.
@@ -1997,7 +2027,7 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
             staging_bucket="dummy",
         )
 
-        job._gca_resource = job._get_gca_resource(resource_name=training_job_name)
+        job._gca_resource = job._get_gca_resource(resource_name=resource_name)
 
         if (
             job._gca_resource.training_task_definition
@@ -2005,8 +2035,8 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
         ):
             raise ValueError(
                 f"The retrieved job's training task definition "
-                "is {job._gca_resource.training_task_definition}, "
-                "which is not compatible with CustomTrainingJob."
+                f"is {job._gca_resource.training_task_definition}, "
+                f"which is not compatible with CustomTrainingJob."
             )
 
         return job

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -454,9 +454,16 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
 
         return self._gca_resource.state
 
-    def get_model(self) -> Optional[models.Model]:
+    @base.optional_sync()
+    def get_model(self, sync: bool = True,) -> Optional[models.Model]:
         """AI Platform Model produced by this training, if one was produced.
 
+        Args:
+            sync (bool):
+                Whether to execute this method synchronously. If False, this method
+                will be executed in concurrent Future and any downstream object will
+                be immediately returned and synced when the Future has completed.
+                
         Returns:
             model: AI Platform Model produced by this training or None if a model was
                 not produced by this training.

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -1259,6 +1259,19 @@ class _CustomTrainingJob(_TrainingJob):
     ) -> "CustomTrainingJob":
         """Get CustomTrainingJob for the given resource_name.
 
+        Args:
+            resource_name (str):
+                Required. A fully-qualified resource name or ID.
+            project (str):
+                Optional project to retrieve dataset from. If not set, project
+                set in aiplatform.init will be used.
+            location (str):
+                Optional location to retrieve dataset from. If not set, location
+                set in aiplatform.init will be used.
+            credentials (auth_credentials.Credentials):
+                Custom credentials to use to upload this model. Overrides
+                credentials set in aiplatform.init.
+
         Raises:
             ValueError: If the retrieved training job's training task definition
                 doesn't match the custom training task definition.
@@ -1270,7 +1283,9 @@ class _CustomTrainingJob(_TrainingJob):
         # Create job with dummy parameters
         # These parameters won't be used as user can not run the job again.
         # If they try, an exception will be raised.
-        self = cls._empty_constructor()
+        self = cls._empty_constructor(
+            project=project, location=location, credentials=credentials
+        )
 
         self._gca_resource = self._get_gca_resource(resource_name=resource_name)
 

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -1516,6 +1516,51 @@ class CustomTrainingJob(_CustomTrainingJob):
         self._requirements = requirements
         self._script_path = script_path
 
+    @classmethod
+    def get(
+        cls,
+        resource_name: str,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+        credentials: Optional[auth_credentials.Credentials] = None,
+    ) -> "CustomTrainingJob":
+        """Get CustomTrainingJob for the given resource_name.
+
+        Raises:
+            ValueError: If the retrieved training job's training task definition
+                doesn't match the custom training task definition.
+
+        Returns:
+            An AI Platform Training Job
+        """
+
+        # Create job with dummy parameters
+        # These parameters won't be used as user can not run the job again.
+        # If they try, an exception will be raised.
+        self = CustomTrainingJob(
+            display_name="dummy",
+            script_path="dummy",
+            container_uri="dummy",
+            project=project,
+            location=location,
+            credentials=credentials,
+            staging_bucket="dummy",
+        )
+
+        self._gca_resource = self._get_gca_resource(resource_name=resource_name)
+
+        if (
+            self._gca_resource.training_task_definition
+            != schema.training_job.definition.custom_task
+        ):
+            raise ValueError(
+                f"The retrieved job's training task definition "
+                f"is {self._gca_resource.training_task_definition}, "
+                f"which is not compatible with CustomTrainingJob."
+            )
+
+        return self
+
     # TODO(b/172365904) add filter split, training_pipeline.FilterSplit
     # TODO(b/172368070) add timestamp split, training_pipeline.TimestampSplit
     def run(
@@ -1975,51 +2020,6 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
         )
 
         self._command = command
-
-    @classmethod
-    def get(
-        cls,
-        resource_name: str,
-        project: Optional[str] = None,
-        location: Optional[str] = None,
-        credentials: Optional[auth_credentials.Credentials] = None,
-    ) -> "CustomTrainingJob":
-        """Get CustomTrainingJob for the given resource_name.
-
-        Raises:
-            ValueError: If the retrieved training job's training task definition 
-                doesn't match the custom training task definition.
-
-        Returns:
-            An AI Platform Training Job
-        """
-
-        # Create job with dummy parameters
-        # These parameters won't be used as user can not run the job again.
-        # If they try, an exception will be raised.
-        job = CustomTrainingJob(
-            display_name="dummy",
-            script_path="dummy",
-            container_uri="dummy",
-            project=project,
-            location=location,
-            credentials=credentials,
-            staging_bucket="dummy",
-        )
-
-        job._gca_resource = job._get_gca_resource(resource_name=resource_name)
-
-        if (
-            job._gca_resource.training_task_definition
-            != schema.training_job.definition.custom_task
-        ):
-            raise ValueError(
-                f"The retrieved job's training task definition "
-                f"is {job._gca_resource.training_task_definition}, "
-                f"which is not compatible with CustomTrainingJob."
-            )
-
-        return job
 
     # TODO(b/172365904) add filter split, training_pipeline.FilterSplit
     # TODO(b/172368070) add timestamp split, training_pipeline.TimestampSplit

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -1984,14 +1984,17 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
     ):
+        # Create job with dummy parameters
+        # These parameters won't be used as user can not run the job again.
+        # If they try, an exception will be raised.
         job = CustomTrainingJob(
-            display_name="",
-            script_path="",
-            container_uri="",
+            display_name="dummy",
+            script_path="dummy",
+            container_uri="dummy",
             project=project,
             location=location,
             credentials=credentials,
-            staging_bucket="",
+            staging_bucket="dummy",
         )
 
         job._gca_resource = job._get_gca_resource(resource_name=training_job_name)

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -454,26 +454,6 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
 
         return self._gca_resource.state
 
-    @classmethod
-    @abc.abstractmethod
-    def get(
-        cls,
-        resource_name: str,
-        project: Optional[str] = None,
-        location: Optional[str] = None,
-        credentials: Optional[auth_credentials.Credentials] = None,
-    ):
-        """Get training job for the given resource_name.
-
-        Raises:
-            ValueError: If the retrieved training job's training task definition 
-                doesn't match the training job class type.
-
-        Returns:
-            An AI Platform Training Job
-        """
-        pass
-
     def get_model(self) -> Optional[models.Model]:
         """AI Platform Model produced by this training, if one was produced.
 
@@ -2003,7 +1983,7 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
-    ):
+    ) -> "CustomTrainingJob":
         """Get CustomTrainingJob for the given resource_name.
 
         Raises:

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -1976,6 +1976,28 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
 
         self._command = command
 
+    @classmethod
+    def get(
+        cls,
+        training_job_name: str,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+        credentials: Optional[auth_credentials.Credentials] = None,
+    ):
+        job = CustomTrainingJob(
+            display_name="",
+            script_path="",
+            container_uri="",
+            project=project,
+            location=location,
+            credentials=credentials,
+            staging_bucket="",
+        )
+
+        job._gca_resource = job._get_gca_resource(resource_name=training_job_name)
+
+        return job
+
     # TODO(b/172365904) add filter split, training_pipeline.FilterSplit
     # TODO(b/172368070) add timestamp split, training_pipeline.TimestampSplit
     def run(

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -1218,6 +1218,43 @@ class _CustomTrainingJob(_TrainingJob):
                 "set using aiplatform.init(staging_bucket='gs://my-bucket')"
             )
 
+    @classmethod
+    def get(
+        cls,
+        resource_name: str,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+        credentials: Optional[auth_credentials.Credentials] = None,
+    ) -> "CustomTrainingJob":
+        """Get CustomTrainingJob for the given resource_name.
+
+        Raises:
+            ValueError: If the retrieved training job's training task definition
+                doesn't match the custom training task definition.
+
+        Returns:
+            An AI Platform Training Job
+        """
+
+        # Create job with dummy parameters
+        # These parameters won't be used as user can not run the job again.
+        # If they try, an exception will be raised.
+        self = cls._empty_constructor()
+
+        self._gca_resource = self._get_gca_resource(resource_name=resource_name)
+
+        if (
+            self._gca_resource.training_task_definition
+            != schema.training_job.definition.custom_task
+        ):
+            raise ValueError(
+                f"The retrieved job's training task definition "
+                f"is {self._gca_resource.training_task_definition}, "
+                f"which is not compatible with CustomTrainingJob."
+            )
+
+        return self
+
     def _prepare_and_validate_run(
         self,
         model_display_name: Optional[str] = None,
@@ -1515,51 +1552,6 @@ class CustomTrainingJob(_CustomTrainingJob):
 
         self._requirements = requirements
         self._script_path = script_path
-
-    @classmethod
-    def get(
-        cls,
-        resource_name: str,
-        project: Optional[str] = None,
-        location: Optional[str] = None,
-        credentials: Optional[auth_credentials.Credentials] = None,
-    ) -> "CustomTrainingJob":
-        """Get CustomTrainingJob for the given resource_name.
-
-        Raises:
-            ValueError: If the retrieved training job's training task definition
-                doesn't match the custom training task definition.
-
-        Returns:
-            An AI Platform Training Job
-        """
-
-        # Create job with dummy parameters
-        # These parameters won't be used as user can not run the job again.
-        # If they try, an exception will be raised.
-        self = CustomTrainingJob(
-            display_name="dummy",
-            script_path="dummy",
-            container_uri="dummy",
-            project=project,
-            location=location,
-            credentials=credentials,
-            staging_bucket="dummy",
-        )
-
-        self._gca_resource = self._get_gca_resource(resource_name=resource_name)
-
-        if (
-            self._gca_resource.training_task_definition
-            != schema.training_job.definition.custom_task
-        ):
-            raise ValueError(
-                f"The retrieved job's training task definition "
-                f"is {self._gca_resource.training_task_definition}, "
-                f"which is not compatible with CustomTrainingJob."
-            )
-
-        return self
 
     # TODO(b/172365904) add filter split, training_pipeline.FilterSplit
     # TODO(b/172368070) add timestamp split, training_pipeline.TimestampSplit

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -1999,6 +1999,16 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
 
         job._gca_resource = job._get_gca_resource(resource_name=training_job_name)
 
+        if (
+            job._gca_resource.training_task_definition
+            != schema.training_job.definition.custom_task
+        ):
+            raise ValueError(
+                f"The retrieved job's training task definition "
+                "is {job._gca_resource.training_task_definition}, "
+                "which is not compatible with CustomTrainingJob."
+            )
+
         return job
 
     # TODO(b/172365904) add filter split, training_pipeline.FilterSplit

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -454,15 +454,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
 
         return self._gca_resource.state
 
-    def get_model(self, sync=True) -> Optional[models.Model]:
-        self._assert_has_run()
-        if not self._gca_resource.model_to_upload:
-            raise RuntimeError(self._model_upload_fail_string)
-
-        return self._force_get_model(sync=sync)
-
-    @base.optional_sync()
-    def _force_get_model(self, sync: bool = True) -> Optional[models.Model]:
+    def get_model(self, sync=True) -> models.Model:
         """AI Platform Model produced by this training, if one was produced.
 
         Args:
@@ -470,10 +462,35 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will
                 be immediately returned and synced when the Future has completed.
-                
+
         Returns:
-            model: AI Platform Model produced by this training or None if a model was
-                not produced by this training.
+            model: AI Platform Model produced by this training
+
+        Raises:
+            RuntimeError if training failed or if a model was not produced by this training.
+        """
+
+        self._assert_has_run()
+        if not self._gca_resource.model_to_upload:
+            raise RuntimeError(self._model_upload_fail_string)
+
+        return self._force_get_model(sync=sync)
+
+    @base.optional_sync()
+    def _force_get_model(self, sync: bool = True) -> models.Model:
+        """AI Platform Model produced by this training, if one was produced.
+
+        Args:
+            sync (bool):
+                Whether to execute this method synchronously. If False, this method
+                will be executed in concurrent Future and any downstream object will
+                be immediately returned and synced when the Future has completed.
+
+        Returns:
+            model: AI Platform Model produced by this training
+
+        Raises:
+            RuntimeError if training failed or if a model was not produced by this training.
         """
         model = self._get_model()
 

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -171,7 +171,7 @@ def get_training_job_tabular_mock():
             name=_TEST_PIPELINE_RESOURCE_NAME,
             state=gca_pipeline_state.PipelineState.PIPELINE_STATE_SUCCEEDED,
             model_to_upload=gca_model.Model(name=_TEST_MODEL_NAME),
-            training_task_definition=schema.training_job.definition.tabular_task,
+            training_task_definition=schema.training_job.definition.automl_tabular,
         )
 
         yield get_training_job_tabular_mock

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -103,7 +103,6 @@ _TEST_ID = "12345"
 _TEST_NAME = (
     f"projects/{_TEST_PROJECT}/locations/{_TEST_LOCATION}/trainingPipelines/{_TEST_ID}"
 )
-_TEST_INVALID_NAME = f"prj/{_TEST_PROJECT}/locations/{_TEST_LOCATION}/{_TEST_ID}"
 
 _TEST_MODEL_INSTANCE_SCHEMA_URI = "instance_schema_uri.yaml"
 _TEST_MODEL_PARAMETERS_SCHEMA_URI = "parameters_schema_uri.yaml"


### PR DESCRIPTION
This allows users to retrieve an existing CustomTrainingJob using the resource name.
The `get` function will always block as it is a short function.
The `get_model` is now async, so downstream functions can use the future that was created at this stage.

Fixes https://b.corp.google.com/issues/174771897

### TODO
- [x] Add validation that the job is an instance of CustomTrainingJob
- [x] Add get function to abstract class
- [x] Add unit test for incorrect training task definition
- [x] Add doc strings 
- [x] Fix missing future 
- [x] Test TrainingJob.get_model for a variety of use cases

### Test cases

I've tested this against the below potential use cases.

#### Retrieving the state for retrieved job

```
job = aiplatform.CustomTrainingJob(...)
model = job.run(ds, replica_count=1, model_display_name="abalone-model")
 
Session stops...
 
job = aiplatform.CustomTrainingJob.get(
   resource_name="resource_name"
)
 
job.state # Should be pending/success/failure
```
 
#### Running a job on a retrieved job should raise an error

```
job = aiplatform.CustomTrainingJob(...)
model = job.run(ds, replica_count=1, model_display_name="abalone-model")
 
Session stops...
 
job = aiplatform.CustomTrainingJob.get(
   resource_name="resource_name"
)
 
job.state # Should be pending/success/failure
```

# Async case 1
```
new_job = CustomTrainingJob.get(CURRENTLY_RUNNING_JOB)
new_job.get_model(sync=True) # This should block until training finishes
```

# Async case 2
```
new_job = CustomTrainingJob.get(CURRENTLY_RUNNING_JOB)
new_job.get_model(sync=False)
new_job.wait() # This should block until training finishes
```

# Async case 3 (downstream usage)
```
new_job = CustomTrainingJob.get(CURRENTLY_RUNNING_JOB)
model = new_job.get_model(sync=False)
endpoint = model.deploy(sync=False)
endpoint.wait() # This should block until training finishes
```