### PR TITLE
chore: allow merge commits

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -1,5 +1,6 @@
 # https://github.com/googleapis/repo-automation-bots/tree/master/packages/sync-repo-settings
 # Rules for master branch protection
+mergeCommitAllowed: true
 branchProtectionRules:
 # Identifies the protection rule pattern. Name of the branch to be protected.
 # Defaults to `master`


### PR DESCRIPTION
Merge commits are used for syncing `dev` and `master`.
