### PR TITLE
fix: Fixed exception when the python executable path has a space in it

### DIFF
--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -832,9 +832,7 @@ setup(
     description='My training application.'
 )"""
 
-    _SETUP_PY_SOURCE_DISTRIBUTION_CMD = (
-        "{python_executable} setup.py sdist --formats=gztar"
-    )
+    _SETUP_PY_SOURCE_DISTRIBUTION_CMD = "setup.py sdist --formats=gztar"
 
     # Module name that can be executed during training. ie. python -m
     module_name = f"{_ROOT_MODULE}.{_TASK_MODULE_NAME}"
@@ -908,9 +906,9 @@ setup(
         shutil.copy(self.script_path, script_out_path)
 
         # Run setup.py to create the source distribution.
-        setup_cmd = self._SETUP_PY_SOURCE_DISTRIBUTION_CMD.format(
-            python_executable=_get_python_executable()
-        ).split()
+        setup_cmd = [
+            _get_python_executable()
+        ] + self._SETUP_PY_SOURCE_DISTRIBUTION_CMD.split()
 
         p = subprocess.Popen(
             args=setup_cmd,


### PR DESCRIPTION
In lines (line 768-778) in training_jobs.py:
```
# Run setup.py to create the source distribution.
setup_cmd = self._SETUP_PY_SOURCE_DISTRIBUTION_CMD.format(
    python_executable=_get_python_executable()
).split()

p = subprocess.Popen(
    args=setup_cmd,
    cwd=trainer_root_path,
    stdout=subprocess.PIPE,
    stderr=subprocess.PIPE,
)
```

If your python executable path has spaces in it, you get an exception:

`FileNotFoundError: [Errno 2] No such file or directory: '/Volumes/GoogleDrive/Shared'`

which is the part of your executable path before the first space.

This fixes avoids combining the executable and args together, which fixes the problem.
