### PR TITLE
fix: updating TB webserver hostname

### DIFF
--- a/google/cloud/aiplatform/tensorboard/uploader_main.py
+++ b/google/cloud/aiplatform/tensorboard/uploader_main.py
@@ -129,8 +129,9 @@ def main(argv):
     tb_uploader.create_experiment()
 
     print(
-        "View your Tensorboard at https://{}/experiment/{}".format(
-            "tensorboard-gcp-prod.uc.r.appspot.com",
+        "View your Tensorboard at https://{}.{}/experiment/{}".format(
+            region,
+            "tensorboard.googleusercontent.com",
             tb_uploader.get_experiment_resource_name().replace("/", "+"),
         )
     )


### PR DESCRIPTION
Just learned today that the new hostname is up and running. Updating the uploader to make use of it.