### PR TITLE
Feat: parse project location when passed full resource name to get apis

### DIFF
--- a/google/cloud/aiplatform/datasets/dataset.py
+++ b/google/cloud/aiplatform/datasets/dataset.py
@@ -71,7 +71,10 @@ class Dataset(base.AiPlatformResourceNounWithFutureManager):
         """
 
         super().__init__(
-            project=project, location=location, credentials=credentials,
+            project=project,
+            location=location,
+            credentials=credentials,
+            resource_name=dataset_name,
         )
         self._gca_resource = self._get_gca_resource(resource_name=dataset_name)
         self._validate_metadata_schema_uri()

--- a/google/cloud/aiplatform/jobs.py
+++ b/google/cloud/aiplatform/jobs.py
@@ -107,7 +107,12 @@ class _Job(base.AiPlatformResourceNounWithFutureManager):
                 Custom credentials to use. If not set, credentials set in
                 aiplatform.init will be used.
         """
-        super().__init__(project=project, location=location, credentials=credentials)
+        super().__init__(
+            project=project,
+            location=location,
+            credentials=credentials,
+            resource_name=job_name,
+        )
         self._gca_resource = self._get_gca_resource(resource_name=job_name)
 
     @property

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -99,7 +99,12 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
                 credentials set in aiplatform.init.
         """
 
-        super().__init__(project=project, location=location, credentials=credentials)
+        super().__init__(
+            project=project,
+            location=location,
+            credentials=credentials,
+            resource_name=endpoint_name,
+        )
         self._gca_resource = self._get_gca_resource(resource_name=endpoint_name)
         self._prediction_client = self._instantiate_prediction_client(
             location=location or initializer.global_config.location,
@@ -1144,7 +1149,12 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
                 credentials set in aiplatform.init will be used.
         """
 
