### PR TITLE
fix: fix predict sample tests for proto-plus==1.14.2

### DIFF
--- a/samples/snippets/predict_custom_trained_model_sample_test.py
+++ b/samples/snippets/predict_custom_trained_model_sample_test.py
@@ -37,4 +37,4 @@ def test_ucaip_generated_predict_custom_trained_model_sample(capsys):
     )
 
     out, _ = capsys.readouterr()
-    assert "number_value: 1.0" in out
+    assert "1.0" in out

--- a/samples/snippets/predict_image_object_detection_sample_test.py
+++ b/samples/snippets/predict_image_object_detection_sample_test.py
@@ -31,4 +31,4 @@ def test_ucaip_generated_predict_image_object_detection_sample(capsys):
     )
 
     out, _ = capsys.readouterr()
-    assert 'string_value: "Salad"' in out
+    assert 'Salad' in out

--- a/samples/snippets/predict_tabular_classification_sample_test.py
+++ b/samples/snippets/predict_tabular_classification_sample_test.py
@@ -35,4 +35,4 @@ def test_ucaip_generated_predict_tabular_classification_sample(capsys):
     )
 
     out, _ = capsys.readouterr()
-    assert 'string_value: "setosa"' in out
+    assert 'setosa' in out


### PR DESCRIPTION
proto-plus==1.14.2 caused some predict samples to print different outputs, removing the unwanted tags such as 'string_value`, `number_value`, etc. when protobuf.Value is wrapped in a `dict` call.
