### PR TITLE
fix: Bump google-cloud-storage min version to 1.32.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setuptools.setup(
     install_requires=(
         "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
         "proto-plus >= 1.10.1",
-        "google-cloud-storage >= 1.26.0, < 2.0.0dev",
+        "google-cloud-storage >= 1.32.0, < 2.0.0dev",
         "google-cloud-bigquery >= 1.15.0, < 3.0.0dev",
     ),
     python_requires=">=3.6",

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -9,4 +9,4 @@ google-api-core==1.22.2
 libcst==0.2.5
 proto-plus==1.10.1
 mock==4.0.2
-google-cloud-storage==1.26.0
+google-cloud-storage==1.32.0


### PR DESCRIPTION
This PR (https://github.com/googleapis/python-aiplatform/pull/357) introduced a mock that uses google.cloud.storage.blob.Blob.download_as_bytes.

This method was introduced in 1.32.0.