### PR TITLE
feat: Add accelerator options to Model/Endpoint deploy()

### DIFF
--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -330,6 +330,7 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
     def _validate_deploy_args(
         min_replica_count: int,
         max_replica_count: int,
+        accelerator_type: Optional[str],
         deployed_model_display_name: Optional[str],
         traffic_split: Optional[Dict[str, int]],
         traffic_percentage: int,
@@ -353,6 +354,10 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
                 is not provided, the larger value of min_replica_count or 1 will
                 be used. If value provided is smaller than min_replica_count, it
                 will automatically be increased to be min_replica_count.
+            accelerator_type (str):
+                Required. Hardware accelerator type. One of ACCELERATOR_TYPE_UNSPECIFIED,
+                NVIDIA_TESLA_K80, NVIDIA_TESLA_P100, NVIDIA_TESLA_V100, NVIDIA_TESLA_P4,
+                NVIDIA_TESLA_T4, TPU_V2, TPU_V3
             deployed_model_display_name (str):
                 Required. The display name of the DeployedModel. If not provided
                 upon creation, the Model's display_name is used.
@@ -397,6 +402,10 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
                     "Sum of all traffic within traffic split needs to be 100."
                 )
 
+        # Raises ValueError if invalid accelerator
+        if accelerator_type:
+            utils.validate_accelerator_type(accelerator_type)
+
     def deploy(
         self,
         model: "Model",
@@ -406,6 +415,8 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
         machine_type: Optional[str] = None,
         min_replica_count: int = 1,
         max_replica_count: int = 1,
+        accelerator_type: Optional[str] = None,
+        accelerator_count: Optional[int] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = (),
         sync=True,
     ) -> None:
@@ -452,6 +463,12 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
                 is not provided, the larger value of min_replica_count or 1 will
                 be used. If value provided is smaller than min_replica_count, it
                 will automatically be increased to be min_replica_count.
+            accelerator_type (str):
+                Optional. Hardware accelerator type. Must also set accelerator_count if used.
+                One of ACCELERATOR_TYPE_UNSPECIFIED, NVIDIA_TESLA_K80, NVIDIA_TESLA_P100,
+                NVIDIA_TESLA_V100, NVIDIA_TESLA_P4, NVIDIA_TESLA_T4, TPU_V2, TPU_V3
+            accelerator_count (int):
+                Optional. The number of accelerators to attach to a worker replica.
             metadata (Sequence[Tuple[str, str]]):
                 Optional. Strings which should be sent along with the request as
                 metadata.
@@ -464,6 +481,7 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
         self._validate_deploy_args(
             min_replica_count,
             max_replica_count,
+            accelerator_type,
             deployed_model_display_name,
             traffic_split,
             traffic_percentage,
@@ -477,6 +495,8 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
             machine_type=machine_type,
             min_replica_count=min_replica_count,
             max_replica_count=max_replica_count,
+            accelerator_type=accelerator_type,
+            accelerator_count=accelerator_count,
             metadata=metadata,
             sync=sync,
         )
@@ -491,6 +511,8 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
         machine_type: Optional[str] = None,
         min_replica_count: Optional[int] = 1,
         max_replica_count: Optional[int] = 1,
+        accelerator_type: Optional[str] = None,
+        accelerator_count: Optional[int] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = (),
         sync=True,
     ) -> None:
@@ -537,6 +559,12 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
                 is not provided, the larger value of min_replica_count or 1 will
                 be used. If value provided is smaller than min_replica_count, it
                 will automatically be increased to be min_replica_count.
+            accelerator_type (str):
+                Optional. Hardware accelerator type. Must also set accelerator_count if used.
+                One of ACCELERATOR_TYPE_UNSPECIFIED, NVIDIA_TESLA_K80, NVIDIA_TESLA_P100,
+                NVIDIA_TESLA_V100, NVIDIA_TESLA_P4, NVIDIA_TESLA_T4, TPU_V2, TPU_V3
+            accelerator_count (int):
+                Optional. The number of accelerators to attach to a worker replica.
             metadata (Sequence[Tuple[str, str]]):
                 Optional. Strings which should be sent along with the request as
                 metadata.
@@ -560,6 +588,8 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
             machine_type=machine_type,
             min_replica_count=min_replica_count,
             max_replica_count=max_replica_count,
+            accelerator_type=accelerator_type,
+            accelerator_count=accelerator_count,
             metadata=metadata,
         )
 
@@ -578,6 +608,8 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
         machine_type: Optional[str] = None,
         min_replica_count: Optional[int] = 1,
         max_replica_count: Optional[int] = 1,
+        accelerator_type: Optional[str] = None,
+        accelerator_count: Optional[int] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = (),
     ):
         """
@@ -638,13 +670,24 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
                 be immediately returned and synced when the Future has completed.
         Raises:
             ValueError if there is not current traffic split and traffic percentage
-            is not 0 or 100.
+                is not 0 or 100.
         """
 
         max_replica_count = max(min_replica_count, max_replica_count)
 
+        if bool(accelerator_type) != bool(accelerator_count):
+            raise ValueError(
+                "Both `accelerator_type` and `accelerator_count` should be specified or None."
+            )
+
         if machine_type:
             machine_spec = machine_resources.MachineSpec(machine_type=machine_type)
