### PR TITLE
feat: Add VPC Peering support to CustomTrainingJob classes

### DIFF
--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -1526,6 +1526,7 @@ class _CustomTrainingJob(_TrainingJob):
         worker_pool_specs: _DistributedTrainingSpec,
         base_output_dir: Optional[str] = None,
         service_account: Optional[str] = None,
+        network: Optional[str] = None,
     ) -> Tuple[Dict, str]:
         """Prepares training task inputs and output directory for custom job.
 
@@ -1538,6 +1539,11 @@ class _CustomTrainingJob(_TrainingJob):
             service_account (str):
                 Specifies the service account for workload run-as account.
                 Users submitting jobs must have act-as permission on this run-as account.
+            network (str):
+                The full name of the Compute Engine network to which the job
+                should be peered. For example, projects/12345/global/networks/myVPC.
+                Private services access must already be configured for the network.
+                If left unspecified, the job is not peered with any network.
         Returns:
             Training task inputs and Output directory for custom job.
         """
@@ -1556,6 +1562,8 @@ class _CustomTrainingJob(_TrainingJob):
 
         if service_account:
             training_task_inputs["serviceAccount"] = service_account
+        if network:
+            training_task_inputs["network"] = network
 
         return training_task_inputs, base_output_dir
 
@@ -1803,6 +1811,7 @@ class CustomTrainingJob(_CustomTrainingJob):
         model_display_name: Optional[str] = None,
         base_output_dir: Optional[str] = None,
         service_account: Optional[str] = None,
+        network: Optional[str] = None,
         bigquery_destination: Optional[str] = None,
         args: Optional[List[Union[str, float, int]]] = None,
         environment_variables: Optional[Dict[str, str]] = None,
@@ -1891,6 +1900,11 @@ class CustomTrainingJob(_CustomTrainingJob):
             service_account (str):
                 Specifies the service account for workload run-as account.
                 Users submitting jobs must have act-as permission on this run-as account.
+            network (str):
+                The full name of the Compute Engine network to which the job
+                should be peered. For example, projects/12345/global/networks/myVPC.
+                Private services access must already be configured for the network.
+                If left unspecified, the job is not peered with any network.
             bigquery_destination (str):
                 Provide this field if `dataset` is a BiqQuery dataset.
                 The BigQuery project location where the training data is to
@@ -1981,6 +1995,7 @@ class CustomTrainingJob(_CustomTrainingJob):
             environment_variables=environment_variables,
             base_output_dir=base_output_dir,
             service_account=service_account,
+            network=network,
             bigquery_destination=bigquery_destination,
             training_fraction_split=training_fraction_split,
             validation_fraction_split=validation_fraction_split,
@@ -2008,6 +2023,7 @@ class CustomTrainingJob(_CustomTrainingJob):
         environment_variables: Optional[Dict[str, str]] = None,
         base_output_dir: Optional[str] = None,
         service_account: Optional[str] = None,
+        network: Optional[str] = None,
         bigquery_destination: Optional[str] = None,
         training_fraction_split: float = 0.8,
         validation_fraction_split: float = 0.1,
@@ -2061,6 +2077,11 @@ class CustomTrainingJob(_CustomTrainingJob):
             service_account (str):
                 Specifies the service account for workload run-as account.
                 Users submitting jobs must have act-as permission on this run-as account.
+            network (str):
+                The full name of the Compute Engine network to which the job
+                should be peered. For example, projects/12345/global/networks/myVPC.
+                Private services access must already be configured for the network.
+                If left unspecified, the job is not peered with any network.
             bigquery_destination (str):
                 Provide this field if `dataset` is a BiqQuery dataset.
                 The BigQuery project location where the training data is to
