### PR TITLE
feat: Add SDK-wide delete method, cancel methods to Job and TrainingJob

### DIFF
--- a/google/cloud/aiplatform/base.py
+++ b/google/cloud/aiplatform/base.py
@@ -242,6 +242,12 @@ class AiPlatformResourceNoun(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
+    def _delete_method(cls) -> str:
+        """Name of delete method of client class for deleting the resource."""
+        pass
+
+    @property
+    @abc.abstractmethod
     def _resource_noun(cls) -> str:
         """Resource noun"""
         pass
@@ -327,96 +333,6 @@ class AiPlatformResourceNoun(metaclass=abc.ABCMeta):
     def display_name(self) -> str:
         """Display name of this resource."""
         return self._gca_resource.display_name
-
-
-class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureManager):
-    """Allows optional asynchronous calls to this AI Platform Resource Nouns."""
-
-    def __init__(
-        self,
-        project: Optional[str] = None,
-        location: Optional[str] = None,
-        credentials: Optional[auth_credentials.Credentials] = None,
-    ):
-        """Initializes class with project, location, and api_client.
-
-        Args:
-            project (str): Optional. Project of the resource noun.
-            location (str): Optional. The location of the resource noun.
-            credentials(google.auth.crendentials.Crendentials):
-                Optional. custom credentials to use when accessing interacting with
-                resource noun.
-        """
-        AiPlatformResourceNoun.__init__(
-            self, project=project, location=location, credentials=credentials
-        )
-        FutureManager.__init__(self)
-
-    @classmethod
-    def _empty_constructor(
-        cls,
-        project: Optional[str] = None,
-        location: Optional[str] = None,
-        credentials: Optional[auth_credentials.Credentials] = None,
-    ) -> "AiPlatformResourceNounWithFutureManager":
-        """Initializes with all attributes set to None.
-
-        The attributes should be populated after a future is complete. This allows
-        scheduling of additional API calls before the resource is created.
-
-        Args:
-            project (str): Optional. Project of the resource noun.
-            location (str): Optional. The location of the resource noun.
-            credentials(google.auth.crendentials.Crendentials):
-                Optional. custom credentials to use when accessing interacting with
-                resource noun.
-        Returns:
-            An instance of this class with attributes set to None.
-        """
-        self = cls.__new__(cls)
-        AiPlatformResourceNoun.__init__(self, project, location, credentials)
-        FutureManager.__init__(self)
-        self._gca_resource = None
-        return self
-
-    def _sync_object_with_future_result(
-        self, result: "AiPlatformResourceNounWithFutureManager"
-    ):
-        """Populates attributes from a Future result to this object.
-
-        Args:
-            result: AiPlatformResourceNounWithFutureManager
-                Required. Result of future with same type as this object.
-        """
-        sync_attributes = [
-            "project",
-            "location",
-            "api_client",
-            "_gca_resource",
-            "credentials",
-        ]
-        optional_sync_attributes = ["_prediction_client"]
-
-        for attribute in sync_attributes:
-            setattr(self, attribute, getattr(result, attribute))
-
-        for attribute in optional_sync_attributes:
-            value = getattr(result, attribute, None)
-            if value:
-                setattr(self, attribute, value)
-
-
-def get_annotation_class(annotation: type) -> type:
-    """Helper method to retrieve type annotation.
-
-    Args:
-        annotation (type): Type hint
-    """
-    # typing.Optional
-    if getattr(annotation, "__origin__", None) is Union:
-        return annotation.__args__[0]
-    else:
-        return annotation
 
 
 def optional_sync(
@@ -555,3 +471,106 @@ def optional_sync(
         return wrapper
 
     return optional_run_in_thread
+
+
+class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureManager):
+    """Allows optional asynchronous calls to this AI Platform Resource Nouns."""
+
+    def __init__(
+        self,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+        credentials: Optional[auth_credentials.Credentials] = None,
+    ):
+        """Initializes class with project, location, and api_client.
+
+        Args:
+            project (str): Optional. Project of the resource noun.
+            location (str): Optional. The location of the resource noun.
+            credentials(google.auth.crendentials.Crendentials):
+                Optional. custom credentials to use when accessing interacting with
+                resource noun.
+        """
+        AiPlatformResourceNoun.__init__(
+            self, project=project, location=location, credentials=credentials
+        )
+        FutureManager.__init__(self)
+
+    @classmethod
+    def _empty_constructor(
+        cls,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+        credentials: Optional[auth_credentials.Credentials] = None,
+    ) -> "AiPlatformResourceNounWithFutureManager":
+        """Initializes with all attributes set to None.
+
+        The attributes should be populated after a future is complete. This allows
+        scheduling of additional API calls before the resource is created.
+
+        Args:
+            project (str): Optional. Project of the resource noun.
+            location (str): Optional. The location of the resource noun.
+            credentials(google.auth.crendentials.Crendentials):
+                Optional. custom credentials to use when accessing interacting with
+                resource noun.
+        Returns:
+            An instance of this class with attributes set to None.
+        """
+        self = cls.__new__(cls)
+        AiPlatformResourceNoun.__init__(self, project, location, credentials)
+        FutureManager.__init__(self)
+        self._gca_resource = None
+        return self
+
+    def _sync_object_with_future_result(
+        self, result: "AiPlatformResourceNounWithFutureManager"
+    ):
+        """Populates attributes from a Future result to this object.
+
+        Args:
+            result: AiPlatformResourceNounWithFutureManager
+                Required. Result of future with same type as this object.
+        """
+        sync_attributes = [
+            "project",
+            "location",
+            "api_client",
+            "_gca_resource",
+            "credentials",
+        ]
+        optional_sync_attributes = ["_prediction_client"]
+
+        for attribute in sync_attributes:
+            setattr(self, attribute, getattr(result, attribute))
+
+        for attribute in optional_sync_attributes:
+            value = getattr(result, attribute, None)
+            if value:
+                setattr(self, attribute, value)
+
+    @optional_sync()
+    def delete(self, sync: bool = True) -> None:
+        """Deletes this AI Platform resource. WARNING: This deletion is permament.
+
+        Args:
+            sync (bool):
+                Whether to execute this deletion synchronously. If False, this method
+                will be executed in concurrent Future and any downstream object will
+                be immediately returned and synced when the Future has completed.
+        """
+        lro = getattr(self.api_client, self._delete_method)(name=self.resource_name)
+        lro.result()
+
+
+def get_annotation_class(annotation: type) -> type:
+    """Helper method to retrieve type annotation.
+
+    Args:
+        annotation (type): Type hint
+    """
+    # typing.Optional
+    if getattr(annotation, "__origin__", None) is Union:
+        return annotation.__args__[0]
+    else:
+        return annotation

--- a/google/cloud/aiplatform/datasets/dataset.py
+++ b/google/cloud/aiplatform/datasets/dataset.py
@@ -39,6 +39,7 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
     _is_client_prediction_client = False
     _resource_noun = "datasets"
     _getter_method = "get_dataset"
+    _delete_method = "delete_dataset"
 
     _supported_metadata_schema_uris: Optional[Tuple[str]] = None
 
@@ -456,16 +457,3 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
 
     def update(self):
         raise NotImplementedError("Update dataset has not been implemented yet")
-
-    @base.optional_sync()
-    def delete(self, sync: bool = True) -> None:
-        """Deletes this AI Platform managed Dataset resource.
-
-        Args:
-            sync (bool):
-                Whether to execute this method synchronously. If False, this method
-                will be executed in concurrent Future and any downstream object will
-                be immediately returned and synced when the Future has completed.
-        """
-        lro = self.api_client.delete_dataset(name=self.resource_name)
-        lro.result()

--- a/google/cloud/aiplatform/jobs.py
+++ b/google/cloud/aiplatform/jobs.py
@@ -70,6 +70,8 @@ class _Job(base.AiPlatformResourceNounWithFutureManager):
 
     _getter_method (str): The name of JobServiceClient getter method for specific
     Job type, i.e. 'get_custom_job' for CustomJob
+    _cancel_method (str): The name of the specific JobServiceClient cancel method
+    _delete_method (str): The name of the specific JobServiceClient delete method
     """
 
     client_class = job_service_client.JobServiceClient
@@ -123,6 +125,12 @@ class _Job(base.AiPlatformResourceNounWithFutureManager):
         """Job type."""
         pass
 
+    @property
+    @abc.abstractmethod
+    def _cancel_method(cls) -> str:
+        """Name of cancellation method for cancelling the specific job type."""
+        pass
+
     def _dashboard_uri(self) -> Optional[str]:
         """Helper method to compose the dashboard uri where job can be viewed."""
         fields = utils.extract_fields_from_resource_name(self.resource_name)
@@ -155,11 +163,18 @@ class _Job(base.AiPlatformResourceNounWithFutureManager):
         if self.state in _JOB_ERROR_STATES:
             raise RuntimeError("Job failed with:\n%s" % self._gca_resource.error)
 
+    def cancel(self) -> None:
+        """Cancels this Job. Success of cancellation is not guaranteed. Use `Job.state`
+        property to verify if cancellation was successful."""
+        getattr(self.api_client, self._cancel_method)(name=self.resource_name)
+
 
 class BatchPredictionJob(_Job):
 
     _resource_noun = "batchPredictionJobs"
     _getter_method = "get_batch_prediction_job"
+    _cancel_method = "cancel_batch_prediction_job"
+    _delete_method = "delete_batch_prediction_job"
     _job_type = "batch-predictions"
 
     def __init__(
@@ -600,6 +615,8 @@ class BatchPredictionJob(_Job):
 class CustomJob(_Job):
     _resource_noun = "customJobs"
     _getter_method = "get_custom_job"
+    _cancel_method = "cancel_custom_job"
+    _delete_method = "delete_custom_job"
     _job_type = "training"
     pass
 
@@ -607,6 +624,8 @@ class CustomJob(_Job):
 class DataLabelingJob(_Job):
     _resource_noun = "dataLabelingJobs"
     _getter_method = "get_data_labeling_job"
+    _cancel_method = "cancel_data_labeling_job"
+    _delete_method = "delete_data_labeling_job"
     _job_type = "labeling-tasks"
     pass
 
@@ -614,4 +633,6 @@ class DataLabelingJob(_Job):
 class HyperparameterTuningJob(_Job):
     _resource_noun = "hyperparameterTuningJobs"
     _getter_method = "get_hyperparameter_tuning_job"
+    _cancel_method = "cancel_hyperparameter_tuning_job"
+    _delete_method = "delete_hyperparameter_tuning_job"
     pass

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -920,19 +920,6 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
 
         return self
 
-    @base.optional_sync()
-    def _delete(self, sync: bool = True) -> None:
-        """Private helper method to delete this endpoint via GAPIC.
-
-        Args:
-            sync (bool):
-                Whether to execute this method synchronously. If False, this method
-                will be executed in concurrent Future and any downstream object will
-                be immediately returned and synced when the Future has completed.
-        """
-        lro = self.api_client.delete_endpoint(name=self.resource_name)
-        lro.result()
-
     def delete(self, force: bool = False, sync: bool = True) -> None:
         """Deletes this AI Platform Endpoint resource. If force is set to True,
         all models on this Endpoint will be undeployed prior to deletion.

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -63,6 +63,7 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
     _is_client_prediction_client = False
     _resource_noun = "endpoints"
     _getter_method = "get_endpoint"
+    _delete_method = "delete_endpoint"
 
     def __init__(
         self,
@@ -950,7 +951,7 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
         if force:
             self.undeploy_all(sync=sync)
 
-        self._delete(sync=sync)
+        super().delete(sync=sync)
 
 
 class Model(base.AiPlatformResourceNounWithFutureManager):
@@ -959,6 +960,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
     _is_client_prediction_client = False
     _resource_noun = "models"
     _getter_method = "get_model"
+    _delete_method = "delete_model"
 
     @property
     def uri(self):
@@ -1553,19 +1555,3 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
             credentials=credentials or self.credentials,
             sync=sync,
         )
-
-    @base.optional_sync()
-    def delete(self, sync: bool = True) -> None:
-        """Deletes this AI Platform managed Model resource.
-
-        WARNING: Calling this method will permanently delete your trained Model
-        on AI Platform, this action is irreversable.
-
-        Args:
-            sync (bool):
-                Whether to execute this method synchronously. If False, this method
-                will be executed in concurrent Future and any downstream object will
-                be immediately returned and synced when the Future has completed.
-        """
-        lro = self.api_client.delete_model(name=self.resource_name)
-        lro.result()

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -577,7 +577,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
                 "This TrainingJob has not been launched, use the `run()` method "
                 "to start. `cancel()` can only be called on a job that is running."
             )
