### PR TITLE
chore: Remove hard sample test requirement

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -9,4 +9,3 @@ branchProtectionRules:
     - 'Kokoro'
     - 'cla/google'
     - 'Samples - Lint'
-    - 'Samples - Python 3.7'


### PR DESCRIPTION
Temporarily removing hard requirement to have all sample tests passing to merge to `master` until after AI Platform (Unified) GA.
