### PR TITLE
feat: Added encryption_spec_key_name to all relevant resources

### DIFF
--- a/google/cloud/aiplatform/datasets/dataset.py
+++ b/google/cloud/aiplatform/datasets/dataset.py
@@ -67,6 +67,7 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
             credentials (auth_credentials.Credentials):
                 Custom credentials to use to upload this model. Overrides
                 credentials set in aiplatform.init.
+
         """
 
         super().__init__(

--- a/google/cloud/aiplatform/datasets/dataset.py
+++ b/google/cloud/aiplatform/datasets/dataset.py
@@ -30,6 +30,7 @@ from google.cloud.aiplatform_v1beta1.types import dataset as gca_dataset
 from google.cloud.aiplatform_v1beta1.services.dataset_service import (
     client as dataset_service_client,
 )
+from google.cloud.aiplatform_v1beta1.types.encryption_spec import EncryptionSpec
 
 
 class Dataset(base.AiPlatformResourceNounWithFutureManager):
@@ -106,6 +107,7 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         request_metadata: Optional[Sequence[Tuple[str, str]]] = (),
+        encryption_spec_key_name: Optional[str] = None,
         sync: bool = True,
     ) -> "Dataset":
         """Creates a new dataset and optionally imports data into dataset when
@@ -166,6 +168,15 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
                 credentials set in aiplatform.init.
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the request as metadata.
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect a resource. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
             sync (bool):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will
@@ -201,6 +212,7 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
             location=location or initializer.global_config.location,
             credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
+            encryption_spec_key_name=encryption_spec_key_name,
             sync=sync,
         )
 
@@ -217,6 +229,7 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
         location: str,
         credentials: Optional[auth_credentials.Credentials],
         request_metadata: Optional[Sequence[Tuple[str, str]]] = (),
+        encryption_spec_key_name: Optional[str] = None,
         sync: bool = True,
     ) -> "Dataset":
         """Creates a new dataset and optionally imports data into dataset when
@@ -253,6 +266,15 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
                 credentials set in aiplatform.init.
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the request as metadata.
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect a resource. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
             sync (bool):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will
@@ -264,6 +286,7 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
         """
 
         create_dataset_lro = cls._create(
+            encryption_spec_key_name=encryption_spec_key_name,
             api_client=api_client,
             parent=parent,
             display_name=display_name,
@@ -291,6 +314,7 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
     @classmethod
     def _create(
         cls,
+        encryption_spec_key_name: Optional[str],
         api_client: dataset_service_client.DatasetServiceClient,
         parent: str,
         display_name: str,
@@ -301,6 +325,15 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
         """Creates a new managed dataset by directly calling API client.
 
         Args:
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect a resource. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
             api_client (dataset_service_client.DatasetServiceClient):
                 An instance of DatasetServiceClient with the correct api_endpoint
                 already set based on user's preferences.
@@ -328,10 +361,16 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
             operation (Operation):
                 An object representing a long-running operation.
         """
+
+        encryption_spec: Optional[EncryptionSpec] = None
+        if encryption_spec_key_name:
+            encryption_spec = EncryptionSpec(kms_key_name=encryption_spec_key_name)
+
         gapic_dataset = gca_dataset.Dataset(
             display_name=display_name,
             metadata_schema_uri=metadata_schema_uri,
             metadata=datasource.dataset_metadata,
+            encryption_spec=encryption_spec,
         )
 
         return api_client.create_dataset(

--- a/google/cloud/aiplatform/datasets/dataset.py
+++ b/google/cloud/aiplatform/datasets/dataset.py
@@ -67,10 +67,11 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
             credentials (auth_credentials.Credentials):
                 Custom credentials to use to upload this model. Overrides
                 credentials set in aiplatform.init.
-
         """
 
-        super().__init__(project=project, location=location, credentials=credentials)
+        super().__init__(
+            project=project, location=location, credentials=credentials,
+        )
         self._gca_resource = self._get_gca_resource(resource_name=dataset_name)
         self._validate_metadata_schema_uri()
 
@@ -177,6 +178,8 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
                 resource is created.
 
                 If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init.
             sync (bool):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will
@@ -208,9 +211,9 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
             display_name=display_name,
             metadata_schema_uri=metadata_schema_uri,
             datasource=datasource,
-            project=project or initializer.global_config.project,
-            location=location or initializer.global_config.location,
-            credentials=credentials or initializer.global_config.credentials,
+            project=project,
+            location=location,
+            credentials=credentials,
             request_metadata=request_metadata,
             encryption_spec_key_name=encryption_spec_key_name,
             sync=sync,
@@ -275,6 +278,8 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
                 resource is created.
 
                 If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init.
             sync (bool):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will
@@ -356,15 +361,23 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
                 resource is created.
 
                 If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init.
         Returns:
             operation (Operation):
                 An object representing a long-running operation.
         """
 
+        # Use provided encryption key name or else use one from global config
+        kms_key_name = (
+            encryption_spec_key_name
+            or initializer.global_config.encryption_spec_key_name
+        )
+
         encryption_spec = None
-        if encryption_spec_key_name:
+        if kms_key_name:
             encryption_spec = gca_encryption_spec.EncryptionSpec(
-                kms_key_name=encryption_spec_key_name
+                kms_key_name=kms_key_name
             )
 
         gapic_dataset = gca_dataset.Dataset(

--- a/google/cloud/aiplatform/datasets/dataset.py
+++ b/google/cloud/aiplatform/datasets/dataset.py
@@ -286,13 +286,13 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
         """
 
         create_dataset_lro = cls._create(
-            encryption_spec_key_name=encryption_spec_key_name,
             api_client=api_client,
             parent=parent,
             display_name=display_name,
             metadata_schema_uri=metadata_schema_uri,
             datasource=datasource,
             request_metadata=request_metadata,
+            encryption_spec_key_name=encryption_spec_key_name,
         )
 
         created_dataset = create_dataset_lro.result()
@@ -314,26 +314,17 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
     @classmethod
     def _create(
         cls,
-        encryption_spec_key_name: Optional[str],
         api_client: dataset_service_client.DatasetServiceClient,
         parent: str,
         display_name: str,
         metadata_schema_uri: str,
         datasource: _datasources.Datasource,
         request_metadata: Sequence[Tuple[str, str]] = (),
+        encryption_spec_key_name: Optional[str] = None,
     ) -> operation.Operation:
         """Creates a new managed dataset by directly calling API client.
 
         Args:
-            encryption_spec_key_name (Optional[str]):
-                Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect a resource. Has the
-                form:
-                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
-                The key needs to be in the same region as where the compute
-                resource is created.
-
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
             api_client (dataset_service_client.DatasetServiceClient):
                 An instance of DatasetServiceClient with the correct api_endpoint
                 already set based on user's preferences.
@@ -356,7 +347,15 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the create_dataset
                 request as metadata. Usually to specify special dataset config.
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect a resource. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
 
+                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
         Returns:
             operation (Operation):
                 An object representing a long-running operation.

--- a/google/cloud/aiplatform/datasets/dataset.py
+++ b/google/cloud/aiplatform/datasets/dataset.py
@@ -30,7 +30,7 @@ from google.cloud.aiplatform_v1beta1.types import dataset as gca_dataset
 from google.cloud.aiplatform_v1beta1.services.dataset_service import (
     client as dataset_service_client,
 )
-from google.cloud.aiplatform_v1beta1.types.encryption_spec import EncryptionSpec
+from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 
 
 class Dataset(base.AiPlatformResourceNounWithFutureManager):
@@ -362,9 +362,11 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
                 An object representing a long-running operation.
         """
 
-        encryption_spec: Optional[EncryptionSpec] = None
+        encryption_spec = None
         if encryption_spec_key_name:
-            encryption_spec = EncryptionSpec(kms_key_name=encryption_spec_key_name)
+            encryption_spec = gca_encryption_spec.EncryptionSpec(
+                kms_key_name=encryption_spec_key_name
+            )
 
         gapic_dataset = gca_dataset.Dataset(
             display_name=display_name,

--- a/google/cloud/aiplatform/datasets/dataset.py
+++ b/google/cloud/aiplatform/datasets/dataset.py
@@ -25,6 +25,7 @@ from google.cloud.aiplatform import initializer
 from google.cloud.aiplatform import utils
 
 from google.cloud.aiplatform.datasets import _datasources
+from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 from google.cloud.aiplatform_v1beta1.types import io as gca_io
 from google.cloud.aiplatform_v1beta1.types import dataset as gca_dataset
 from google.cloud.aiplatform_v1beta1.services.dataset_service import (
@@ -215,7 +216,9 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
             location=location or initializer.global_config.location,
             credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
-            encryption_spec_key_name=encryption_spec_key_name,
+            encryption_spec=initializer.global_config.get_encryption_spec(
+                encryption_spec_key_name=encryption_spec_key_name
+            ),
             sync=sync,
         )
 
@@ -232,7 +235,7 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
         location: str,
         credentials: Optional[auth_credentials.Credentials],
         request_metadata: Optional[Sequence[Tuple[str, str]]] = (),
-        encryption_spec_key_name: Optional[str] = None,
+        encryption_spec: Optional[gca_encryption_spec.EncryptionSpec] = None,
         sync: bool = True,
     ) -> "Dataset":
         """Creates a new dataset and optionally imports data into dataset when
@@ -269,17 +272,12 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
                 credentials set in aiplatform.init.
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the request as metadata.
-            encryption_spec_key_name (Optional[str]):
-                Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect the dataset. Has the
-                form:
-                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+            encryption_spec (Optional[gca_encryption_spec.EncryptionSpec]):
+                Optional. The Cloud KMS customer managed encryption key used to protect the dataset.
                 The key needs to be in the same region as where the compute
                 resource is created.
 
                 If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
-
-                Overrides encryption_spec_key_name set in aiplatform.init.
             sync (bool):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will
@@ -297,7 +295,7 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
             metadata_schema_uri=metadata_schema_uri,
             datasource=datasource,
             request_metadata=request_metadata,
-            encryption_spec_key_name=encryption_spec_key_name,
+            encryption_spec=encryption_spec,
         )
 
         created_dataset = create_dataset_lro.result()
@@ -325,7 +323,7 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
         metadata_schema_uri: str,
         datasource: _datasources.Datasource,
         request_metadata: Sequence[Tuple[str, str]] = (),
-        encryption_spec_key_name: Optional[str] = None,
+        encryption_spec: Optional[gca_encryption_spec.EncryptionSpec] = None,
     ) -> operation.Operation:
         """Creates a new managed dataset by directly calling API client.
 
@@ -352,17 +350,12 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the create_dataset
                 request as metadata. Usually to specify special dataset config.
-            encryption_spec_key_name (Optional[str]):
-                Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect the dataset. Has the
-                form:
-                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+            encryption_spec (Optional[gca_encryption_spec.EncryptionSpec]):
+                Optional. The Cloud KMS customer managed encryption key used to protect the dataset.
                 The key needs to be in the same region as where the compute
                 resource is created.
 
                 If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
-
-                Overrides encryption_spec_key_name set in aiplatform.init.
         Returns:
             operation (Operation):
                 An object representing a long-running operation.
@@ -372,9 +365,7 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
             display_name=display_name,
             metadata_schema_uri=metadata_schema_uri,
             metadata=datasource.dataset_metadata,
-            encryption_spec=initializer.global_config.get_encryption_spec(
-                encryption_spec_key_name=encryption_spec_key_name
-            ),
+            encryption_spec=encryption_spec,
         )
 
         return api_client.create_dataset(

--- a/google/cloud/aiplatform/datasets/dataset.py
+++ b/google/cloud/aiplatform/datasets/dataset.py
@@ -172,7 +172,7 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
                 Strings which should be sent along with the request as metadata.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect a resource. Has the
+                managed encryption key used to protect the dataset. Has the
                 form:
                 ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
                 The key needs to be in the same region as where the compute
@@ -272,7 +272,7 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
                 Strings which should be sent along with the request as metadata.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect a resource. Has the
+                managed encryption key used to protect the dataset. Has the
                 form:
                 ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
                 The key needs to be in the same region as where the compute
@@ -355,7 +355,7 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
                 request as metadata. Usually to specify special dataset config.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect a resource. Has the
+                managed encryption key used to protect the dataset. Has the
                 form:
                 ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
                 The key needs to be in the same region as where the compute

--- a/google/cloud/aiplatform/datasets/dataset.py
+++ b/google/cloud/aiplatform/datasets/dataset.py
@@ -30,7 +30,6 @@ from google.cloud.aiplatform_v1beta1.types import dataset as gca_dataset
 from google.cloud.aiplatform_v1beta1.services.dataset_service import (
     client as dataset_service_client,
 )
-from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 
 
 class Dataset(base.AiPlatformResourceNounWithFutureManager):
@@ -212,9 +211,9 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
             display_name=display_name,
             metadata_schema_uri=metadata_schema_uri,
             datasource=datasource,
-            project=project,
-            location=location,
-            credentials=credentials,
+            project=project or initializer.global_config.project,
+            location=location or initializer.global_config.location,
+            credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
             encryption_spec_key_name=encryption_spec_key_name,
             sync=sync,
@@ -369,23 +368,13 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
                 An object representing a long-running operation.
         """
 
-        # Use provided encryption key name or else use one from global config
-        kms_key_name = (
-            encryption_spec_key_name
-            or initializer.global_config.encryption_spec_key_name
-        )
-
-        encryption_spec = None
-        if kms_key_name:
-            encryption_spec = gca_encryption_spec.EncryptionSpec(
-                kms_key_name=kms_key_name
-            )
-
         gapic_dataset = gca_dataset.Dataset(
             display_name=display_name,
             metadata_schema_uri=metadata_schema_uri,
             metadata=datasource.dataset_metadata,
-            encryption_spec=encryption_spec,
+            encryption_spec=initializer.global_config.get_encryption_spec(
+                encryption_spec_key_name=encryption_spec_key_name
+            ),
         )
 
         return api_client.create_dataset(

--- a/google/cloud/aiplatform/datasets/image_dataset.py
+++ b/google/cloud/aiplatform/datasets/image_dataset.py
@@ -44,6 +44,7 @@ class ImageDataset(datasets.Dataset):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         request_metadata: Optional[Sequence[Tuple[str, str]]] = (),
+        encryption_spec_key_name: Optional[str] = None,
         sync: bool = True,
     ) -> "ImageDataset":
         """Creates a new image dataset and optionally imports data into dataset when
@@ -94,6 +95,15 @@ class ImageDataset(datasets.Dataset):
                 credentials set in aiplatform.init.
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the request as metadata.
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect a resource. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
             sync (bool):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will
@@ -130,5 +140,6 @@ class ImageDataset(datasets.Dataset):
             location=location or initializer.global_config.location,
             credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
+            encryption_spec_key_name=encryption_spec_key_name,
             sync=sync,
         )

--- a/google/cloud/aiplatform/datasets/image_dataset.py
+++ b/google/cloud/aiplatform/datasets/image_dataset.py
@@ -104,6 +104,8 @@ class ImageDataset(datasets.Dataset):
                 resource is created.
 
                 If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init.
             sync (bool):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will

--- a/google/cloud/aiplatform/datasets/image_dataset.py
+++ b/google/cloud/aiplatform/datasets/image_dataset.py
@@ -142,6 +142,8 @@ class ImageDataset(datasets.Dataset):
             location=location or initializer.global_config.location,
             credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
-            encryption_spec_key_name=encryption_spec_key_name,
+            encryption_spec=initializer.global_config.get_encryption_spec(
+                encryption_spec_key_name=encryption_spec_key_name
+            ),
             sync=sync,
         )

--- a/google/cloud/aiplatform/datasets/image_dataset.py
+++ b/google/cloud/aiplatform/datasets/image_dataset.py
@@ -97,7 +97,7 @@ class ImageDataset(datasets.Dataset):
                 Strings which should be sent along with the request as metadata.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect a resource. Has the
+                managed encryption key used to protect the dataset. Has the
                 form:
                 ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
                 The key needs to be in the same region as where the compute

--- a/google/cloud/aiplatform/datasets/tabular_dataset.py
+++ b/google/cloud/aiplatform/datasets/tabular_dataset.py
@@ -85,6 +85,8 @@ class TabularDataset(datasets.Dataset):
                 resource is created.
 
                 If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init.
             sync (bool):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will

--- a/google/cloud/aiplatform/datasets/tabular_dataset.py
+++ b/google/cloud/aiplatform/datasets/tabular_dataset.py
@@ -43,6 +43,7 @@ class TabularDataset(datasets.Dataset):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         request_metadata: Optional[Sequence[Tuple[str, str]]] = (),
+        encryption_spec_key_name: Optional[str] = None,
         sync: bool = True,
     ) -> "TabularDataset":
         """Creates a new tabular dataset.
@@ -75,6 +76,15 @@ class TabularDataset(datasets.Dataset):
                 credentials set in aiplatform.init.
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the request as metadata.
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect a resource. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
             sync (bool):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will
@@ -110,6 +120,7 @@ class TabularDataset(datasets.Dataset):
             location=location or initializer.global_config.location,
             credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
+            encryption_spec_key_name=encryption_spec_key_name,
             sync=sync,
         )
 

--- a/google/cloud/aiplatform/datasets/tabular_dataset.py
+++ b/google/cloud/aiplatform/datasets/tabular_dataset.py
@@ -78,7 +78,7 @@ class TabularDataset(datasets.Dataset):
                 Strings which should be sent along with the request as metadata.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect a resource. Has the
+                managed encryption key used to protect the dataset. Has the
                 form:
                 ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
                 The key needs to be in the same region as where the compute

--- a/google/cloud/aiplatform/datasets/tabular_dataset.py
+++ b/google/cloud/aiplatform/datasets/tabular_dataset.py
@@ -122,7 +122,9 @@ class TabularDataset(datasets.Dataset):
             location=location or initializer.global_config.location,
             credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
-            encryption_spec_key_name=encryption_spec_key_name,
+            encryption_spec=initializer.global_config.get_encryption_spec(
+                encryption_spec_key_name=encryption_spec_key_name
+            ),
             sync=sync,
         )
 

