### PR TITLE
fix(deps): remove optional dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,7 @@ setuptools.setup(
     include_package_data=True,
     install_requires=(
         "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
-        "libcst >= 0.2.5",
         "proto-plus >= 1.10.1",
-        "mock >= 4.0.2",
         "google-cloud-storage >= 1.26.0, < 2.0.0dev",
     ),
     python_requires=">=3.6",


### PR DESCRIPTION
`mock` is only needed to run the tests https://github.com/googleapis/python-aiplatform/blob/8c0932f3f4d0e1ac40e55b1f0b2ce67c1873dee6/noxfile.py#L75-L77 and `libcst` is not needed by this library.

Fixes #183 