@@ -2127,7 +2148,10 @@ class CustomTrainingJob(_CustomTrainingJob):
             training_task_inputs,
             base_output_dir,
         ) = self._prepare_training_task_inputs_and_output_dir(
-            worker_pool_specs, base_output_dir, service_account
+            worker_pool_specs=worker_pool_specs,
+            base_output_dir=base_output_dir,
+            service_account=service_account,
+            network=network
         )
 
         model = self._run_job(
@@ -2372,6 +2396,7 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
         model_display_name: Optional[str] = None,
         base_output_dir: Optional[str] = None,
         service_account: Optional[str] = None,
+        network: Optional[str] = None,
         bigquery_destination: Optional[str] = None,
         args: Optional[List[Union[str, float, int]]] = None,
         environment_variables: Optional[Dict[str, str]] = None,
@@ -2453,6 +2478,11 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
             service_account (str):
                 Specifies the service account for workload run-as account.
                 Users submitting jobs must have act-as permission on this run-as account.
+            network (str):
+                The full name of the Compute Engine network to which the job
+                should be peered. For example, projects/12345/global/networks/myVPC.
+                Private services access must already be configured for the network.
+                If left unspecified, the job is not peered with any network.
             bigquery_destination (str):
                 Provide this field if `dataset` is a BiqQuery dataset.
                 The BigQuery project location where the training data is to
@@ -2542,6 +2572,7 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
             environment_variables=environment_variables,
             base_output_dir=base_output_dir,
             service_account=service_account,
+            network=network,
             bigquery_destination=bigquery_destination,
             training_fraction_split=training_fraction_split,
             validation_fraction_split=validation_fraction_split,
@@ -2568,6 +2599,7 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
         environment_variables: Optional[Dict[str, str]] = None,
         base_output_dir: Optional[str] = None,
         service_account: Optional[str] = None,
+        network: Optional[str] = None,
         bigquery_destination: Optional[str] = None,
         training_fraction_split: float = 0.8,
         validation_fraction_split: float = 0.1,
@@ -2618,6 +2650,11 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
             service_account (str):
                 Specifies the service account for workload run-as account.
                 Users submitting jobs must have act-as permission on this run-as account.
+            network (str):
+                The full name of the Compute Engine network to which the job
+                should be peered. For example, projects/12345/global/networks/myVPC.
+                Private services access must already be configured for the network.
+                If left unspecified, the job is not peered with any network.
             bigquery_destination (str):
                 The BigQuery project location where the training data is to
                 be written to. In the given project a new dataset is created
@@ -2677,7 +2714,10 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
             training_task_inputs,
             base_output_dir,
         ) = self._prepare_training_task_inputs_and_output_dir(
-            worker_pool_specs, base_output_dir, service_account
+            worker_pool_specs=worker_pool_specs,
+            base_output_dir=base_output_dir,
+            service_account=service_account,
+            network=network
         )
 
         model = self._run_job(
@@ -3703,6 +3743,7 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
         model_display_name: Optional[str] = None,
         base_output_dir: Optional[str] = None,
         service_account: Optional[str] = None,
+        network: Optional[str] = None,
         bigquery_destination: Optional[str] = None,
         args: Optional[List[Union[str, float, int]]] = None,
         environment_variables: Optional[Dict[str, str]] = None,
@@ -3784,6 +3825,11 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
             service_account (str):
                 Specifies the service account for workload run-as account.
                 Users submitting jobs must have act-as permission on this run-as account.
+            network (str):
+                The full name of the Compute Engine network to which the job
+                should be peered. For example, projects/12345/global/networks/myVPC.
+                Private services access must already be configured for the network.
+                If left unspecified, the job is not peered with any network.
             bigquery_destination (str):
                 Provide this field if `dataset` is a BiqQuery dataset.
                 The BigQuery project location where the training data is to
@@ -3868,6 +3914,7 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
             environment_variables=environment_variables,
             base_output_dir=base_output_dir,
             service_account=service_account,
+            network=network,
             training_fraction_split=training_fraction_split,
             validation_fraction_split=validation_fraction_split,
             test_fraction_split=test_fraction_split,
@@ -3894,6 +3941,7 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
         environment_variables: Optional[Dict[str, str]] = None,
         base_output_dir: Optional[str] = None,
         service_account: Optional[str] = None,
+        network: Optional[str] = None,
         training_fraction_split: float = 0.8,
         validation_fraction_split: float = 0.1,
         test_fraction_split: float = 0.1,
@@ -3945,6 +3993,11 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
             service_account (str):
                 Specifies the service account for workload run-as account.
                 Users submitting jobs must have act-as permission on this run-as account.
+            network (str):
+                The full name of the Compute Engine network to which the job
+                should be peered. For example, projects/12345/global/networks/myVPC.
+                Private services access must already be configured for the network.
+                If left unspecified, the job is not peered with any network.
             training_fraction_split (float):
                 The fraction of the input data that is to be
                 used to train the Model.
@@ -3990,7 +4043,10 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
             training_task_inputs,
             base_output_dir,
         ) = self._prepare_training_task_inputs_and_output_dir(
-            worker_pool_specs, base_output_dir, service_account
+            worker_pool_specs=worker_pool_specs,
+            base_output_dir=base_output_dir,
+            service_account=service_account,
+            network=network,
         )
 
         model = self._run_job(

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -2151,7 +2151,7 @@ class CustomTrainingJob(_CustomTrainingJob):
             worker_pool_specs=worker_pool_specs,
             base_output_dir=base_output_dir,
             service_account=service_account,
-            network=network
+            network=network,
         )
 
         model = self._run_job(
@@ -2717,7 +2717,7 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
             worker_pool_specs=worker_pool_specs,
             base_output_dir=base_output_dir,
             service_account=service_account,
-            network=network
+            network=network,
         )
 
         model = self._run_job(

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -3053,7 +3053,7 @@ class TestCustomPythonPackageTrainingJob:
                     "workerPoolSpecs": [true_worker_pool_spec],
                     "baseOutputDirectory": {"output_uri_prefix": _TEST_BASE_OUTPUT_DIR},
                     "serviceAccount": _TEST_SERVICE_ACCOUNT,
-                    "network": _TEST_NETWORK
+                    "network": _TEST_NETWORK,
                 },
                 struct_pb2.Value(),
             ),

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -109,6 +109,7 @@ _TEST_NAME = (
 )
 _TEST_ALT_PROJECT = "test-project-alt"
 _TEST_ALT_LOCATION = "europe-west4"