--- a/google/cloud/aiplatform/datasets/text_dataset.py
+++ b/google/cloud/aiplatform/datasets/text_dataset.py
@@ -44,6 +44,7 @@ class TextDataset(datasets.Dataset):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         request_metadata: Optional[Sequence[Tuple[str, str]]] = (),
+        encryption_spec_key_name: Optional[str] = None,
         sync: bool = True,
     ) -> "TextDataset":
         """Creates a new text dataset and optionally imports data into dataset when
@@ -101,6 +102,15 @@ class TextDataset(datasets.Dataset):
                 credentials set in aiplatform.init.
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the request as metadata.
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect a resource. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
             sync (bool):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will
@@ -137,5 +147,6 @@ class TextDataset(datasets.Dataset):
             location=location or initializer.global_config.location,
             credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
+            encryption_spec_key_name=encryption_spec_key_name,
             sync=sync,
         )

--- a/google/cloud/aiplatform/datasets/text_dataset.py
+++ b/google/cloud/aiplatform/datasets/text_dataset.py
@@ -111,6 +111,8 @@ class TextDataset(datasets.Dataset):
                 resource is created.
 
                 If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init.
             sync (bool):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will

--- a/google/cloud/aiplatform/datasets/text_dataset.py
+++ b/google/cloud/aiplatform/datasets/text_dataset.py
@@ -149,6 +149,8 @@ class TextDataset(datasets.Dataset):
             location=location or initializer.global_config.location,
             credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
-            encryption_spec_key_name=encryption_spec_key_name,
+            encryption_spec=initializer.global_config.get_encryption_spec(
+                encryption_spec_key_name=encryption_spec_key_name
+            ),
             sync=sync,
         )

--- a/google/cloud/aiplatform/datasets/text_dataset.py
+++ b/google/cloud/aiplatform/datasets/text_dataset.py
@@ -104,7 +104,7 @@ class TextDataset(datasets.Dataset):
                 Strings which should be sent along with the request as metadata.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect a resource. Has the
+                managed encryption key used to protect the dataset. Has the
                 form:
                 ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
                 The key needs to be in the same region as where the compute

--- a/google/cloud/aiplatform/datasets/video_dataset.py
+++ b/google/cloud/aiplatform/datasets/video_dataset.py
@@ -44,6 +44,7 @@ class VideoDataset(datasets.Dataset):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         request_metadata: Optional[Sequence[Tuple[str, str]]] = (),
+        encryption_spec_key_name: Optional[str] = None,
         sync: bool = True,
     ) -> "VideoDataset":
         """Creates a new video dataset and optionally imports data into dataset when
@@ -94,6 +95,17 @@ class VideoDataset(datasets.Dataset):
                 credentials set in aiplatform.init.
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the request as metadata.
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect the dataset. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init.
             sync (bool):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will
@@ -130,5 +142,8 @@ class VideoDataset(datasets.Dataset):
             location=location or initializer.global_config.location,
             credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
+            encryption_spec=initializer.global_config.get_encryption_spec(
+                encryption_spec_key_name=encryption_spec_key_name
+            ),
             sync=sync,
         )

--- a/google/cloud/aiplatform/initializer.py
+++ b/google/cloud/aiplatform/initializer.py
@@ -61,10 +61,18 @@ class _Config:
             experiment (str): The experiment to assign
             staging_bucket (str): The default staging bucket to use to stage artifacts
                 when making API calls. In the form gs://...
-            credentials (google.auth.crendentials.Crendentials): The default custom
+            credentials (google.auth.crendentials.Credentials): The default custom
                 credentials to use when making API calls. If not provided crendentials
                 will be ascertained from the environment.
-            TODO
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect a resource. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
         """
         if project:
             self._project = project

--- a/google/cloud/aiplatform/initializer.py
+++ b/google/cloud/aiplatform/initializer.py
@@ -40,6 +40,7 @@ class _Config:
         self._location = None
         self._staging_bucket = None
         self._credentials = None
+        self._encryption_spec_key_name = None
 
     def init(
         self,
@@ -49,6 +50,7 @@ class _Config:
         experiment: Optional[str] = None,
         staging_bucket: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
+        encryption_spec_key_name: Optional[str] = None,
     ):
         """Updates common initalization parameters with provided options.
 
@@ -62,6 +64,7 @@ class _Config:
             credentials (google.auth.crendentials.Crendentials): The default custom
                 credentials to use when making API calls. If not provided crendentials
                 will be ascertained from the environment.
+            TODO
         """
         if project:
             self._project = project
@@ -75,6 +78,8 @@ class _Config:
             self._staging_bucket = staging_bucket
         if credentials:
             self._credentials = credentials
+        if encryption_spec_key_name:
+            self._encryption_spec_key_name = encryption_spec_key_name
 
     @property
     def project(self) -> str:
@@ -125,6 +130,11 @@ class _Config:
         credentials, _ = google.auth.default()
         logger.removeFilter(logging_warning_filter)
         return credentials
+
+    @property
+    def encryption_spec_key_name(self) -> Optional[str]:
+        """Default encryption spec key name, if provided."""
+        return self._encryption_spec_key_name
 
     def get_client_options(
         self, location_override: Optional[str] = None, prediction_client: bool = False,

--- a/google/cloud/aiplatform/initializer.py
+++ b/google/cloud/aiplatform/initializer.py
@@ -73,7 +73,7 @@ class _Config:
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, this resource and all sub-resources will be secured by this key.
         """
         if project:
             self._project = project

--- a/google/cloud/aiplatform/initializer.py
+++ b/google/cloud/aiplatform/initializer.py
@@ -91,8 +91,11 @@ class _Config:
             self._encryption_spec_key_name = encryption_spec_key_name
 
     def get_encryption_spec(
-        self, encryption_spec_key_name: str
+        self, encryption_spec_key_name: Optional[str]
     ) -> Optional[gca_encryption_spec.EncryptionSpec]:
+        """Creates a gca_encryption_spec.EncryptionSpec instance from the given key name.
+        If the provided key name is None, it uses the default key name if provided.
+        """
         kms_key_name = encryption_spec_key_name or self.encryption_spec_key_name
         encryption_spec = None
         if kms_key_name:

--- a/google/cloud/aiplatform/initializer.py
+++ b/google/cloud/aiplatform/initializer.py
@@ -29,6 +29,7 @@ from google.auth import credentials as auth_credentials
 from google.auth.exceptions import GoogleAuthError
 from google.cloud.aiplatform import utils
 from google.cloud.aiplatform import constants
+from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 
 
 class _Config:
@@ -88,6 +89,17 @@ class _Config:
             self._credentials = credentials
         if encryption_spec_key_name:
             self._encryption_spec_key_name = encryption_spec_key_name
+
+    def get_encryption_spec(
+        self, encryption_spec_key_name: str
+    ) -> Optional[gca_encryption_spec.EncryptionSpec]:
+        kms_key_name = encryption_spec_key_name or self.encryption_spec_key_name
+        encryption_spec = None
+        if kms_key_name:
+            encryption_spec = gca_encryption_spec.EncryptionSpec(
+                kms_key_name=kms_key_name
+            )
+        return encryption_spec
 
     @property
     def project(self) -> str:

--- a/google/cloud/aiplatform/initializer.py
+++ b/google/cloud/aiplatform/initializer.py
@@ -95,6 +95,9 @@ class _Config:
     ) -> Optional[gca_encryption_spec.EncryptionSpec]:
         """Creates a gca_encryption_spec.EncryptionSpec instance from the given key name.
         If the provided key name is None, it uses the default key name if provided.
+
+        Args:
+            encryption_spec_key_name (Optional[str]): The default encryption key name to use when creating resources.
         """
         kms_key_name = encryption_spec_key_name or self.encryption_spec_key_name
         encryption_spec = None

--- a/google/cloud/aiplatform/jobs.py
+++ b/google/cloud/aiplatform/jobs.py
@@ -384,7 +384,7 @@ class BatchPredictionJob(_Job):
 
                 If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
 
-                Overrides encryption_spec_key_name set in aiplatform.init.                
+                Overrides encryption_spec_key_name set in aiplatform.init.
             sync (bool):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will

--- a/google/cloud/aiplatform/jobs.py
+++ b/google/cloud/aiplatform/jobs.py
@@ -382,7 +382,9 @@ class BatchPredictionJob(_Job):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If this is set, then all
+                resources created by the BatchPredictionJob will
+                be encrypted with the provided encryption key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
             sync (bool):

--- a/google/cloud/aiplatform/jobs.py
+++ b/google/cloud/aiplatform/jobs.py
@@ -42,8 +42,8 @@ from google.cloud.aiplatform_v1beta1.types import batch_prediction_job as gca_bp
 from google.cloud.aiplatform_v1beta1.types import (
     machine_resources as gca_machine_resources,
 )
+
 from google.cloud.aiplatform_v1beta1.types import explanation as gca_explanation
-from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 
 logging.basicConfig(level=logging.INFO, stream=sys.stdout)
 _LOGGER = logging.getLogger(__name__)
@@ -433,19 +433,10 @@ class BatchPredictionJob(_Job):
                 f"type. Please choose from: {constants.BATCH_PREDICTION_OUTPUT_STORAGE_FORMATS}"
             )
 
-        # Use provided encryption key name or else use one from global config
-        kms_key_name = (
-            encryption_spec_key_name
-            or initializer.global_config.encryption_spec_key_name
-        )
-        encryption_spec = None
-        if kms_key_name:
-            encryption_spec = gca_encryption_spec.EncryptionSpec(
-                kms_key_name=kms_key_name
-            )
-
         gapic_batch_prediction_job = gca_bp_job.BatchPredictionJob(
-            encryption_spec=encryption_spec,
+            encryption_spec=initializer.global_config.get_encryption_spec(
+                encryption_spec_key_name=encryption_spec_key_name
+            ),
         )
 
         # Required Fields

