### PR TITLE
Fixed incorrect key for AutoMLTrainingJob

### DIFF
--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -2652,7 +2652,7 @@ class AutoMLImageTrainingJob(_TrainingJob):
             # required inputs
             "modelType": self._model_type,
             "budgetMilliNodeHours": budget_milli_node_hours,
-            "modelLabel": self._multi_label,
+            "multiLabel": self._multi_label,
             # optional inputs
             "disableEarlyStopping": disable_early_stopping,
         }

--- a/tests/unit/aiplatform/test_automl_image_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_image_training_jobs.py
@@ -50,7 +50,7 @@ _TEST_TRAINING_TASK_INPUTS = json_format.ParseDict(
     {
         "modelType": "CLOUD",
         "budgetMilliNodeHours": _TEST_TRAINING_BUDGET_MILLI_NODE_HOURS,
-        "modelLabel": False,
+        "multiLabel": False,
         "disableEarlyStopping": _TEST_TRAINING_DISABLE_EARLY_STOPPING,
     },
     struct_pb2.Value(),
@@ -60,7 +60,7 @@ _TEST_TRAINING_TASK_INPUTS_WITH_BASE_MODEL = json_format.ParseDict(
     {
         "modelType": "CLOUD",
         "budgetMilliNodeHours": _TEST_TRAINING_BUDGET_MILLI_NODE_HOURS,
-        "modelLabel": False,
+        "multiLabel": False,
         "disableEarlyStopping": _TEST_TRAINING_DISABLE_EARLY_STOPPING,
         "baseModelId": _TEST_MODEL_ID,
     },


### PR DESCRIPTION
The training task key "multiLabel" was incorrectly named "modelLabel" which results in failed training job run.

```
_InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.INVALID_ARGUMENT
	details = "TrainingJob.inputs does not match job definition: com.google.protobuf.InvalidProtocolBufferException: Cannot find field: modelLabel in message google.cloud.aiplatform.master.schema.trainingjob.definition.AutoMlImageClassificationInputs."
	debug_error_string = "{"created":"@1610450635.815653353","description":"Error received from peer ipv4:74.125.195.95:443","file":"src/core/lib/surface/call.cc","file_line":1061,"grpc_message":"TrainingJob.inputs does not match job definition: com.google.protobuf.InvalidProtocolBufferException: Cannot find field: modelLabel in message google.cloud.aiplatform.master.schema.trainingjob.definition.AutoMlImageClassificationInputs.","grpc_status":3}"
>
```