+_TEST_NETWORK = f"projects/{_TEST_PROJECT}/global/networks/{_TEST_ID}"
 
 _TEST_MODEL_INSTANCE_SCHEMA_URI = "instance_schema_uri.yaml"
 _TEST_MODEL_PARAMETERS_SCHEMA_URI = "parameters_schema_uri.yaml"
@@ -598,6 +599,7 @@ class TestCustomTrainingJob:
             dataset=mock_tabular_dataset,
             base_output_dir=_TEST_BASE_OUTPUT_DIR,
             service_account=_TEST_SERVICE_ACCOUNT,
+            network=_TEST_NETWORK,
             args=_TEST_RUN_ARGS,
             environment_variables=_TEST_ENVIRONMENT_VARIABLES,
             replica_count=1,
@@ -697,6 +699,7 @@ class TestCustomTrainingJob:
                     "workerPoolSpecs": [true_worker_pool_spec],
                     "baseOutputDirectory": {"output_uri_prefix": _TEST_BASE_OUTPUT_DIR},
                     "serviceAccount": _TEST_SERVICE_ACCOUNT,
+                    "network": _TEST_NETWORK,
                 },
                 struct_pb2.Value(),
             ),
@@ -2524,6 +2527,7 @@ class TestCustomContainerTrainingJob:
             annotation_schema_uri=_TEST_ANNOTATION_SCHEMA_URI,
             base_output_dir=_TEST_BASE_OUTPUT_DIR,
             service_account=_TEST_SERVICE_ACCOUNT,
+            network=_TEST_NETWORK,
             args=_TEST_RUN_ARGS,
             replica_count=1,
             machine_type=_TEST_MACHINE_TYPE,
@@ -2606,6 +2610,7 @@ class TestCustomContainerTrainingJob:
                     "workerPoolSpecs": [true_worker_pool_spec],
                     "baseOutputDirectory": {"output_uri_prefix": _TEST_BASE_OUTPUT_DIR},
                     "serviceAccount": _TEST_SERVICE_ACCOUNT,
+                    "network": _TEST_NETWORK,
                 },
                 struct_pb2.Value(),
             ),
@@ -2955,6 +2960,7 @@ class TestCustomPythonPackageTrainingJob:
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
             base_output_dir=_TEST_BASE_OUTPUT_DIR,
             service_account=_TEST_SERVICE_ACCOUNT,
+            network=_TEST_NETWORK,
             args=_TEST_RUN_ARGS,
             environment_variables=_TEST_ENVIRONMENT_VARIABLES,
             replica_count=1,
@@ -3047,6 +3053,7 @@ class TestCustomPythonPackageTrainingJob:
                     "workerPoolSpecs": [true_worker_pool_spec],
                     "baseOutputDirectory": {"output_uri_prefix": _TEST_BASE_OUTPUT_DIR},
                     "serviceAccount": _TEST_SERVICE_ACCOUNT,
+                    "network": _TEST_NETWORK
                 },
                 struct_pb2.Value(),
             ),


### PR DESCRIPTION
Exposes the `network` parameter in `CustomTrainingJob.run()` and subclasses to allow user to peer Job to a GCE network.

Fixes [b/186368472](http://b/186368472) 🦕