--- a/google/cloud/aiplatform/jobs.py
+++ b/google/cloud/aiplatform/jobs.py
@@ -433,11 +433,7 @@ class BatchPredictionJob(_Job):
                 f"type. Please choose from: {constants.BATCH_PREDICTION_OUTPUT_STORAGE_FORMATS}"
             )
 
-        gapic_batch_prediction_job = gca_bp_job.BatchPredictionJob(
-            encryption_spec=initializer.global_config.get_encryption_spec(
-                encryption_spec_key_name=encryption_spec_key_name
-            ),
-        )
+        gapic_batch_prediction_job = gca_bp_job.BatchPredictionJob()
 
         # Required Fields
         gapic_batch_prediction_job.display_name = job_display_name
@@ -476,6 +472,9 @@ class BatchPredictionJob(_Job):
         gapic_batch_prediction_job.output_config = output_config
 
         # Optional Fields
+        gapic_batch_prediction_job.encryption_spec = initializer.global_config.get_encryption_spec(
+            encryption_spec_key_name=encryption_spec_key_name
+        )
 
         if model_parameters:
             gapic_batch_prediction_job.model_parameters = model_parameters

--- a/google/cloud/aiplatform/jobs.py
+++ b/google/cloud/aiplatform/jobs.py
@@ -376,7 +376,7 @@ class BatchPredictionJob(_Job):
                 job. Overrides credentials set in aiplatform.init.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect a resource. Has the
+                managed encryption key used to protect the job. Has the
                 form:
                 ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
                 The key needs to be in the same region as where the compute

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1143,7 +1143,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
 
                 If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
 
-                Overrides encryption_spec_key_name set in aiplatform.init.                
+                Overrides encryption_spec_key_name set in aiplatform.init.
         """
 
         super().__init__(project=project, location=location, credentials=credentials)
@@ -1799,7 +1799,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
 
                 If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
 
-                Overrides encryption_spec_key_name set in aiplatform.init.                
+                Overrides encryption_spec_key_name set in aiplatform.init.
         Returns:
             (jobs.BatchPredictionJob):
                 Instantiated representation of the created batch prediction job.

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1354,15 +1354,18 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
                 prediction_schema_uri=prediction_schema_uri,
             )
 
+        # TODO(b/182388545) initializer.global_config.get_encryption_spec from a sync function
+        encryption_spec = initializer.global_config.get_encryption_spec(
+            encryption_spec_key_name=encryption_spec_key_name
+        )
+
         managed_model = gca_model.Model(
             display_name=display_name,
             description=description,
             artifact_uri=artifact_uri,
             container_spec=container_spec,
             predict_schemata=model_predict_schemata,
-            encryption_spec=initializer.global_config.get_encryption_spec(
-                encryption_spec_key_name=encryption_spec_key_name
-            ),
+            encryption_spec=encryption_spec,
         )
 
         # Override explanation_spec if both required fields are provided

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -157,7 +157,7 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, this Endpoint and all sub-resources of this Endpoint will be secured by this key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
             sync (bool):
@@ -1279,7 +1279,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, this Model and all sub-resources of this Model will be secured by this key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
         Returns:
@@ -1447,7 +1447,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, this Model and all sub-resources of this Model will be secured by this key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init
             sync (bool):
@@ -1575,7 +1575,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, this Model and all sub-resources of this Model will be secured by this key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init
             sync (bool):
@@ -1791,7 +1791,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, this Model and all sub-resources of this Model will be secured by this key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
         Returns:

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -151,7 +151,7 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
                 credentials set in aiplatform.init.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect a resource. Has the
+                managed encryption key used to protect the model. Has the
                 form:
                 ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
                 The key needs to be in the same region as where the compute
@@ -240,7 +240,7 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
                 credentials set in aiplatform.init.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect a resource. Has the
+                managed encryption key used to protect the model. Has the
                 form:
                 ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
                 The key needs to be in the same region as where the compute
@@ -1135,7 +1135,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
                 credentials set in aiplatform.init will be used.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect a resource. Has the
+                managed encryption key used to protect the model. Has the
                 form:
                 ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
                 The key needs to be in the same region as where the compute
@@ -1177,6 +1177,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
+        encryption_spec_key_name: Optional[str] = None,
         sync=True,
     ) -> "Model":
         """Uploads a model and returns a Model representing the uploaded Model resource.
@@ -1297,6 +1298,17 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
             credentials: Optional[auth_credentials.Credentials]=None,
                 Custom credentials to use to upload this model. Overrides credentials
                 set in aiplatform.init.
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect the model. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init.
         Returns:
             model: Instantiated representation of the uploaded model resource.
         Raises:
@@ -1344,7 +1356,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
 
         # Use provided encryption key name or else use one from global config
         kms_key_name = (
-            self._encryption_spec_key_name
+            encryption_spec_key_name
             or initializer.global_config.encryption_spec_key_name
         )
         encryption_spec = None
@@ -1779,7 +1791,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
                 job. Overrides credentials set in aiplatform.init.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect a resource. Has the
+                managed encryption key used to protect the model. Has the
                 form:
                 ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
                 The key needs to be in the same region as where the compute

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -34,14 +34,14 @@ from google.cloud.aiplatform_v1beta1.services.prediction_service import (
     client as prediction_service_client,
 )
 
-from google.cloud.aiplatform_v1beta1.types import explanation as gca_explanation
+from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 from google.cloud.aiplatform_v1beta1.types import endpoint as gca_endpoint
+from google.cloud.aiplatform_v1beta1.types import explanation as gca_explanation
 from google.cloud.aiplatform_v1beta1.types import machine_resources
 from google.cloud.aiplatform_v1beta1.types import model as gca_model
 from google.cloud.aiplatform_v1beta1.types import env_var
 
 from google.protobuf import json_format
-from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 
 
 class Prediction(NamedTuple):
@@ -1354,24 +1354,15 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
                 prediction_schema_uri=prediction_schema_uri,
             )
 
-        # Use provided encryption key name or else use one from global config
-        kms_key_name = (
-            encryption_spec_key_name
-            or initializer.global_config.encryption_spec_key_name
-        )
-        encryption_spec = None
-        if kms_key_name:
-            encryption_spec = gca_encryption_spec.EncryptionSpec(
-                kms_key_name=kms_key_name
-            )
-
         managed_model = gca_model.Model(
             display_name=display_name,
             description=description,
             artifact_uri=artifact_uri,
             container_spec=container_spec,
             predict_schemata=model_predict_schemata,
-            encryption_spec=encryption_spec,
+            encryption_spec=initializer.global_config.get_encryption_spec(
+                encryption_spec_key_name=encryption_spec_key_name
+            ),
         )
 
         # Override explanation_spec if both required fields are provided

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1610,6 +1610,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
         ] = None,
         labels: Optional[dict] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
+        encryption_spec_key_name: Optional[str] = None,
         sync: bool = True,
     ) -> "jobs.BatchPredictionJob":
         """Creates a batch prediction job using this Model and outputs prediction
@@ -1751,6 +1752,17 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
             credentials: Optional[auth_credentials.Credentials] = None
                 Optional. Custom credentials to use to create this batch prediction
                 job. Overrides credentials set in aiplatform.init.
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect a resource. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init.                
         Returns:
             (jobs.BatchPredictionJob):
                 Instantiated representation of the created batch prediction job.
@@ -1780,5 +1792,6 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
             project=self.project,
             location=self.location,
             credentials=credentials or self.credentials,
+            encryption_spec_key_name=encryption_spec_key_name,
             sync=sync,
         )

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -185,7 +185,9 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
             labels=labels,
             metadata=metadata,
             credentials=credentials,
-            encryption_spec_key_name=encryption_spec_key_name,
+            encryption_spec=initializer.global_config.get_encryption_spec(
+                encryption_spec_key_name=encryption_spec_key_name
+            ),
             sync=sync,
         )
 
@@ -201,7 +203,7 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
         labels: Optional[Dict] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = (),
         credentials: Optional[auth_credentials.Credentials] = None,
-        encryption_spec_key_name: Optional[str] = None,
+        encryption_spec: Optional[gca_encryption_spec.EncryptionSpec] = None,
         sync=True,
     ) -> "Endpoint":
         """
@@ -238,17 +240,12 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
             credentials (auth_credentials.Credentials):
                 Optional. Custom credentials to use to upload this model. Overrides
                 credentials set in aiplatform.init.
-            encryption_spec_key_name (Optional[str]):
-                Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect the model. Has the
-                form:
-                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+            encryption_spec (Optional[gca_encryption_spec.EncryptionSpec]):
+                Optional. The Cloud KMS customer managed encryption key used to protect the dataset.
                 The key needs to be in the same region as where the compute
                 resource is created.
 
                 If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
-
-                Overrides encryption_spec_key_name set in aiplatform.init.
             sync (bool):
                 Whether to create this endpoint synchronously.
         Returns:
@@ -259,17 +256,6 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
         parent = initializer.global_config.common_location_path(
             project=project, location=location
         )
-
-        # Use provided encryption key name or else use one from global config
-        kms_key_name = (
-            encryption_spec_key_name
-            or initializer.global_config.encryption_spec_key_name
-        )
-        encryption_spec = None
-        if kms_key_name:
-            encryption_spec = gca_encryption_spec.EncryptionSpec(
-                kms_key_name=kms_key_name
-            )
 
         gapic_endpoint = gca_endpoint.Endpoint(
             display_name=display_name,
@@ -1115,7 +1101,6 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
-        encryption_spec_key_name: Optional[str] = None,
     ):
         """Retrieves the model resource and instantiates its representation.
 
@@ -1133,22 +1118,10 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
             credentials: Optional[auth_credentials.Credentials]=None,
                 Custom credentials to use to upload this model. If not set,
                 credentials set in aiplatform.init will be used.
-            encryption_spec_key_name (Optional[str]):
-                Optional. The Cloud KMS resource identifier of the customer
-                managed encryption key used to protect the model. Has the
-                form:
-                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
-                The key needs to be in the same region as where the compute
-                resource is created.
-
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
-
-                Overrides encryption_spec_key_name set in aiplatform.init.
         """
 
         super().__init__(project=project, location=location, credentials=credentials)
         self._gca_resource = self._get_gca_resource(resource_name=model_name)
-        self._encryption_spec_key_name = encryption_spec_key_name
 
     # TODO(b/170979552) Add support for predict schemata
     # TODO(b/170979926) Add support for metadata and metadata schema
@@ -1403,6 +1376,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
             "aiplatform.explain.ExplanationParameters"
         ] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = (),
+        encryption_spec_key_name: Optional[str] = None,
         sync=True,
     ) -> Endpoint:
         """
@@ -1465,6 +1439,17 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
             metadata (Sequence[Tuple[str, str]]):
                 Optional. Strings which should be sent along with the request as
                 metadata.
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect the model. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init
             sync (bool):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will
@@ -1497,6 +1482,8 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
             explanation_metadata=explanation_metadata,
             explanation_parameters=explanation_parameters,
             metadata=metadata,
+            encryption_spec_key_name=encryption_spec_key_name
+            or initializer.global_config.encryption_spec_key_name,
             sync=sync,
         )
 
@@ -1517,6 +1504,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
             "aiplatform.explain.ExplanationParameters"
         ] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = (),
+        encryption_spec_key_name: Optional[str] = None,
         sync: bool = True,
     ) -> Endpoint:
         """
@@ -1579,6 +1567,17 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
             metadata (Sequence[Tuple[str, str]]):
                 Optional. Strings which should be sent along with the request as
                 metadata.
+            encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect the model. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init
             sync (bool):
                 Whether to execute this method synchronously. If False, this method
                 will be executed in concurrent Future and any downstream object will
@@ -1595,6 +1594,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
                 project=self.project,
                 location=self.location,
                 credentials=self.credentials,
+                encryption_spec_key_name=encryption_spec_key_name,
             )
 
         Endpoint._deploy_call(

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -1870,9 +1870,7 @@ class CustomTrainingJob(_CustomTrainingJob):
         training_fraction_split: float = 0.8,
         validation_fraction_split: float = 0.1,
         test_fraction_split: float = 0.1,
-        predefined_split_column_name: Optional[str] = None,
-        model_encryption_spec: Optional[gca_encryption_spec.EncryptionSpec] = None,
-        training_encryption_spec: Optional[gca_encryption_spec.EncryptionSpec] = None,
+        predefined_split_column_name: Optional[str] = None,        
         sync=True,
     ) -> Optional[models.Model]:
         """Packages local script and launches training_job.

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -2189,7 +2189,7 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
                 Overrides encryption_spec_key_name set in aiplatform.init.
             staging_bucket (str):
                 Bucket used to stage source and training artifacts. Overrides
-                staging_bucket set in aiplatform.init.               
+                staging_bucket set in aiplatform.init.
         """
         super().__init__(
             display_name=display_name,
@@ -2961,7 +2961,7 @@ class AutoMLImageTrainingJob(_TrainingJob):
 
                 If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
 
-                Overrides encryption_spec_key_name set in aiplatform.init.                
+                Overrides encryption_spec_key_name set in aiplatform.init.
         Raises:
             ValueError: When an invalid prediction_type or model_type is provided.
         """
@@ -3779,7 +3779,7 @@ class AutoMLVideoTrainingJob(_TrainingJob):
 
                 If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
 
-                Overrides encryption_spec_key_name set in aiplatform.init.                
+                Overrides encryption_spec_key_name set in aiplatform.init.
         Raises:
             ValueError: When an invalid prediction_type and/or model_type is provided.
         """

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -651,10 +651,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
             )
 
             return models.Model(
-                fields.id,
-                project=fields.project,
-                location=fields.location,
-                encryption_spec=self.model_encryption_spec,
+                fields.id, project=fields.project, location=fields.location,
             )
 
     def _block_until_complete(self):

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -109,7 +109,10 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, this TrainingPipeline will be secured by this key.
+
+                Note: Model trained by this TrainingPipeline is also secured
+                by this key if ``model_to_upload`` is not set separately.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
             model_encryption_spec_key_name (Optional[str]):
