### PR TITLE
fix: rollback six to 1.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ with io.open(readme_filename, encoding="utf-8") as readme_file:
 
 tensorboard_extra_require = [
     "tensorflow-cpu>=2.3.0, <=2.5.0",
+    "grpcio~=1.34.0",
     "six~=1.15.0",
 ]
 metadata_extra_require = ["pandas >= 1.0.0"]

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,7 @@ with io.open(readme_filename, encoding="utf-8") as readme_file:
 
 tensorboard_extra_require = [
     "tensorflow-cpu>=2.3.0, <=2.5.0",
-    "grpcio~=1.34.0",
-    "six~=1.16.0",
+    "six~=1.15.0",
 ]
 metadata_extra_require = ["pandas >= 1.0.0"]
 full_extra_require = tensorboard_extra_require + metadata_extra_require


### PR DESCRIPTION
six 1.16 is causing neverending pip lookups