-        super().__init__(project=project, location=location, credentials=credentials)
+        super().__init__(
+            project=project,
+            location=location,
+            credentials=credentials,
+            resource_name=model_name,
+        )
         self._gca_resource = self._get_gca_resource(resource_name=model_name)
 
     # TODO(b/170979552) Add support for predict schemata

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -180,7 +180,10 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
         # These parameters won't be used as user can not run the job again.
         # If they try, an exception will be raised.
         self = cls._empty_constructor(
-            project=project, location=location, credentials=credentials
+            project=project,
+            location=location,
+            credentials=credentials,
+            resource_name=resource_name,
         )
 
         self._gca_resource = self._get_gca_resource(resource_name=resource_name)

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -48,6 +48,7 @@ from google.cloud.aiplatform_v1.types import (
 _TEST_PROJECT = "test-project"
 _TEST_LOCATION = "us-central1"
 _TEST_PARENT = f"projects/{_TEST_PROJECT}/locations/{_TEST_LOCATION}"
+_TEST_ALT_PROJECT = "test-project_alt"
 
 _TEST_ALT_LOCATION = "europe-west4"
 _TEST_INVALID_LOCATION = "us-central2"
@@ -258,6 +259,38 @@ class TestDataset:
         aiplatform.init(project=_TEST_PROJECT)
         datasets.Dataset(dataset_name=_TEST_NAME)
         get_dataset_mock.assert_called_once_with(name=_TEST_NAME)
+
+    def test_init_dataset_with_id_only_with_project_and_location(
+        self, get_dataset_mock
+    ):
+        aiplatform.init(project=_TEST_PROJECT)
+        datasets.Dataset(
+            dataset_name=_TEST_ID, project=_TEST_PROJECT, location=_TEST_LOCATION
+        )
+        get_dataset_mock.assert_called_once_with(name=_TEST_NAME)
+
+    def test_init_dataset_with_project_and_location(self, get_dataset_mock):
+        aiplatform.init(project=_TEST_PROJECT)
+        datasets.Dataset(
+            dataset_name=_TEST_NAME, project=_TEST_PROJECT, location=_TEST_LOCATION
+        )
+        get_dataset_mock.assert_called_once_with(name=_TEST_NAME)
+
+    def test_init_dataset_with_alt_project_and_location(self, get_dataset_mock):
+        aiplatform.init(project=_TEST_PROJECT)
+        datasets.Dataset(
+            dataset_name=_TEST_NAME, project=_TEST_ALT_PROJECT, location=_TEST_LOCATION
+        )
+        get_dataset_mock.assert_called_once_with(name=_TEST_NAME)
+
+    def test_init_dataset_with_project_and_alt_location(self):
+        aiplatform.init(project=_TEST_PROJECT)
+        with pytest.raises(RuntimeError):
+            datasets.Dataset(
+                dataset_name=_TEST_NAME,
+                project=_TEST_PROJECT,
+                location=_TEST_ALT_LOCATION,
+            )
 
     def test_init_dataset_with_id_only(self, get_dataset_mock):
         aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -65,7 +65,6 @@ _TEST_GCS_PATH = f"{_TEST_BUCKET_NAME}/{_TEST_GCS_PATH_WITHOUT_BUCKET}"
 _TEST_GCS_PATH_WITH_TRAILING_SLASH = f"{_TEST_GCS_PATH}/"
 _TEST_LOCAL_SCRIPT_FILE_NAME = "____test____script.py"
 _TEST_LOCAL_SCRIPT_FILE_PATH = f"path/to/{_TEST_LOCAL_SCRIPT_FILE_NAME}"
-_TEST_PROJECT = "test-project"
 _TEST_PYTHON_SOURCE = """
 print('hello world')
 """
@@ -107,6 +106,8 @@ _TEST_ID = "12345"
 _TEST_NAME = (
     f"projects/{_TEST_PROJECT}/locations/{_TEST_LOCATION}/trainingPipelines/{_TEST_ID}"
 )
+_TEST_ALT_PROJECT = "test-project-alt"
+_TEST_ALT_LOCATION = "europe-west4"
 
 _TEST_MODEL_INSTANCE_SCHEMA_URI = "instance_schema_uri.yaml"
 _TEST_MODEL_PARAMETERS_SCHEMA_URI = "parameters_schema_uri.yaml"
@@ -1380,6 +1381,42 @@ class TestCustomTrainingJob:
         aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
         training_jobs.CustomTrainingJob.get(resource_name=_TEST_ID)
         get_training_job_custom_mock.assert_called_once_with(name=_TEST_NAME)
+
+    def test_get_training_job_with_id_only_with_project_and_location(
+        self, get_training_job_custom_mock
+    ):
+        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
+        training_jobs.CustomTrainingJob.get(
+            resource_name=_TEST_ID, project=_TEST_PROJECT, location=_TEST_LOCATION
+        )
+        get_training_job_custom_mock.assert_called_once_with(name=_TEST_NAME)
+
+    def test_get_training_job_with_project_and_location(
+        self, get_training_job_custom_mock
+    ):
+        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
+        training_jobs.CustomTrainingJob.get(
+            resource_name=_TEST_NAME, project=_TEST_PROJECT, location=_TEST_LOCATION
+        )
+        get_training_job_custom_mock.assert_called_once_with(name=_TEST_NAME)
+
+    def test_get_training_job_with_alt_project_and_location(
+        self, get_training_job_custom_mock
+    ):
+        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
+        training_jobs.CustomTrainingJob.get(
+            resource_name=_TEST_NAME, project=_TEST_ALT_PROJECT, location=_TEST_LOCATION
+        )
+        get_training_job_custom_mock.assert_called_once_with(name=_TEST_NAME)
+
+    def test_get_training_job_with_project_and_alt_location(self):
+        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
+        with pytest.raises(RuntimeError):
+            training_jobs.CustomTrainingJob.get(
+                resource_name=_TEST_NAME,
+                project=_TEST_PROJECT,
+                location=_TEST_ALT_LOCATION,
+            )
 
     @pytest.mark.parametrize("sync", [True, False])
     def test_run_call_pipeline_service_create_with_nontabular_dataset(


### PR DESCRIPTION
- [x] add __get_and_validate_project_location_ for resource_name in **AiPlatformResourceNoun** in _base.py_
- [x] pass in resource_name for AiPlatformResourceNoun subclasses.

_unit tests:_
- [x] add tests through **dataset.Dataset**
- [x] add tests through **training_jobs.CustomTrainingJob.get**

Fixes <[b/180923329](https://b.corp.google.com/issues/180923329)> 