+
+            if accelerator_type and accelerator_count:
+                utils.validate_accelerator_type(accelerator_type)
+                machine_spec.accelerator_type = accelerator_type
+                machine_spec.accelerator_count = accelerator_count
+
             dedicated_resources = machine_resources.DedicatedResources(
                 machine_spec=machine_spec,
                 min_replica_count=min_replica_count,
@@ -1162,6 +1205,8 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
         machine_type: Optional[str] = None,
         min_replica_count: Optional[int] = 1,
         max_replica_count: Optional[int] = 1,
+        accelerator_type: Optional[str] = None,
+        accelerator_count: Optional[int] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = (),
         sync=True,
     ) -> Endpoint:
@@ -1208,6 +1253,12 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
                 handle, a portion of the traffic will be dropped. If this value
                 is not provided, the smaller value of min_replica_count or 1 will
                 be used.
+            accelerator_type (str):
+                Optional. Hardware accelerator type. Must also set accelerator_count if used.
+                One of ACCELERATOR_TYPE_UNSPECIFIED, NVIDIA_TESLA_K80, NVIDIA_TESLA_P100,
+                NVIDIA_TESLA_V100, NVIDIA_TESLA_P4, NVIDIA_TESLA_T4, TPU_V2, TPU_V3
+            accelerator_count (int):
+                Optional. The number of accelerators to attach to a worker replica.
             metadata (Sequence[Tuple[str, str]]):
                 Optional. Strings which should be sent along with the request as
                 metadata.
@@ -1224,6 +1275,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
         Endpoint._validate_deploy_args(
             min_replica_count,
             max_replica_count,
+            accelerator_type,
             deployed_model_display_name,
             traffic_split,
             traffic_percentage,
@@ -1237,6 +1289,8 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
             machine_type=machine_type,
             min_replica_count=min_replica_count,
             max_replica_count=max_replica_count,
+            accelerator_type=accelerator_type,
+            accelerator_count=accelerator_count,
             metadata=metadata,
             sync=sync,
         )
@@ -1251,6 +1305,8 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
         machine_type: Optional[str] = None,
         min_replica_count: Optional[int] = 1,
         max_replica_count: Optional[int] = 1,
+        accelerator_type: Optional[str] = None,
+        accelerator_count: Optional[int] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = (),
         sync: bool = True,
     ) -> Endpoint:
@@ -1297,6 +1353,12 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
                 handle, a portion of the traffic will be dropped. If this value
                 is not provided, the smaller value of min_replica_count or 1 will
                 be used.
+            accelerator_type (str):
+                Optional. Hardware accelerator type. Must also set accelerator_count if used.
+                One of ACCELERATOR_TYPE_UNSPECIFIED, NVIDIA_TESLA_K80, NVIDIA_TESLA_P100,
+                NVIDIA_TESLA_V100, NVIDIA_TESLA_P4, NVIDIA_TESLA_T4, TPU_V2, TPU_V3
+            accelerator_count (int):
+                Optional. The number of accelerators to attach to a worker replica.
             metadata (Sequence[Tuple[str, str]]):
                 Optional. Strings which should be sent along with the request as
                 metadata.

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -803,15 +803,8 @@ class _MachineSpec(NamedTuple):
             ValueError if accelerator type is invalid.
         """
 
-        # validate accelerator type
-        if (
-            self.accelerator_type
-            not in gca_accelerator_type.AcceleratorType._member_names_
-        ):
-            raise ValueError(
-                f"accelerator_type `{self.accelerator_type}` invalid. "
-                f"Choose one of {gca_accelerator_type.AcceleratorType._member_names_}"
-            )
+        # Raises ValueError if invalid accelerator_type
+        utils.validate_accelerator_type(self.accelerator_type)
 
         accelerator_enum = getattr(
             gca_accelerator_type.AcceleratorType, self.accelerator_type

--- a/google/cloud/aiplatform/utils.py
+++ b/google/cloud/aiplatform/utils.py
@@ -27,6 +27,9 @@ from google.api_core import gapic_v1
 from google.auth import credentials as auth_credentials
 from google.cloud.aiplatform import constants
 from google.cloud.aiplatform import initializer
+from google.cloud.aiplatform_v1beta1.types import (
+    accelerator_type as gca_accelerator_type,
+)
 from google.cloud.aiplatform_v1beta1.services.dataset_service import (
     client as dataset_client,
 )
@@ -237,6 +240,25 @@ def validate_region(region: str) -> bool:
             f"Unsupported region for AI Platform, select from {constants.SUPPORTED_REGIONS}"
         )
 
+    return True
+
+
+def validate_accelerator_type(accelerator_type: str):
+    """Validates user provided accelerator_type string for training and prediction
+
+    Args:
+        accelerator_type (str):
+            Represents a hardware accelerator type.
+    Returns:
+        bool: True if valid accelerator_type
+    Raises:
+        ValueError if accelerator type is invalid.
+    """
+    if accelerator_type not in gca_accelerator_type.AcceleratorType._member_names_:
+        raise ValueError(
+            f"Given accelerator_type `{accelerator_type}` invalid. "
+            f"Choose one of {gca_accelerator_type.AcceleratorType._member_names_}"
+        )
     return True
 
 


### PR DESCRIPTION
Addition of `accelerator_type` and `accelerator_count` to `Endpoint.deploy()` and `Model.deploy()` methods. Also added a util method to validate the `accelerator_type` against the GAPIC Enum.

Manually tested that deploying with GPUs work. Does not affect existing tests.

Fixes [b/179069467](http://b/179069467) 🦕