@@ -120,7 +123,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, the trained Model will be secured by this key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
         """
@@ -1282,7 +1285,10 @@ class _CustomTrainingJob(_TrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, this TrainingPipeline will be secured by this key.
+
+                Note: Model trained by this TrainingPipeline is also secured
+                by this key if ``model_to_upload`` is not set separately.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
             model_encryption_spec_key_name (Optional[str]):
@@ -1293,7 +1299,7 @@ class _CustomTrainingJob(_TrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, the trained Model will be secured by this key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
             staging_bucket (str):
@@ -1650,7 +1656,10 @@ class CustomTrainingJob(_CustomTrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, this TrainingPipeline will be secured by this key.
+
+                Note: Model trained by this TrainingPipeline is also secured
+                by this key if ``model_to_upload`` is not set separately.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
             model_encryption_spec_key_name (Optional[str]):
@@ -1661,7 +1670,7 @@ class CustomTrainingJob(_CustomTrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, the trained Model will be secured by this key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
             staging_bucket (str):
@@ -2137,7 +2146,10 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, this TrainingPipeline will be secured by this key.
+
+                Note: Model trained by this TrainingPipeline is also secured
+                by this key if ``model_to_upload`` is not set separately.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
             model_encryption_spec_key_name (Optional[str]):
@@ -2148,7 +2160,7 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, the trained Model will be secured by this key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
             staging_bucket (str):
@@ -2542,7 +2554,10 @@ class AutoMLTabularTrainingJob(_TrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, this TrainingPipeline will be secured by this key.
+
+                Note: Model trained by this TrainingPipeline is also secured
+                by this key if ``model_to_upload`` is not set separately.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
             model_encryption_spec_key_name (Optional[str]):
@@ -2553,7 +2568,7 @@ class AutoMLTabularTrainingJob(_TrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, the trained Model will be secured by this key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
         """
@@ -2913,7 +2928,10 @@ class AutoMLImageTrainingJob(_TrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, this TrainingPipeline will be secured by this key.
+
+                Note: Model trained by this TrainingPipeline is also secured
+                by this key if ``model_to_upload`` is not set separately.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
             model_encryption_spec_key_name (Optional[str]):
@@ -2924,7 +2942,7 @@ class AutoMLImageTrainingJob(_TrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, the trained Model will be secured by this key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
         Raises:
@@ -3366,7 +3384,10 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, this TrainingPipeline will be secured by this key.
+
+                Note: Model trained by this TrainingPipeline is also secured
+                by this key if ``model_to_upload`` is not set separately.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
             model_encryption_spec_key_name (Optional[str]):
@@ -3377,7 +3398,7 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, the trained Model will be secured by this key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
             staging_bucket (str):
@@ -3731,7 +3752,10 @@ class AutoMLVideoTrainingJob(_TrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, this TrainingPipeline will be secured by this key.
+
+                Note: Model trained by this TrainingPipeline is also secured
+                by this key if ``model_to_upload`` is not set separately.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
             model_encryption_spec_key_name (Optional[str]):
@@ -3742,7 +3766,7 @@ class AutoMLVideoTrainingJob(_TrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, the trained Model will be secured by this key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
         Raises:
@@ -3982,7 +4006,10 @@ class AutoMLTextTrainingJob(_TrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, this TrainingPipeline will be secured by this key.
+
+                Note: Model trained by this TrainingPipeline is also secured
+                by this key if ``model_to_upload`` is not set separately.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
             model_encryption_spec_key_name (Optional[str]):
@@ -3993,7 +4020,7 @@ class AutoMLTextTrainingJob(_TrainingJob):
                 The key needs to be in the same region as where the compute
                 resource is created.
 
-                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+                If set, the trained Model will be secured by this key.
 
                 Overrides encryption_spec_key_name set in aiplatform.init.
         """

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -39,7 +39,6 @@ from google.cloud.aiplatform import utils
 from google.cloud.aiplatform_v1beta1.services.pipeline_service import (
     client as pipeline_service_client,
 )
-from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 from google.cloud.aiplatform_v1beta1.types import env_var
 from google.cloud.aiplatform_v1beta1.types import (
     accelerator_type as gca_accelerator_type,
@@ -1870,7 +1869,7 @@ class CustomTrainingJob(_CustomTrainingJob):
         training_fraction_split: float = 0.8,
         validation_fraction_split: float = 0.1,
         test_fraction_split: float = 0.1,
-        predefined_split_column_name: Optional[str] = None,        
+        predefined_split_column_name: Optional[str] = None,
         sync=True,
     ) -> Optional[models.Model]:
         """Packages local script and launches training_job.

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -3709,6 +3709,8 @@ class AutoMLVideoTrainingJob(_TrainingJob):
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
+        training_pipeline_encryption_spec_key_name: Optional[str] = None,
+        model_encryption_spec_key_name: Optional[str] = None,
     ):
         """Constructs a AutoML Video Training Job.
 
@@ -3756,6 +3758,28 @@ class AutoMLVideoTrainingJob(_TrainingJob):
             credentials (auth_credentials.Credentials):
                 Optional. Custom credentials to use to run call training service. Overrides
                 credentials set in aiplatform.init.
+            training_pipeline_encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect the training pipeline. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init.
+            model_encryption_spec_key_name (Optional[str]):
+                Optional. The Cloud KMS resource identifier of the customer
+                managed encryption key used to protect the model. Has the
+                form:
+                ``projects/my-project/locations/my-region/keyRings/my-kr/cryptoKeys/my-key``.
+                The key needs to be in the same region as where the compute
+                resource is created.
+
+                If set, this Dataset and all sub-resources of this Dataset will be secured by this key.
+
+                Overrides encryption_spec_key_name set in aiplatform.init.                
         Raises:
             ValueError: When an invalid prediction_type and/or model_type is provided.
         """
@@ -3780,6 +3804,8 @@ class AutoMLVideoTrainingJob(_TrainingJob):
             project=project,
             location=location,
             credentials=credentials,
+            training_pipeline_encryption_spec_key_name=training_pipeline_encryption_spec_key_name,
+            model_encryption_spec_key_name=model_encryption_spec_key_name,
         )
 
         self._model_type = model_type

--- a/tests/unit/aiplatform/test_automl_image_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_image_training_jobs.py
@@ -25,7 +25,7 @@ from google.cloud.aiplatform_v1beta1.types import (
     training_pipeline as gca_training_pipeline,
 )
 from google.cloud.aiplatform_v1beta1.types import dataset as gca_dataset
-
+from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 
 _TEST_PROJECT = "test-project"
 _TEST_LOCATION = "us-central1"
@@ -77,6 +77,12 @@ _TEST_MODEL_NAME = (
 
 _TEST_PIPELINE_RESOURCE_NAME = (
     f"projects/{_TEST_PROJECT}/locations/{_TEST_LOCATION}/trainingPipeline/12345"
+)
+
+# CMEK encryption
+_TEST_ENCRYPTION_KEY_NAME = "key_1234"
+_TEST_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_ENCRYPTION_KEY_NAME
 )
 
 
@@ -213,7 +219,9 @@ class TestAutoMLImageTrainingJob:
     ):
         """Create and run an AutoML ICN training job, verify calls and return value"""
 
-        aiplatform.init(project=_TEST_PROJECT)
+        aiplatform.init(
+            project=_TEST_PROJECT, encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME
+        )
 
         job = training_jobs.AutoMLImageTrainingJob(
             display_name=_TEST_DISPLAY_NAME, base_model=mock_model_image
@@ -254,6 +262,7 @@ class TestAutoMLImageTrainingJob:
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS_WITH_BASE_MODEL,
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -278,7 +287,10 @@ class TestAutoMLImageTrainingJob:
     ):
         aiplatform.init(project=_TEST_PROJECT)
 
-        job = training_jobs.AutoMLImageTrainingJob(display_name=_TEST_DISPLAY_NAME)
+        job = training_jobs.AutoMLImageTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+        )
 
         model_from_job = job.run(
             dataset=mock_dataset_image,
@@ -311,6 +323,7 @@ class TestAutoMLImageTrainingJob:
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(

--- a/tests/unit/aiplatform/test_automl_image_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_image_training_jobs.py
@@ -80,9 +80,19 @@ _TEST_PIPELINE_RESOURCE_NAME = (
 )
 
 # CMEK encryption
-_TEST_ENCRYPTION_KEY_NAME = "key_1234"
-_TEST_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
-    kms_key_name=_TEST_ENCRYPTION_KEY_NAME
+_TEST_DEFAULT_ENCRYPTION_KEY_NAME = "key_default"
+_TEST_DEFAULT_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME
+)
+
+_TEST_PIPELINE_ENCRYPTION_KEY_NAME = "key_pipeline"
+_TEST_PIPELINE_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME
+)
+
+_TEST_MODEL_ENCRYPTION_KEY_NAME = "key_model"
+_TEST_MODEL_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME
 )
 
 
@@ -220,7 +230,8 @@ class TestAutoMLImageTrainingJob:
         """Create and run an AutoML ICN training job, verify calls and return value"""
 
         aiplatform.init(
-            project=_TEST_PROJECT, encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
         )
 
         job = training_jobs.AutoMLImageTrainingJob(
@@ -250,6 +261,7 @@ class TestAutoMLImageTrainingJob:
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
             description=mock_model_image._gca_resource.description,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
@@ -262,7 +274,7 @@ class TestAutoMLImageTrainingJob:
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS_WITH_BASE_MODEL,
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
-            encryption_spec=_TEST_ENCRYPTION_SPEC,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -289,7 +301,8 @@ class TestAutoMLImageTrainingJob:
 
         job = training_jobs.AutoMLImageTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
-            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            training_pipeline_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
+            model_encryption_spec_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME,
         )
 
         model_from_job = job.run(
@@ -311,7 +324,9 @@ class TestAutoMLImageTrainingJob:
         )
 
         # Test that if defaults to the job display name
-        true_managed_model = gca_model.Model(display_name=_TEST_DISPLAY_NAME)
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_DISPLAY_NAME, encryption_spec=_TEST_MODEL_ENCRYPTION_SPEC
+        )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
             fraction_split=true_fraction_split, dataset_id=mock_dataset_image.name,
@@ -323,7 +338,7 @@ class TestAutoMLImageTrainingJob:
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
-            encryption_spec=_TEST_ENCRYPTION_SPEC,
+            encryption_spec=_TEST_PIPELINE_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(

--- a/tests/unit/aiplatform/test_automl_image_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_image_training_jobs.py
@@ -301,7 +301,7 @@ class TestAutoMLImageTrainingJob:
 
         job = training_jobs.AutoMLImageTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
-            training_pipeline_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
+            training_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
             model_encryption_spec_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME,
         )
 

--- a/tests/unit/aiplatform/test_automl_tabular_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_tabular_training_jobs.py
@@ -19,6 +19,7 @@ from google.cloud.aiplatform_v1beta1.types import pipeline_state as gca_pipeline
 from google.cloud.aiplatform_v1beta1.types import (
     training_pipeline as gca_training_pipeline,
 )
+from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 from google.cloud.aiplatform_v1beta1 import Dataset as GapicDataset
 
 from google.protobuf import json_format
@@ -80,6 +81,12 @@ _TEST_MODEL_NAME = "projects/my-project/locations/us-central1/models/12345"
 
 _TEST_PIPELINE_RESOURCE_NAME = (
     "projects/my-project/locations/us-central1/trainingPipeline/12345"
+)
+
+# CMEK encryption
+_TEST_ENCRYPTION_KEY_NAME = "key_1234"
+_TEST_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_ENCRYPTION_KEY_NAME
 )
 
 
@@ -172,7 +179,11 @@ class TestAutoMLTabularTrainingJob:
         mock_model_service_get,
         sync,
     ):
-        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            staging_bucket=_TEST_BUCKET_NAME,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+        )
 
         job = AutoMLTabularTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
@@ -222,6 +233,7 @@ class TestAutoMLTabularTrainingJob:
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -258,6 +270,7 @@ class TestAutoMLTabularTrainingJob:
             column_transformations=_TEST_TRAINING_COLUMN_TRANSFORMATIONS,
             optimization_objective_recall_value=None,
             optimization_objective_precision_value=None,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
         )
 
         model_from_job = job.run(
@@ -293,6 +306,7 @@ class TestAutoMLTabularTrainingJob:
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(

--- a/tests/unit/aiplatform/test_automl_tabular_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_tabular_training_jobs.py
@@ -84,9 +84,19 @@ _TEST_PIPELINE_RESOURCE_NAME = (
 )
 
 # CMEK encryption
-_TEST_ENCRYPTION_KEY_NAME = "key_1234"
-_TEST_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
-    kms_key_name=_TEST_ENCRYPTION_KEY_NAME
+_TEST_DEFAULT_ENCRYPTION_KEY_NAME = "key_default"
+_TEST_DEFAULT_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME
+)
+
+_TEST_PIPELINE_ENCRYPTION_KEY_NAME = "key_pipeline"
+_TEST_PIPELINE_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME
+)
+
+_TEST_MODEL_ENCRYPTION_KEY_NAME = "key_model"
+_TEST_MODEL_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME
 )
 
 
@@ -182,7 +192,7 @@ class TestAutoMLTabularTrainingJob:
         aiplatform.init(
             project=_TEST_PROJECT,
             staging_bucket=_TEST_BUCKET_NAME,
-            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
         )
 
         job = AutoMLTabularTrainingJob(
@@ -217,7 +227,10 @@ class TestAutoMLTabularTrainingJob:
             test_fraction=_TEST_TEST_FRACTION_SPLIT,
         )
 
-        true_managed_model = gca_model.Model(display_name=_TEST_MODEL_DISPLAY_NAME)
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
             fraction_split=true_fraction_split,