-        self.api_client.cancel_training_pipeline(name=self._gca_resource.resource_name)
+        self.api_client.cancel_training_pipeline(name=self.resource_name)
 
 
 def _timestamped_gcs_dir(root_gcs_path: str, dir_name_prefix: str) -> str:

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -73,6 +73,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
     _is_client_prediction_client = False
     _resource_noun = "trainingPipelines"
     _getter_method = "get_training_pipeline"
+    _delete_method = "delete_training_pipeline"
 
     def __init__(
         self,
@@ -561,6 +562,22 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
                 " TrainingPipeline using TrainingPipeline.run. "
             )
         return False
+
+    def cancel(self) -> None:
+        """Starts asynchronous cancellation on the TrainingJob. The server
+        makes a best effort to cancel the job, but success is not guaranteed.
+        On successful cancellation, the TrainingJob is not deleted; instead it
+        becomes a job with state set to `CANCELLED`.
+
+        Raises:
+            RuntimeError if this TrainingJob has not started running.
+        """
+        if not self._has_run:
+            raise RuntimeError(
+                "This TrainingJob has not been launched, use the `run()` method "
+                "to start. `cancel()` can only be called on a job that is running."
+            )
+        self.api_client.cancel_training_pipeline(name=self._gca_resource.resource_name)
 
 
 def _timestamped_gcs_dir(root_gcs_path: str, dir_name_prefix: str) -> str:

