### PR TITLE
feat: Made get function available to all training jobs

### DIFF
--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -3465,6 +3465,12 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
 
 
 class AutoMLTextTrainingJob(_TrainingJob):
+    _supported_training_schemas = (
+        schema.training_job.definition.automl_text_classification,
+        schema.training_job.definition.automl_text_extraction,
+        schema.training_job.definition.automl_text_sentiment,
+    )
+
     def __init__(
         self,
         display_name: str,

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -107,9 +107,10 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
         self._project = project
         self._gca_resource = None
 
+    @property
     @classmethod
     @abc.abstractmethod
-    def _supported_training_schemas(self) -> Tuple[str]:
+    def _supported_training_schemas(cls) -> Tuple[str]:
         """List of supported schemas for this training job"""
 
         pass
@@ -156,7 +157,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
 
         if (
             self._gca_resource.training_task_definition
-            not in cls._supported_training_schemas()
+            not in cls._supported_training_schemas
         ):
             raise ValueError(
                 f"The retrieved job's training task definition "
@@ -1117,6 +1118,8 @@ class _CustomTrainingJob(_TrainingJob):
     """ABC for Custom Training Pipelines..
     """
 
+    _supported_training_schemas = (schema.training_job.definition.custom_task,)
+
     def __init__(
         self,
         display_name: str,
@@ -1306,10 +1309,6 @@ class _CustomTrainingJob(_TrainingJob):
                 "staging_bucket should be set in TrainingJob constructor or "
                 "set using aiplatform.init(staging_bucket='gs://my-bucket')"
             )
-
-    @classmethod
-    def _supported_training_schemas(self) -> Tuple[str]:
-        return (schema.training_job.definition.custom_task,)
 
     def _prepare_and_validate_run(
         self,
@@ -2339,6 +2338,8 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
 
 
 class AutoMLTabularTrainingJob(_TrainingJob):
+    _supported_training_schemas = (schema.training_job.definition.automl_tabular,)
+
     def __init__(
         self,
         display_name: str,
@@ -2549,10 +2550,6 @@ class AutoMLTabularTrainingJob(_TrainingJob):
             sync=sync,
         )
 
-    @classmethod
-    def _supported_training_schemas(self) -> Tuple[str]:
-        return (schema.training_job.definition.automl_tabular,)
-
     @base.optional_sync()
     def _run(
         self,
@@ -2688,6 +2685,11 @@ class AutoMLTabularTrainingJob(_TrainingJob):
 
 
 class AutoMLImageTrainingJob(_TrainingJob):
+    _supported_training_schemas = (
+        schema.training_job.definition.automl_image_classification,
+        schema.training_job.definition.automl_image_object_detection,
+    )
+
     def __init__(
         self,
         display_name: str,
@@ -2891,13 +2893,6 @@ class AutoMLImageTrainingJob(_TrainingJob):
             model_display_name=model_display_name,
             disable_early_stopping=disable_early_stopping,
             sync=sync,
-        )
-
-    @classmethod
-    def _supported_training_schemas(self) -> Tuple[str]:
-        return (
-            schema.training_job.definition.automl_image_classification,
-            schema.training_job.definition.automl_image_object_detection,
         )
 
     @base.optional_sync()

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -107,9 +107,9 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
         self._project = project
         self._gca_resource = None
 
-    @property
+    @classmethod
     @abc.abstractmethod
-    def _supported_training_schemas(self) -> List[str]:
+    def _supported_training_schemas(self) -> Tuple[str]:
         """List of supported schemas for this training job"""
 
         pass
@@ -121,8 +121,8 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
-    ) -> "CustomTrainingJob":
-        """Get CustomTrainingJob for the given resource_name.
+    ) -> "_TrainingJob":
+        """Get Training Job for the given resource_name.
 
         Args:
             resource_name (str):
@@ -156,12 +156,12 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
 
         if (
             self._gca_resource.training_task_definition
-            not in self._supported_training_schemas
+            not in cls._supported_training_schemas()
         ):
             raise ValueError(
                 f"The retrieved job's training task definition "
                 f"is {self._gca_resource.training_task_definition}, "
-                f"which is not compatible with this type of job."
+                f"which is not compatible with {cls.__name__}."
             )
 
         return self
@@ -1307,9 +1307,9 @@ class _CustomTrainingJob(_TrainingJob):
                 "set using aiplatform.init(staging_bucket='gs://my-bucket')"
             )
 
-    @property
-    def _supported_training_schemas(self) -> List[str]:
-        return [schema.training_job.definition.custom_task]
+    @classmethod
+    def _supported_training_schemas(self) -> Tuple[str]:
+        return (schema.training_job.definition.custom_task,)
 
     def _prepare_and_validate_run(
         self,
@@ -2549,9 +2549,9 @@ class AutoMLTabularTrainingJob(_TrainingJob):
             sync=sync,
         )
 
-    @property
-    def _supported_training_schemas(self) -> List[str]:
-        return [schema.training_job.definition.automl_tabular]
+    @classmethod
+    def _supported_training_schemas(self) -> Tuple[str]:
+        return (schema.training_job.definition.automl_tabular,)
 
     @base.optional_sync()
     def _run(
@@ -2893,12 +2893,12 @@ class AutoMLImageTrainingJob(_TrainingJob):
             sync=sync,
         )
 
-    @property
-    def _supported_training_schemas(self) -> List[str]:
-        return [
+    @classmethod
+    def _supported_training_schemas(self) -> Tuple[str]:
+        return (
             schema.training_job.definition.automl_image_classification,
             schema.training_job.definition.automl_image_object_detection,
-        ]
+        )
 
     @base.optional_sync()
     def _run(

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -123,7 +123,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
         credentials: Optional[auth_credentials.Credentials] = None,
     ) -> "CustomTrainingJob":
         """Get CustomTrainingJob for the given resource_name.
-        
+
         Args:
             resource_name (str):
                 Required. A fully-qualified resource name or ID.

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -1313,8 +1313,20 @@ class TestCustomTrainingJob:
     @pytest.mark.usefixtures("get_training_job_custom_mock")
     def test_get_training_job(self, get_training_job_custom_mock):
         aiplatform.init(project=_TEST_PROJECT)
-        training_jobs.CustomTrainingJob.get(resource_name=_TEST_NAME)
+        job = training_jobs.CustomTrainingJob.get(resource_name=_TEST_NAME)
+
         get_training_job_custom_mock.assert_called_once_with(name=_TEST_NAME)
+        assert isinstance(job, training_jobs.CustomTrainingJob)
+
+    @pytest.mark.usefixtures("get_training_job_custom_mock")
+    def test_get_training_job_wrong_job_type(self, get_training_job_custom_mock):
+        aiplatform.init(project=_TEST_PROJECT)
+
+        # The returned job is for a custom training task,
+        # but the calling type if of AutoMLImageTrainingJob.
+        # Hence, it should throw an error.
+        with pytest.raises(ValueError):
+            training_jobs.AutoMLImageTrainingJob.get(resource_name=_TEST_NAME)
 
     @pytest.mark.usefixtures("get_training_job_custom_mock_no_model_to_upload")
     def test_get_training_job_no_model_to_upload(


### PR DESCRIPTION
Lifted `get` function to `_TrainingJob` so that all subclasses can use this function to get an existing TrainingJob.

Fixes #https://b.corp.google.com/issues/180746020