@@ -233,7 +246,7 @@ class TestAutoMLTabularTrainingJob:
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
-            encryption_spec=_TEST_ENCRYPTION_SPEC,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -270,7 +283,8 @@ class TestAutoMLTabularTrainingJob:
             column_transformations=_TEST_TRAINING_COLUMN_TRANSFORMATIONS,
             optimization_objective_recall_value=None,
             optimization_objective_precision_value=None,
-            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            training_pipeline_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
+            model_encryption_spec_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME,
         )
 
         model_from_job = job.run(
@@ -294,7 +308,9 @@ class TestAutoMLTabularTrainingJob:
         )
 
         # Test that if defaults to the job display name
-        true_managed_model = gca_model.Model(display_name=_TEST_DISPLAY_NAME)
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_DISPLAY_NAME, encryption_spec=_TEST_MODEL_ENCRYPTION_SPEC
+        )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
             fraction_split=true_fraction_split, dataset_id=mock_dataset_tabular.name,
@@ -306,7 +322,7 @@ class TestAutoMLTabularTrainingJob:
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
-            encryption_spec=_TEST_ENCRYPTION_SPEC,
+            encryption_spec=_TEST_PIPELINE_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(

--- a/tests/unit/aiplatform/test_automl_tabular_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_tabular_training_jobs.py
@@ -283,7 +283,7 @@ class TestAutoMLTabularTrainingJob:
             column_transformations=_TEST_TRAINING_COLUMN_TRANSFORMATIONS,
             optimization_objective_recall_value=None,
             optimization_objective_precision_value=None,
-            training_pipeline_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
+            training_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
             model_encryption_spec_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME,
         )
 

--- a/tests/unit/aiplatform/test_automl_text_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_text_training_jobs.py
@@ -65,9 +65,19 @@ _TEST_PIPELINE_RESOURCE_NAME = (
 )
 
 # CMEK encryption
-_TEST_ENCRYPTION_KEY_NAME = "key_1234"
-_TEST_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
-    kms_key_name=_TEST_ENCRYPTION_KEY_NAME
+_TEST_DEFAULT_ENCRYPTION_KEY_NAME = "key_default"
+_TEST_DEFAULT_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME
+)
+
+_TEST_PIPELINE_ENCRYPTION_KEY_NAME = "key_pipeline"
+_TEST_PIPELINE_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME
+)
+
+_TEST_MODEL_ENCRYPTION_KEY_NAME = "key_model"
+_TEST_MODEL_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME
 )
 
 