--- a/tests/unit/aiplatform/test_jobs.py
+++ b/tests/unit/aiplatform/test_jobs.py
@@ -115,9 +115,40 @@ _TEST_MAX_REPLICA_COUNT = 12
 
 _TEST_LABEL = {"team": "experimentation", "trial_id": "x435"}
 
+_TEST_JOB_GET_METHOD_NAME = "get_fake_job"
+_TEST_JOB_CANCEL_METHOD_NAME = "cancel_fake_job"
+_TEST_JOB_DELETE_METHOD_NAME = "delete_fake_job"
+_TEST_JOB_RESOURCE_NAME = f"{_TEST_PARENT}/fakeJobs/{_TEST_ID}"
 
 # TODO(b/171333554): Move reusable test fixtures to conftest.py file
+
+
+@pytest.fixture
+def fake_job_getter_mock():
+    with patch.object(
+        job_service_client.JobServiceClient, _TEST_JOB_GET_METHOD_NAME, create=True
+    ) as fake_job_getter_mock:
+        fake_job_getter_mock.return_value = {}
+        yield fake_job_getter_mock
+
+
+@pytest.fixture
+def fake_job_cancel_mock():
+    with patch.object(
+        job_service_client.JobServiceClient, _TEST_JOB_CANCEL_METHOD_NAME, create=True
+    ) as fake_job_cancel_mock:
+        yield fake_job_cancel_mock
+
+
 class TestJob:
+    class FakeJob(jobs._Job):
+        _job_type = "fake-job"
+        _resource_noun = "fakeJobs"
+        _getter_method = _TEST_JOB_GET_METHOD_NAME
+        _cancel_method = _TEST_JOB_CANCEL_METHOD_NAME
+        _delete_method = _TEST_JOB_DELETE_METHOD_NAME
+        resource_name = _TEST_JOB_RESOURCE_NAME
+
     def setup_method(self):
         reload(initializer)
         reload(aiplatform)
@@ -134,6 +165,14 @@ class TestJob:
         """
         with pytest.raises(TypeError):
             jobs._Job(job_name=_TEST_BATCH_PREDICTION_JOB_NAME)
+
+    @pytest.mark.usefixtures("fake_job_getter_mock")
+    def test_cancel_mock_job(self, fake_job_cancel_mock):
+        """Create a fake `_Job` child class, and ensure the high-level cancel method works"""
+        fake_job = self.FakeJob(job_name=_TEST_JOB_RESOURCE_NAME)
+        fake_job.cancel()
+
+        fake_job_cancel_mock.assert_called_once_with(name=_TEST_JOB_RESOURCE_NAME)
 
 
 @pytest.fixture

--- a/tests/unit/aiplatform/test_lro.py
+++ b/tests/unit/aiplatform/test_lro.py
@@ -49,6 +49,7 @@ class AiPlatformResourceNounImpl(base.AiPlatformResourceNoun):
     _is_client_prediction_client = False
     _resource_noun = None
     _getter_method = None
+    _delete_method = None
 
 
 def make_operation_proto(name=TEST_OPERATION_NAME, response=None, **kwargs):


### PR DESCRIPTION
## Summary of changes
- Add `_delete_method` abstract property to `AiPlatformResourceNoun` class, requiring a resource noun to define it's delete method in GAPIC (i.e. `Dataset` would set this property to `delete_dataset`)
- Add abstract property `_cancel_method` to `_Job` class to force children to define it's cancel method (i.e. `BatchPredictionJob` would set `cancel_batch_prediction_job`
- Add high-level `delete()` method to `AiPlatformResourceNounWithFutureManager` that calls subclass deletion method
- Shifted the `optional_sync` decorator higher in `base.py` to be referenced by `delete()` for async capability
- Removed `Dataset.delete()` and `Model.delete()` but left their tests; they now test the high-level delete method
- Add `_TrainingJob.cancel()` and `_Job.cancel()` along with unit tests


Fixes [b/179510193](http://b/179510193) and [b/179945882](http://b/179945882) 🦕
