### PR TITLE
fix(deps): add packaging requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setuptools.setup(
     install_requires=(
         "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
         "proto-plus >= 1.10.1",
+        "packaging >= 14.3"
         "google-cloud-storage >= 1.32.0, < 2.0.0dev",
         "google-cloud-bigquery >= 1.15.0, < 3.0.0dev",
     ),

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setuptools.setup(
     install_requires=(
         "google-api-core[grpc] >= 1.22.2, < 2.0.0dev",
         "proto-plus >= 1.10.1",
-        "packaging >= 14.3"
+        "packaging >= 14.3",
         "google-cloud-storage >= 1.32.0, < 2.0.0dev",
         "google-cloud-bigquery >= 1.15.0, < 3.0.0dev",
     ),

--- a/testing/constraints-3.6.txt
+++ b/testing/constraints-3.6.txt
@@ -11,3 +11,4 @@ proto-plus==1.10.1
 mock==4.0.2
 google-cloud-storage==1.32.0
 google-auth==1.25.0  # TODO: Remove when google-api-core >= 1.26.0 is required
+packaging==14.3


### PR DESCRIPTION
Add packaging requirement. packaging.version
              is used for a version comparison in transports/base.py and is needed after the upgrade to gapic-generator-python 0.46.3