@@ -228,14 +238,14 @@ class TestAutoMLTextTrainingJob:
         """
 
         aiplatform.init(
-            project=_TEST_PROJECT, encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
         )
 
         job = training_jobs.AutoMLTextTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
             prediction_type=_TEST_PREDICTION_TYPE_CLASSIFICATION,
             multi_label=_TEST_CLASSIFICATION_MULTILABEL,
-            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
         )
 
         model_from_job = job.run(
@@ -256,7 +266,10 @@ class TestAutoMLTextTrainingJob:
             test_fraction=_TEST_FRACTION_SPLIT_TEST,
         )
 
-        true_managed_model = gca_model.Model(display_name=_TEST_MODEL_DISPLAY_NAME)
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
             fraction_split=true_fraction_split, dataset_id=mock_dataset_text.name,
@@ -268,7 +281,7 @@ class TestAutoMLTextTrainingJob:
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS_CLASSIFICATION,
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
-            encryption_spec=_TEST_ENCRYPTION_SPEC,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -292,7 +305,8 @@ class TestAutoMLTextTrainingJob:
             display_name=_TEST_DISPLAY_NAME,
             prediction_type=_TEST_PREDICTION_TYPE_CLASSIFICATION,
             multi_label=_TEST_CLASSIFICATION_MULTILABEL,
-            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            training_pipeline_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
+            model_encryption_spec_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME,
         )
 
         model_from_job = job.run(
@@ -313,7 +327,10 @@ class TestAutoMLTextTrainingJob:
             test_fraction=_TEST_FRACTION_SPLIT_TEST,
         )
 
-        true_managed_model = gca_model.Model(display_name=_TEST_MODEL_DISPLAY_NAME)
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            encryption_spec=_TEST_MODEL_ENCRYPTION_SPEC,
+        )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
             fraction_split=true_fraction_split, dataset_id=mock_dataset_text.name,
@@ -325,7 +342,7 @@ class TestAutoMLTextTrainingJob:
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS_CLASSIFICATION,
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
-            encryption_spec=_TEST_ENCRYPTION_SPEC,
+            encryption_spec=_TEST_PIPELINE_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(

--- a/tests/unit/aiplatform/test_automl_text_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_text_training_jobs.py
@@ -22,7 +22,7 @@ from google.cloud.aiplatform_v1beta1.types import (
     training_pipeline as gca_training_pipeline,
 )
 from google.cloud.aiplatform_v1beta1.types import dataset as gca_dataset
-
+from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 from google.cloud.aiplatform.v1beta1.schema.trainingjob import (
     definition_v1beta1 as training_job_inputs,
 )
@@ -62,6 +62,12 @@ _TEST_MODEL_NAME = (
 
 _TEST_PIPELINE_RESOURCE_NAME = (
     f"projects/{_TEST_PROJECT}/locations/{_TEST_LOCATION}/trainingPipeline/12345"
+)
+
+# CMEK encryption
+_TEST_ENCRYPTION_KEY_NAME = "key_1234"
+_TEST_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_ENCRYPTION_KEY_NAME
 )
 
 
@@ -209,21 +215,27 @@ class TestAutoMLTextTrainingJob:
         )
 
     @pytest.mark.parametrize("sync", [True, False])
-    def test_run_call_pipeline_service_create_classification(
+    def test_init_aiplatform_with_encryption_key_name_and_create_training_job(
         self,
         mock_pipeline_service_create,
         mock_dataset_text,
         mock_model_service_get,
         sync,
     ):
-        """Create and run an AutoML ICN training job, verify calls and return value"""
+        """
+        Initiate aiplatform with encryption key name.
+        Create and run an AutoML Text Classification training job, verify calls and return value
+        """
 
-        aiplatform.init(project=_TEST_PROJECT)
+        aiplatform.init(
+            project=_TEST_PROJECT, encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME
+        )
 
         job = training_jobs.AutoMLTextTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
             prediction_type=_TEST_PREDICTION_TYPE_CLASSIFICATION,
             multi_label=_TEST_CLASSIFICATION_MULTILABEL,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
         )
 
         model_from_job = job.run(
@@ -256,6 +268,64 @@ class TestAutoMLTextTrainingJob:
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS_CLASSIFICATION,
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_run_call_pipeline_service_create_classification(
+        self,
+        mock_pipeline_service_create,
+        mock_dataset_text,
+        mock_model_service_get,
+        sync,
+    ):
+        """Create and run an AutoML Text Classification training job, verify calls and return value"""
+
+        aiplatform.init(project=_TEST_PROJECT)
+
+        job = training_jobs.AutoMLTextTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            prediction_type=_TEST_PREDICTION_TYPE_CLASSIFICATION,
+            multi_label=_TEST_CLASSIFICATION_MULTILABEL,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+        )
+
+        model_from_job = job.run(
+            dataset=mock_dataset_text,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
+            validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
+            test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
+            sync=sync,
+        )
+
+        if not sync:
+            model_from_job.wait()
+
+        true_fraction_split = gca_training_pipeline.FractionSplit(
+            training_fraction=_TEST_FRACTION_SPLIT_TRAINING,
+            validation_fraction=_TEST_FRACTION_SPLIT_VALIDATION,
+            test_fraction=_TEST_FRACTION_SPLIT_TEST,
+        )
+
+        true_managed_model = gca_model.Model(display_name=_TEST_MODEL_DISPLAY_NAME)
+
+        true_input_data_config = gca_training_pipeline.InputDataConfig(
+            fraction_split=true_fraction_split, dataset_id=mock_dataset_text.name,
+        )
+
+        true_training_pipeline = gca_training_pipeline.TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.automl_text_classification,
+            training_task_inputs=_TEST_TRAINING_TASK_INPUTS_CLASSIFICATION,
+            model_to_upload=true_managed_model,
+            input_data_config=true_input_data_config,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -278,7 +348,7 @@ class TestAutoMLTextTrainingJob:
         mock_model_service_get,
         sync,
     ):
-        """Create and run an AutoML ICN training job, verify calls and return value"""
+        """Create and run an AutoML Text Extraction training job, verify calls and return value"""
 
         aiplatform.init(project=_TEST_PROJECT)
 
@@ -339,7 +409,7 @@ class TestAutoMLTextTrainingJob:
         mock_model_service_get,
         sync,
     ):
-        """Create and run an AutoML ICN training job, verify calls and return value"""
+        """Create and run an AutoML Text Sentiment training job, verify calls and return value"""
 
         aiplatform.init(project=_TEST_PROJECT)
 

--- a/tests/unit/aiplatform/test_automl_text_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_text_training_jobs.py
@@ -305,7 +305,7 @@ class TestAutoMLTextTrainingJob:
             display_name=_TEST_DISPLAY_NAME,
             prediction_type=_TEST_PREDICTION_TYPE_CLASSIFICATION,
             multi_label=_TEST_CLASSIFICATION_MULTILABEL,
-            training_pipeline_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
+            training_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
             model_encryption_spec_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME,
         )
 

--- a/tests/unit/aiplatform/test_automl_video_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_video_training_jobs.py
@@ -275,7 +275,7 @@ class TestAutoMLVideoTrainingJob:
             display_name=_TEST_DISPLAY_NAME,
             prediction_type=_TEST_PREDICTION_TYPE_VCN,
             model_type=_TEST_MODEL_TYPE_CLOUD,
-            training_pipeline_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
+            training_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
             model_encryption_spec_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME,
         )
 

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -38,7 +38,6 @@ from google.cloud.aiplatform_v1beta1 import ImportDataConfig
 from google.cloud.aiplatform_v1beta1 import ExportDataConfig
 from google.cloud.aiplatform_v1beta1 import DatasetServiceClient
 from google.cloud.aiplatform_v1beta1 import Dataset as GapicDataset
-from google.cloud.aiplatform_v1beta1.types import dataset_service, encryption_spec
 from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 
 # project
@@ -1036,7 +1035,7 @@ class TestVideoDataset:
         aiplatform.init(project=_TEST_PROJECT)
 
         my_dataset = datasets.VideoDataset.create(
-            display_name=_TEST_DISPLAY_NAME, 
+            display_name=_TEST_DISPLAY_NAME,
             encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
             sync=sync,
         )

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -38,6 +38,7 @@ from google.cloud.aiplatform_v1beta1 import ExportDataConfig
 from google.cloud.aiplatform_v1beta1 import DatasetServiceClient
 from google.cloud.aiplatform_v1beta1 import Dataset as GapicDataset
 from google.cloud.aiplatform_v1beta1.types import dataset_service
+from google.cloud.aiplatform_v1beta1.types import EncryptionSpec
 
 # project
 _TEST_PROJECT = "test-project"
@@ -95,6 +96,9 @@ _TEST_METADATA_TABULAR_BQ = {
     "input_config": {"bigquery_source": {"uri": _TEST_SOURCE_URI_BQ}}
 }
 
+# dataset_encryption
+_TEST_ENCRYPTION_KEY_NAME = "key_1234"
+_TEST_ENCRYPTION_SPEC = EncryptionSpec(kms_key_name=_TEST_ENCRYPTION_KEY_NAME)
 
 # misc
 _TEST_OUTPUT_DIR = "gs://my-output-bucket"
@@ -108,6 +112,7 @@ def get_dataset_mock():
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR,
             name=_TEST_NAME,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
         yield get_dataset_mock
 
@@ -118,6 +123,7 @@ def get_dataset_without_name_mock():
         get_dataset_mock.return_value = GapicDataset(
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
         yield get_dataset_mock
 
@@ -130,6 +136,7 @@ def get_dataset_image_mock():
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_IMAGE,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
             name=_TEST_NAME,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
         yield get_dataset_mock
 
@@ -142,6 +149,7 @@ def get_dataset_tabular_mock():
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_TABULAR,
             metadata=_TEST_METADATA_TABULAR_BQ,
             name=_TEST_NAME,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
         yield get_dataset_mock
 
@@ -154,6 +162,7 @@ def get_dataset_text_mock():
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_TEXT,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
             name=_TEST_NAME,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
         yield get_dataset_mock
 
@@ -175,7 +184,10 @@ def create_dataset_mock():
     with patch.object(DatasetServiceClient, "create_dataset") as create_dataset_mock:
         create_dataset_lro_mock = mock.Mock(operation.Operation)
         create_dataset_lro_mock.result.return_value = GapicDataset(
-            name=_TEST_NAME, display_name=_TEST_DISPLAY_NAME
+            name=_TEST_NAME,
+            display_name=_TEST_DISPLAY_NAME,
+            metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_TEXT,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
         create_dataset_mock.return_value = create_dataset_lro_mock
         yield create_dataset_mock
@@ -257,6 +269,7 @@ class TestDataset:
         my_dataset = datasets.Dataset.create(
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
             sync=sync,
         )
 
@@ -267,6 +280,7 @@ class TestDataset:
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         create_dataset_mock.assert_called_once_with(
@@ -283,12 +297,14 @@ class TestDataset:
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_TABULAR,
             bq_source=_TEST_SOURCE_URI_BQ,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
         )
 
         expected_dataset = GapicDataset(
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_TABULAR,
             metadata=_TEST_METADATA_TABULAR_BQ,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         create_dataset_mock.assert_called_once_with(
@@ -310,6 +326,7 @@ class TestDataset:
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR,
             import_schema_uri=_TEST_IMPORT_SCHEMA_URI,
             data_item_labels=_TEST_DATA_LABEL_ITEMS,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
             sync=sync,
         )
 
@@ -320,6 +337,7 @@ class TestDataset:
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         expected_import_config = ImportDataConfig(
@@ -394,6 +412,7 @@ class TestDataset:
         my_dataset = datasets.Dataset.create(
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
             sync=sync,
         )
 
@@ -411,6 +430,7 @@ class TestDataset:
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         expected_import_config = ImportDataConfig(
@@ -473,7 +493,9 @@ class TestImageDataset:
         aiplatform.init(project=_TEST_PROJECT)
 
         my_dataset = datasets.ImageDataset.create(
-            display_name=_TEST_DISPLAY_NAME, sync=sync,
+            display_name=_TEST_DISPLAY_NAME,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            sync=sync,
         )
 
         if not sync:
@@ -483,6 +505,7 @@ class TestImageDataset:
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_IMAGE,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         create_dataset_mock.assert_called_once_with(
@@ -502,6 +525,7 @@ class TestImageDataset:
             display_name=_TEST_DISPLAY_NAME,
             gcs_source=[_TEST_SOURCE_URI_GCS],
             import_schema_uri=_TEST_IMPORT_SCHEMA_URI_IMAGE,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
             sync=sync,
         )
 
@@ -512,6 +536,7 @@ class TestImageDataset:
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_IMAGE,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         create_dataset_mock.assert_called_once_with(
@@ -564,7 +589,9 @@ class TestImageDataset:
         aiplatform.init(project=_TEST_PROJECT)
 
         my_dataset = datasets.ImageDataset.create(
-            display_name=_TEST_DISPLAY_NAME, sync=sync,
+            display_name=_TEST_DISPLAY_NAME,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            sync=sync,
         )
 
         my_dataset.import_data(
@@ -580,6 +607,7 @@ class TestImageDataset:
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_IMAGE,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
         create_dataset_mock.assert_called_once_with(
             parent=_TEST_PARENT,
@@ -627,7 +655,10 @@ class TestTabularDataset:
         aiplatform.init(project=_TEST_PROJECT)
 
         my_dataset = datasets.TabularDataset.create(
-            display_name=_TEST_DISPLAY_NAME, bq_source=_TEST_SOURCE_URI_BQ, sync=sync,
+            display_name=_TEST_DISPLAY_NAME,
+            bq_source=_TEST_SOURCE_URI_BQ,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            sync=sync,
         )
 
         if not sync:
@@ -637,6 +668,7 @@ class TestTabularDataset:
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_TABULAR,
             metadata=_TEST_METADATA_TABULAR_BQ,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         create_dataset_mock.assert_called_once_with(
@@ -680,7 +712,9 @@ class TestTextDataset:
         aiplatform.init(project=_TEST_PROJECT)
 
         my_dataset = datasets.TextDataset.create(
-            display_name=_TEST_DISPLAY_NAME, sync=sync,
+            display_name=_TEST_DISPLAY_NAME,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            sync=sync,
         )
 
         if not sync:
@@ -690,6 +724,7 @@ class TestTextDataset:
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_TEXT,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         create_dataset_mock.assert_called_once_with(
@@ -709,6 +744,7 @@ class TestTextDataset:
             display_name=_TEST_DISPLAY_NAME,
             gcs_source=[_TEST_SOURCE_URI_GCS],
             import_schema_uri=_TEST_IMPORT_SCHEMA_URI_TEXT,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
             sync=sync,
         )
 
@@ -719,6 +755,7 @@ class TestTextDataset:
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_TEXT,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         create_dataset_mock.assert_called_once_with(
@@ -771,7 +808,9 @@ class TestTextDataset:
         aiplatform.init(project=_TEST_PROJECT)
 
         my_dataset = datasets.TextDataset.create(
-            display_name=_TEST_DISPLAY_NAME, sync=sync,
+            display_name=_TEST_DISPLAY_NAME,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            sync=sync,
         )
 
         my_dataset.import_data(
@@ -787,6 +826,7 @@ class TestTextDataset:
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_TEXT,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
         create_dataset_mock.assert_called_once_with(
             parent=_TEST_PARENT,

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -16,6 +16,7 @@
 #
 
 import os
+
 import pytest
 
 from unittest import mock
@@ -523,12 +524,12 @@ class TestImageDataset:
     @pytest.mark.usefixtures("get_dataset_image_mock")
     @pytest.mark.parametrize("sync", [True, False])
     def test_create_dataset(self, create_dataset_mock, sync):
-        aiplatform.init(project=_TEST_PROJECT)
+        aiplatform.init(
+            project=_TEST_PROJECT, encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+        )
 
         my_dataset = datasets.ImageDataset.create(
-            display_name=_TEST_DISPLAY_NAME,
-            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
-            sync=sync,
+            display_name=_TEST_DISPLAY_NAME, sync=sync,
         )
 
         if not sync:
@@ -684,6 +685,35 @@ class TestTabularDataset:
 
     @pytest.mark.usefixtures("get_dataset_tabular_mock")
     @pytest.mark.parametrize("sync", [True, False])
+    def test_create_dataset_with_default_encryption_key(
+        self, create_dataset_mock, sync
+    ):
+        aiplatform.init(
+            project=_TEST_PROJECT, encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+        )
+
+        my_dataset = datasets.TabularDataset.create(
+            display_name=_TEST_DISPLAY_NAME, bq_source=_TEST_SOURCE_URI_BQ, sync=sync,
+        )
+
+        if not sync:
+            my_dataset.wait()
+
+        expected_dataset = GapicDataset(
+            display_name=_TEST_DISPLAY_NAME,
+            metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_TABULAR,
+            metadata=_TEST_METADATA_TABULAR_BQ,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
+        )
+
+        create_dataset_mock.assert_called_once_with(
+            parent=_TEST_PARENT,
+            dataset=expected_dataset,
+            metadata=_TEST_REQUEST_METADATA,
+        )
+
+    @pytest.mark.usefixtures("get_dataset_tabular_mock")
+    @pytest.mark.parametrize("sync", [True, False])
     def test_create_dataset(self, create_dataset_mock, sync):
         aiplatform.init(project=_TEST_PROJECT)
 
@@ -742,12 +772,12 @@ class TestTextDataset:
     @pytest.mark.usefixtures("get_dataset_text_mock")
     @pytest.mark.parametrize("sync", [True, False])
     def test_create_dataset(self, create_dataset_mock, sync):
-        aiplatform.init(project=_TEST_PROJECT)
+        aiplatform.init(
+            project=_TEST_PROJECT, encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+        )
 
         my_dataset = datasets.TextDataset.create(
-            display_name=_TEST_DISPLAY_NAME,
-            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
-            sync=sync,
+            display_name=_TEST_DISPLAY_NAME, sync=sync,
         )
 
         if not sync:
@@ -811,7 +841,9 @@ class TestTextDataset:
     @pytest.mark.usefixtures("get_dataset_text_mock")
     @pytest.mark.parametrize("sync", [True, False])
     def test_import_data(self, import_data_mock, sync):
-        aiplatform.init(project=_TEST_PROJECT)
+        aiplatform.init(
+            project=_TEST_PROJECT, encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME
+        )
 
         my_dataset = datasets.TextDataset(dataset_name=_TEST_NAME)
 
@@ -904,7 +936,9 @@ class TestVideoDataset:
     @pytest.mark.usefixtures("get_dataset_video_mock")
     @pytest.mark.parametrize("sync", [True, False])
     def test_create_dataset(self, create_dataset_mock, sync):
-        aiplatform.init(project=_TEST_PROJECT)
+        aiplatform.init(
+            project=_TEST_PROJECT, encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME
+        )
 
         my_dataset = datasets.VideoDataset.create(
             display_name=_TEST_DISPLAY_NAME, sync=sync,
@@ -917,6 +951,7 @@ class TestVideoDataset:
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_VIDEO,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         create_dataset_mock.assert_called_once_with(
@@ -946,6 +981,7 @@ class TestVideoDataset:
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_VIDEO,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         create_dataset_mock.assert_called_once_with(

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -38,7 +38,7 @@ from google.cloud.aiplatform_v1beta1 import ImportDataConfig
 from google.cloud.aiplatform_v1beta1 import ExportDataConfig
 from google.cloud.aiplatform_v1beta1 import DatasetServiceClient
 from google.cloud.aiplatform_v1beta1 import Dataset as GapicDataset
-from google.cloud.aiplatform_v1beta1.types import dataset_service
+from google.cloud.aiplatform_v1beta1.types import dataset_service, encryption_spec
 from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 
 # project
@@ -178,6 +178,7 @@ def get_dataset_video_mock():
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_VIDEO,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
             name=_TEST_NAME,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
         yield get_dataset_mock
 
@@ -971,6 +972,7 @@ class TestVideoDataset:
             display_name=_TEST_DISPLAY_NAME,
             gcs_source=[_TEST_SOURCE_URI_GCS],
             import_schema_uri=_TEST_IMPORT_SCHEMA_URI_VIDEO,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
             sync=sync,
         )
 
@@ -1034,7 +1036,9 @@ class TestVideoDataset:
         aiplatform.init(project=_TEST_PROJECT)
 
         my_dataset = datasets.VideoDataset.create(
-            display_name=_TEST_DISPLAY_NAME, sync=sync,
+            display_name=_TEST_DISPLAY_NAME, 
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            sync=sync,
         )
 
         my_dataset.import_data(
@@ -1050,6 +1054,7 @@ class TestVideoDataset:
             display_name=_TEST_DISPLAY_NAME,
             metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_VIDEO,
             metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
         create_dataset_mock.assert_called_once_with(
             parent=_TEST_PARENT,

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -263,6 +263,37 @@ class TestDataset:
 
     @pytest.mark.usefixtures("get_dataset_mock")
     @pytest.mark.parametrize("sync", [True, False])
+    def test_init_aiplatform_with_encryption_key_name_and_create_dataset(
+        self, create_dataset_mock, sync
+    ):
+        aiplatform.init(
+            project=_TEST_PROJECT, encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+        )
+
+        my_dataset = datasets.Dataset.create(
+            display_name=_TEST_DISPLAY_NAME,
+            metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR,
+            sync=sync,
+        )
+
+        if not sync:
+            my_dataset.wait()
+
+        expected_dataset = GapicDataset(
+            display_name=_TEST_DISPLAY_NAME,
+            metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_NONTABULAR,
+            metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
+        )
+
+        create_dataset_mock.assert_called_once_with(
+            parent=_TEST_PARENT,
+            dataset=expected_dataset,
+            metadata=_TEST_REQUEST_METADATA,
+        )
+
+    @pytest.mark.usefixtures("get_dataset_mock")
+    @pytest.mark.parametrize("sync", [True, False])
     def test_create_dataset_nontabular(self, create_dataset_mock, sync):
         aiplatform.init(project=_TEST_PROJECT)
 

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -38,7 +38,7 @@ from google.cloud.aiplatform_v1beta1 import ExportDataConfig
 from google.cloud.aiplatform_v1beta1 import DatasetServiceClient
 from google.cloud.aiplatform_v1beta1 import Dataset as GapicDataset
 from google.cloud.aiplatform_v1beta1.types import dataset_service
-from google.cloud.aiplatform_v1beta1.types import EncryptionSpec
+from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 
 # project
 _TEST_PROJECT = "test-project"
@@ -96,9 +96,11 @@ _TEST_METADATA_TABULAR_BQ = {
     "input_config": {"bigquery_source": {"uri": _TEST_SOURCE_URI_BQ}}
 }
 
-# dataset_encryption
+# CMEK encryption
 _TEST_ENCRYPTION_KEY_NAME = "key_1234"
-_TEST_ENCRYPTION_SPEC = EncryptionSpec(kms_key_name=_TEST_ENCRYPTION_KEY_NAME)
+_TEST_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_ENCRYPTION_KEY_NAME
+)
 
 # misc
 _TEST_OUTPUT_DIR = "gs://my-output-bucket"

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -38,6 +38,7 @@ from google.cloud.aiplatform_v1beta1 import ImportDataConfig
 from google.cloud.aiplatform_v1beta1 import ExportDataConfig
 from google.cloud.aiplatform_v1beta1 import DatasetServiceClient
 from google.cloud.aiplatform_v1beta1 import Dataset as GapicDataset
+from google.cloud.aiplatform_v1beta1.types import dataset_service
 from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 
 # project

--- a/tests/unit/aiplatform/test_end_to_end.py
+++ b/tests/unit/aiplatform/test_end_to_end.py
@@ -34,6 +34,7 @@ from google.cloud.aiplatform_v1beta1.types import pipeline_state as gca_pipeline
 from google.cloud.aiplatform_v1beta1.types import (
     training_pipeline as gca_training_pipeline,
 )
+from google.cloud.aiplatform_v1beta1.types import EncryptionSpec
 
 import test_datasets
 from test_datasets import create_dataset_mock  # noqa: F401
@@ -55,9 +56,12 @@ from test_training_jobs import (  # noqa: F401
 )
 from test_training_jobs import mock_python_package_to_gcs  # noqa: F401
 
-
 from google.protobuf import json_format
 from google.protobuf import struct_pb2
+
+# dataset_encryption
+_TEST_ENCRYPTION_KEY_NAME = "key_1234"
+_TEST_ENCRYPTION_SPEC = EncryptionSpec(kms_key_name=_TEST_ENCRYPTION_KEY_NAME)
 
 
 class TestEndToEnd:
@@ -95,6 +99,7 @@ class TestEndToEnd:
         my_dataset = aiplatform.Dataset.create(
             display_name=test_datasets._TEST_DISPLAY_NAME,
             metadata_schema_uri=test_datasets._TEST_METADATA_SCHEMA_URI_NONTABULAR,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
             sync=sync,
         )
 
@@ -130,7 +135,7 @@ class TestEndToEnd:
         )
 
         created_endpoint = models.Endpoint.create(
-            display_name=test_endpoints._TEST_DISPLAY_NAME, sync=sync
+            display_name=test_endpoints._TEST_DISPLAY_NAME, sync=sync,
         )
 
         my_endpoint = model_from_job.deploy(sync=sync)
@@ -163,6 +168,7 @@ class TestEndToEnd:
             display_name=test_datasets._TEST_DISPLAY_NAME,
             metadata_schema_uri=test_datasets._TEST_METADATA_SCHEMA_URI_NONTABULAR,
             metadata=test_datasets._TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         expected_import_config = ImportDataConfig(
@@ -294,6 +300,7 @@ class TestEndToEnd:
         my_dataset = aiplatform.Dataset.create(
             display_name=test_datasets._TEST_DISPLAY_NAME,
             metadata_schema_uri=test_datasets._TEST_METADATA_SCHEMA_URI_NONTABULAR,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
             sync=sync,
         )
 
@@ -348,6 +355,7 @@ class TestEndToEnd:
             display_name=test_datasets._TEST_DISPLAY_NAME,
             metadata_schema_uri=test_datasets._TEST_METADATA_SCHEMA_URI_NONTABULAR,
             metadata=test_datasets._TEST_NONTABULAR_DATASET_METADATA,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         expected_import_config = ImportDataConfig(

--- a/tests/unit/aiplatform/test_end_to_end.py
+++ b/tests/unit/aiplatform/test_end_to_end.py
@@ -28,7 +28,7 @@ from google.cloud.aiplatform import training_jobs
 from google.cloud.aiplatform_v1beta1 import GcsSource
 from google.cloud.aiplatform_v1beta1 import ImportDataConfig
 from google.cloud.aiplatform_v1beta1 import Dataset as GapicDataset
-from google.cloud.aiplatform_v1beta1.types import encryption_spec, io as gca_io
+from google.cloud.aiplatform_v1beta1.types import io as gca_io
 from google.cloud.aiplatform_v1beta1.types import model as gca_model
 from google.cloud.aiplatform_v1beta1.types import pipeline_state as gca_pipeline_state
 from google.cloud.aiplatform_v1beta1.types import (

--- a/tests/unit/aiplatform/test_end_to_end.py
+++ b/tests/unit/aiplatform/test_end_to_end.py
@@ -28,7 +28,7 @@ from google.cloud.aiplatform import training_jobs
 from google.cloud.aiplatform_v1beta1 import GcsSource
 from google.cloud.aiplatform_v1beta1 import ImportDataConfig
 from google.cloud.aiplatform_v1beta1 import Dataset as GapicDataset
-from google.cloud.aiplatform_v1beta1.types import io as gca_io
+from google.cloud.aiplatform_v1beta1.types import encryption_spec, io as gca_io
 from google.cloud.aiplatform_v1beta1.types import model as gca_model
 from google.cloud.aiplatform_v1beta1.types import pipeline_state as gca_pipeline_state
 from google.cloud.aiplatform_v1beta1.types import (
@@ -135,10 +135,14 @@ class TestEndToEnd:
         )
 
         created_endpoint = models.Endpoint.create(
-            display_name=test_endpoints._TEST_DISPLAY_NAME, sync=sync,
+            display_name=test_endpoints._TEST_DISPLAY_NAME,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            sync=sync,
         )
 
-        my_endpoint = model_from_job.deploy(sync=sync)
+        my_endpoint = model_from_job.deploy(
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME, sync=sync
+        )
 
         endpoint_deploy_return = created_endpoint.deploy(model_from_job, sync=sync)
 
@@ -295,12 +299,12 @@ class TestEndToEnd:
             project=test_datasets._TEST_PROJECT,
             staging_bucket=test_training_jobs._TEST_BUCKET_NAME,
             credentials=test_training_jobs._TEST_CREDENTIALS,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
         )
 
         my_dataset = aiplatform.Dataset.create(
             display_name=test_datasets._TEST_DISPLAY_NAME,
             metadata_schema_uri=test_datasets._TEST_METADATA_SCHEMA_URI_NONTABULAR,
-            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
             sync=sync,
         )
 
@@ -321,7 +325,7 @@ class TestEndToEnd:
         )
 
         created_endpoint = models.Endpoint.create(
-            display_name=test_endpoints._TEST_DISPLAY_NAME, sync=sync
+            display_name=test_endpoints._TEST_DISPLAY_NAME, sync=sync,
         )
 
         model_from_job = job.run(
@@ -415,6 +419,7 @@ class TestEndToEnd:
         true_managed_model = gca_model.Model(
             display_name=test_training_jobs._TEST_MODEL_DISPLAY_NAME,
             container_spec=true_container_spec,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
@@ -439,6 +444,7 @@ class TestEndToEnd:
             ),
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create_and_get_with_fail[0].assert_called_once_with(

--- a/tests/unit/aiplatform/test_endpoints.py
+++ b/tests/unit/aiplatform/test_endpoints.py
@@ -40,7 +40,7 @@ from google.cloud.aiplatform_v1beta1.types import model as gca_model
 from google.cloud.aiplatform_v1beta1.types import machine_resources
 from google.cloud.aiplatform_v1beta1.types import prediction_service
 from google.cloud.aiplatform_v1beta1.types import endpoint_service
-from google.cloud.aiplatform_v1beta1.types import EncryptionSpec
+from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 
 _TEST_PROJECT = "test-project"
 _TEST_PROJECT_2 = "test-project-2"
@@ -111,9 +111,11 @@ _TEST_EXPLANATION_PARAMETERS = aiplatform.explain.ExplanationParameters(
     {"sampled_shapley_attribution": {"path_count": 10}}
 )
 
-# dataset_encryption
+# CMEK encryption
 _TEST_ENCRYPTION_KEY_NAME = "key_1234"
-_TEST_ENCRYPTION_SPEC = EncryptionSpec(kms_key_name=_TEST_ENCRYPTION_KEY_NAME)
+_TEST_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_ENCRYPTION_KEY_NAME
+)
 
 
 @pytest.fixture

--- a/tests/unit/aiplatform/test_endpoints.py
+++ b/tests/unit/aiplatform/test_endpoints.py
@@ -40,6 +40,7 @@ from google.cloud.aiplatform_v1beta1.types import model as gca_model
 from google.cloud.aiplatform_v1beta1.types import machine_resources
 from google.cloud.aiplatform_v1beta1.types import prediction_service
 from google.cloud.aiplatform_v1beta1.types import endpoint_service
+from google.cloud.aiplatform_v1beta1.types import EncryptionSpec
 
 _TEST_PROJECT = "test-project"
 _TEST_PROJECT_2 = "test-project-2"
@@ -110,12 +111,18 @@ _TEST_EXPLANATION_PARAMETERS = aiplatform.explain.ExplanationParameters(
     {"sampled_shapley_attribution": {"path_count": 10}}
 )
 
+# dataset_encryption
+_TEST_ENCRYPTION_KEY_NAME = "key_1234"
+_TEST_ENCRYPTION_SPEC = EncryptionSpec(kms_key_name=_TEST_ENCRYPTION_KEY_NAME)
+
 
 @pytest.fixture
 def get_endpoint_mock():
     with mock.patch.object(EndpointServiceClient, "get_endpoint") as get_endpoint_mock:
         get_endpoint_mock.return_value = gca_endpoint.Endpoint(
-            display_name=_TEST_DISPLAY_NAME, name=_TEST_ENDPOINT_NAME,
+            display_name=_TEST_DISPLAY_NAME,
+            name=_TEST_ENDPOINT_NAME,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
         yield get_endpoint_mock
 
@@ -335,14 +342,45 @@ class TestEndpoint:
 
     @pytest.mark.usefixtures("get_endpoint_mock")
     @pytest.mark.parametrize("sync", [True, False])
-    def test_create(self, create_endpoint_mock, sync):
-        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
+    def test_init_aiplatform_with_encryption_key_name_and_create_endpoint(
+        self, create_endpoint_mock, sync
+    ):
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            location=_TEST_LOCATION,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+        )
         my_endpoint = models.Endpoint.create(display_name=_TEST_DISPLAY_NAME, sync=sync)
 
         if not sync:
             my_endpoint.wait()
 
-        expected_endpoint = gca_endpoint.Endpoint(display_name=_TEST_DISPLAY_NAME)
+        expected_endpoint = gca_endpoint.Endpoint(
+            display_name=_TEST_DISPLAY_NAME, encryption_spec=_TEST_ENCRYPTION_SPEC
+        )
+        create_endpoint_mock.assert_called_once_with(
+            parent=_TEST_PARENT, endpoint=expected_endpoint, metadata=(),
+        )
+
+        expected_endpoint.name = _TEST_ENDPOINT_NAME
+        assert my_endpoint._gca_resource == expected_endpoint
+
+    @pytest.mark.usefixtures("get_endpoint_mock")
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_create(self, create_endpoint_mock, sync):
+        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
+        my_endpoint = models.Endpoint.create(
+            display_name=_TEST_DISPLAY_NAME,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            sync=sync,
+        )
+
+        if not sync:
+            my_endpoint.wait()
+
+        expected_endpoint = gca_endpoint.Endpoint(
+            display_name=_TEST_DISPLAY_NAME, encryption_spec=_TEST_ENCRYPTION_SPEC
+        )
         create_endpoint_mock.assert_called_once_with(
             parent=_TEST_PARENT, endpoint=expected_endpoint, metadata=(),
         )

--- a/tests/unit/aiplatform/test_models.py
+++ b/tests/unit/aiplatform/test_models.py
@@ -558,7 +558,7 @@ class TestModel:
         test_model = models.Model(_TEST_ID)
         test_endpoint = models.Endpoint(_TEST_ID)
 
-        assert test_model.deploy(test_endpoint, sync=sync) == test_endpoint
+        assert test_model.deploy(test_endpoint, sync=sync,) == test_endpoint
 
         if not sync:
             test_endpoint.wait()

--- a/tests/unit/aiplatform/test_models.py
+++ b/tests/unit/aiplatform/test_models.py
@@ -39,6 +39,7 @@ from google.cloud.aiplatform_v1beta1.types import endpoint as gca_endpoint
 from google.cloud.aiplatform_v1beta1.types import machine_resources
 from google.cloud.aiplatform_v1beta1.types import model_service
 from google.cloud.aiplatform_v1beta1.types import endpoint_service
+from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 
 from test_endpoints import create_endpoint_mock  # noqa: F401
 
@@ -103,6 +104,12 @@ _TEST_EXPLANATION_METADATA = aiplatform.explain.ExplanationMetadata(
 )
 _TEST_EXPLANATION_PARAMETERS = aiplatform.explain.ExplanationParameters(
     {"sampled_shapley_attribution": {"path_count": 10}}
+)
+
+# CMEK encryption
+_TEST_ENCRYPTION_KEY_NAME = "key_1234"
+_TEST_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_ENCRYPTION_KEY_NAME
 )
 
 
@@ -698,10 +705,61 @@ class TestModel:
 
     @pytest.mark.parametrize("sync", [True, False])
     @pytest.mark.usefixtures("get_model_mock", "get_batch_prediction_job_mock")
+    def test_init_aiplatform_with_encryption_key_name_and_batch_predict_gcs_source_and_dest(
+        self, create_batch_prediction_job_mock, sync
+    ):
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            location=_TEST_LOCATION,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+        )
+        test_model = models.Model(_TEST_ID)
+
+        # Make SDK batch_predict method call
+        batch_prediction_job = test_model.batch_predict(
+            job_display_name=_TEST_BATCH_PREDICTION_DISPLAY_NAME,
+            gcs_source=_TEST_BATCH_PREDICTION_GCS_SOURCE,
+            gcs_destination_prefix=_TEST_BATCH_PREDICTION_GCS_DEST_PREFIX,
+            sync=sync,
+        )
+
+        if not sync:
+            batch_prediction_job.wait()
+
+        # Construct expected request
+        expected_gapic_batch_prediction_job = gapic_types.BatchPredictionJob(
+            display_name=_TEST_BATCH_PREDICTION_DISPLAY_NAME,
+            model=ModelServiceClient.model_path(
+                _TEST_PROJECT, _TEST_LOCATION, _TEST_ID
+            ),
+            input_config=gapic_types.BatchPredictionJob.InputConfig(
+                instances_format="jsonl",
+                gcs_source=gapic_types.GcsSource(
+                    uris=[_TEST_BATCH_PREDICTION_GCS_SOURCE]
+                ),
+            ),
+            output_config=gapic_types.BatchPredictionJob.OutputConfig(
+                gcs_destination=gapic_types.GcsDestination(
+                    output_uri_prefix=_TEST_BATCH_PREDICTION_GCS_DEST_PREFIX
+                ),
+                predictions_format="jsonl",
+            ),
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
+        )
+
+        create_batch_prediction_job_mock.assert_called_once_with(
+            parent=_TEST_PARENT,
+            batch_prediction_job=expected_gapic_batch_prediction_job,
+        )
+
+    @pytest.mark.parametrize("sync", [True, False])
+    @pytest.mark.usefixtures("get_model_mock", "get_batch_prediction_job_mock")
     def test_batch_predict_gcs_source_and_dest(
         self, create_batch_prediction_job_mock, sync
     ):
-        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
+        aiplatform.init(
+            project=_TEST_PROJECT, location=_TEST_LOCATION,
+        )
         test_model = models.Model(_TEST_ID)
 
         # Make SDK batch_predict method call
@@ -808,6 +866,7 @@ class TestModel:
             explanation_parameters=_TEST_EXPLANATION_PARAMETERS,
             labels=_TEST_LABEL,
             credentials=creds,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
             sync=sync,
         )
 
@@ -847,6 +906,7 @@ class TestModel:
                 parameters=_TEST_EXPLANATION_PARAMETERS,
             ),
             labels=_TEST_LABEL,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         create_batch_prediction_job_mock.assert_called_once_with(

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -41,13 +41,14 @@ from google.cloud.aiplatform_v1beta1.services.model_service import (
 from google.cloud.aiplatform_v1beta1.services.pipeline_service import (
     client as pipeline_service_client,
 )
-from google.cloud.aiplatform_v1beta1.types import io as gca_io
+from google.cloud.aiplatform_v1beta1.types import encryption_spec, io as gca_io
 from google.cloud.aiplatform_v1beta1.types import env_var
 from google.cloud.aiplatform_v1beta1.types import model as gca_model
 from google.cloud.aiplatform_v1beta1.types import pipeline_state as gca_pipeline_state
 from google.cloud.aiplatform_v1beta1.types import (
     training_pipeline as gca_training_pipeline,
 )
+from google.cloud.aiplatform_v1beta1.types import encryption_spec as gca_encryption_spec
 from google.cloud.aiplatform_v1beta1 import Dataset as GapicDataset
 
 from google.cloud import storage
@@ -125,6 +126,12 @@ _TEST_PIPELINE_RESOURCE_NAME = (
     "projects/my-project/locations/us-central1/trainingPipeline/12345"
 )
 _TEST_CREDENTIALS = mock.Mock(spec=auth_credentials.AnonymousCredentials())
+
+# CMEK encryption
+_TEST_ENCRYPTION_KEY_NAME = "key_1234"
+_TEST_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_ENCRYPTION_KEY_NAME
+)
 
 
 def local_copy_method(path):
@@ -521,6 +528,7 @@ class TestCustomTrainingJob:
             project=_TEST_PROJECT,
             staging_bucket=_TEST_BUCKET_NAME,
             credentials=_TEST_CREDENTIALS,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
         )
 
         job = training_jobs.CustomTrainingJob(
@@ -642,6 +650,7 @@ class TestCustomTrainingJob:
             ),
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -670,7 +679,9 @@ class TestCustomTrainingJob:
         mock_model_service_get,
         sync,
     ):
-        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+        aiplatform.init(
+            project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME,
+        )
 
         job = training_jobs.CustomTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
@@ -687,6 +698,7 @@ class TestCustomTrainingJob:
             model_serving_container_environment_variables=_TEST_MODEL_SERVING_CONTAINER_ENVIRONMENT_VARIABLES,
             model_serving_container_ports=_TEST_MODEL_SERVING_CONTAINER_PORTS,
             model_description=_TEST_MODEL_DESCRIPTION,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
         )
 
         model_from_job = job.run(
@@ -786,6 +798,7 @@ class TestCustomTrainingJob:
             ),
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -1597,7 +1610,11 @@ class TestCustomContainerTrainingJob:
         mock_model_service_get,
         sync,
     ):
-        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+        aiplatform.init(
+            project=_TEST_PROJECT,            
+            staging_bucket=_TEST_BUCKET_NAME,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+        )
 
         job = training_jobs.CustomContainerTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
@@ -1711,6 +1728,7 @@ class TestCustomContainerTrainingJob:
             ),
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -1755,6 +1773,7 @@ class TestCustomContainerTrainingJob:
             model_serving_container_environment_variables=_TEST_MODEL_SERVING_CONTAINER_ENVIRONMENT_VARIABLES,
             model_serving_container_ports=_TEST_MODEL_SERVING_CONTAINER_PORTS,
             model_description=_TEST_MODEL_DESCRIPTION,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
         )
 
         model_from_job = job.run(
@@ -1853,6 +1872,7 @@ class TestCustomContainerTrainingJob:
             ),
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -2778,7 +2798,11 @@ class TestCustomPythonPackageTrainingJob:
         mock_model_service_get,
         sync,
     ):
-        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            staging_bucket=_TEST_BUCKET_NAME,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+        )
 
         job = training_jobs.CustomPythonPackageTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
@@ -2894,6 +2918,7 @@ class TestCustomPythonPackageTrainingJob:
             ),
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -2939,6 +2964,7 @@ class TestCustomPythonPackageTrainingJob:
             model_instance_schema_uri=_TEST_MODEL_INSTANCE_SCHEMA_URI,
             model_parameters_schema_uri=_TEST_MODEL_PARAMETERS_SCHEMA_URI,
             model_prediction_schema_uri=_TEST_MODEL_PREDICTION_SCHEMA_URI,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
         )
 
         model_from_job = job.run(
@@ -3038,6 +3064,7 @@ class TestCustomPythonPackageTrainingJob:
             ),
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -41,7 +41,8 @@ from google.cloud.aiplatform_v1beta1.services.model_service import (
 from google.cloud.aiplatform_v1beta1.services.pipeline_service import (
     client as pipeline_service_client,
 )
-from google.cloud.aiplatform_v1beta1.types import encryption_spec, io as gca_io
+
+from google.cloud.aiplatform_v1beta1.types import io as gca_io
 from google.cloud.aiplatform_v1beta1.types import env_var
 from google.cloud.aiplatform_v1beta1.types import model as gca_model
 from google.cloud.aiplatform_v1beta1.types import pipeline_state as gca_pipeline_state

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -710,7 +710,7 @@ class TestCustomTrainingJob:
             model_serving_container_environment_variables=_TEST_MODEL_SERVING_CONTAINER_ENVIRONMENT_VARIABLES,
             model_serving_container_ports=_TEST_MODEL_SERVING_CONTAINER_PORTS,
             model_description=_TEST_MODEL_DESCRIPTION,
-            training_pipeline_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
+            training_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
             model_encryption_spec_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME,
         )
 
@@ -1788,7 +1788,7 @@ class TestCustomContainerTrainingJob:
             model_serving_container_environment_variables=_TEST_MODEL_SERVING_CONTAINER_ENVIRONMENT_VARIABLES,
             model_serving_container_ports=_TEST_MODEL_SERVING_CONTAINER_PORTS,
             model_description=_TEST_MODEL_DESCRIPTION,
-            training_pipeline_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
+            training_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
             model_encryption_spec_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME,
         )
 
@@ -2982,7 +2982,7 @@ class TestCustomPythonPackageTrainingJob:
             model_instance_schema_uri=_TEST_MODEL_INSTANCE_SCHEMA_URI,
             model_parameters_schema_uri=_TEST_MODEL_PARAMETERS_SCHEMA_URI,
             model_prediction_schema_uri=_TEST_MODEL_PREDICTION_SCHEMA_URI,
-            training_pipeline_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
+            training_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
             model_encryption_spec_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME,
         )
 

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -128,9 +128,19 @@ _TEST_PIPELINE_RESOURCE_NAME = (
 _TEST_CREDENTIALS = mock.Mock(spec=auth_credentials.AnonymousCredentials())
 
 # CMEK encryption
-_TEST_ENCRYPTION_KEY_NAME = "key_1234"
-_TEST_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
-    kms_key_name=_TEST_ENCRYPTION_KEY_NAME
+_TEST_DEFAULT_ENCRYPTION_KEY_NAME = "key_default"
+_TEST_DEFAULT_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME
+)
+
+_TEST_PIPELINE_ENCRYPTION_KEY_NAME = "key_pipeline"
+_TEST_PIPELINE_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME
+)
+
+_TEST_MODEL_ENCRYPTION_KEY_NAME = "key_model"
+_TEST_MODEL_ENCRYPTION_SPEC = gca_encryption_spec.EncryptionSpec(
+    kms_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME
 )
 
 
@@ -528,7 +538,7 @@ class TestCustomTrainingJob:
             project=_TEST_PROJECT,
             staging_bucket=_TEST_BUCKET_NAME,
             credentials=_TEST_CREDENTIALS,
-            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
         )
 
         job = training_jobs.CustomTrainingJob(
@@ -625,6 +635,7 @@ class TestCustomTrainingJob:
                 parameters_schema_uri=_TEST_MODEL_PARAMETERS_SCHEMA_URI,
                 prediction_schema_uri=_TEST_MODEL_PREDICTION_SCHEMA_URI,
             ),
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
@@ -650,7 +661,7 @@ class TestCustomTrainingJob:
             ),
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
-            encryption_spec=_TEST_ENCRYPTION_SPEC,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -698,7 +709,8 @@ class TestCustomTrainingJob:
             model_serving_container_environment_variables=_TEST_MODEL_SERVING_CONTAINER_ENVIRONMENT_VARIABLES,
             model_serving_container_ports=_TEST_MODEL_SERVING_CONTAINER_PORTS,
             model_description=_TEST_MODEL_DESCRIPTION,
-            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            training_pipeline_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
+            model_encryption_spec_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME,
         )
 
         model_from_job = job.run(
@@ -773,6 +785,7 @@ class TestCustomTrainingJob:
                 parameters_schema_uri=_TEST_MODEL_PARAMETERS_SCHEMA_URI,
                 prediction_schema_uri=_TEST_MODEL_PREDICTION_SCHEMA_URI,
             ),
+            encryption_spec=_TEST_MODEL_ENCRYPTION_SPEC,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
@@ -798,7 +811,7 @@ class TestCustomTrainingJob:
             ),
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
-            encryption_spec=_TEST_ENCRYPTION_SPEC,
+            encryption_spec=_TEST_PIPELINE_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -1611,9 +1624,9 @@ class TestCustomContainerTrainingJob:
         sync,
     ):
         aiplatform.init(
-            project=_TEST_PROJECT,            
+            project=_TEST_PROJECT,
             staging_bucket=_TEST_BUCKET_NAME,
-            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
         )
 
         job = training_jobs.CustomContainerTrainingJob(
@@ -1703,6 +1716,7 @@ class TestCustomContainerTrainingJob:
                 parameters_schema_uri=_TEST_MODEL_PARAMETERS_SCHEMA_URI,
                 prediction_schema_uri=_TEST_MODEL_PREDICTION_SCHEMA_URI,
             ),
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
@@ -1728,7 +1742,7 @@ class TestCustomContainerTrainingJob:
             ),
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
-            encryption_spec=_TEST_ENCRYPTION_SPEC,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -1773,7 +1787,8 @@ class TestCustomContainerTrainingJob:
             model_serving_container_environment_variables=_TEST_MODEL_SERVING_CONTAINER_ENVIRONMENT_VARIABLES,
             model_serving_container_ports=_TEST_MODEL_SERVING_CONTAINER_PORTS,
             model_description=_TEST_MODEL_DESCRIPTION,
-            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            training_pipeline_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
+            model_encryption_spec_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME,
         )
 
         model_from_job = job.run(
@@ -1847,6 +1862,7 @@ class TestCustomContainerTrainingJob:
                 parameters_schema_uri=_TEST_MODEL_PARAMETERS_SCHEMA_URI,
                 prediction_schema_uri=_TEST_MODEL_PREDICTION_SCHEMA_URI,
             ),
+            encryption_spec=_TEST_MODEL_ENCRYPTION_SPEC,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
@@ -1872,7 +1888,7 @@ class TestCustomContainerTrainingJob:
             ),
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
-            encryption_spec=_TEST_ENCRYPTION_SPEC,
+            encryption_spec=_TEST_PIPELINE_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -2801,7 +2817,7 @@ class TestCustomPythonPackageTrainingJob:
         aiplatform.init(
             project=_TEST_PROJECT,
             staging_bucket=_TEST_BUCKET_NAME,
-            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
         )
 
         job = training_jobs.CustomPythonPackageTrainingJob(
@@ -2893,6 +2909,7 @@ class TestCustomPythonPackageTrainingJob:
                 parameters_schema_uri=_TEST_MODEL_PARAMETERS_SCHEMA_URI,
                 prediction_schema_uri=_TEST_MODEL_PREDICTION_SCHEMA_URI,
             ),
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
@@ -2918,7 +2935,7 @@ class TestCustomPythonPackageTrainingJob:
             ),
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
-            encryption_spec=_TEST_ENCRYPTION_SPEC,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -2964,7 +2981,8 @@ class TestCustomPythonPackageTrainingJob:
             model_instance_schema_uri=_TEST_MODEL_INSTANCE_SCHEMA_URI,
             model_parameters_schema_uri=_TEST_MODEL_PARAMETERS_SCHEMA_URI,
             model_prediction_schema_uri=_TEST_MODEL_PREDICTION_SCHEMA_URI,
-            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            training_pipeline_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
+            model_encryption_spec_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME,
         )
 
         model_from_job = job.run(
@@ -3039,6 +3057,7 @@ class TestCustomPythonPackageTrainingJob:
                 parameters_schema_uri=_TEST_MODEL_PARAMETERS_SCHEMA_URI,
                 prediction_schema_uri=_TEST_MODEL_PREDICTION_SCHEMA_URI,
             ),
+            encryption_spec=_TEST_MODEL_ENCRYPTION_SPEC,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
@@ -3064,7 +3083,7 @@ class TestCustomPythonPackageTrainingJob:
             ),
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
-            encryption_spec=_TEST_ENCRYPTION_SPEC,
+            encryption_spec=_TEST_PIPELINE_ENCRYPTION_SPEC,
         )
 
         mock_pipeline_service_create.assert_called_once_with(


### PR DESCRIPTION
The encryption key can be passed into aiplatform.init which will be applied to all applicable resources:

```
aiplatform.init(
            project=_TEST_PROJECT,
            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
        )
```

Alternatively, it can be passed directly into the resource itself on creation. This will override the aiplatform default.

1. Added CMEK support to:
- [x] Dataset
- [x] ImageDataset
- [x] TabularDataset
- [x] TextDataset
- [x] VideoDataset
- [x] Endpoint
- [x] Batch Prediction Job
- [x] Model
- [x] Training Pipeline
- [x] _TrainingJob
- [x] _CustomTrainingJob
- [x] CustomPythonPackageTrainingJob
- [x] CustomContainerTrainingJob
- [x] CustomTrainingJob
- [x] AutoMLTabularTrainingJob
- [x] AutoMLImageTrainingJob
- [x] AutoMLTextTrainingJob

2. Added tests:
- [x] Dataset
- [x] ImageDataset
- [x] TabularDataset
- [x] TextDataset
- [x] VideoDataset
- [x] Endpoint
- [x] Batch Prediction Job
- [x] Model
- [x] Training Pipeline
- [x] _TrainingJob
- [x] _CustomTrainingJob
- [x] CustomPythonPackageTrainingJob
- [x] CustomContainerTrainingJob
- [x] CustomTrainingJob
- [x] AutoMLTabularTrainingJob
- [x] AutoMLImageTrainingJob
- [x] AutoMLTextTrainingJob

Currently Unused:
- [ ] Custom Job
- [ ] Hyper-parameter Tuning

Fixes [b/178500930](https://b.corp.google.com/issues/178500930)
