### PR TITLE
chore: Replace AI Platform naming with Vertex AI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 # The AI Platform GAPIC libraries are owned by Cloud AI DPE
 /google/cloud/aiplatform*              @googleapis/cdpe-cloudai
 
-# The AI Platform SDK is owned by Model Builder SDK Dev team
+# The Vertex SDK is owned by Model Builder SDK Dev team
 /google/cloud/aiplatform/*             @googleapis/cloud-aiplatform-model-builder-sdk
 /tests/unit/aiplatform/*               @googleapis/cloud-aiplatform-model-builder-sdk
 

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
     "product_documentation": "https://cloud.google.com/ai-platform",
     "client_documentation": "https://googleapis.dev/python/aiplatform/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559744",
-    "release_level": "beta",
+    "release_level": "ga",
     "language": "python",
     "library_type": "GAPIC_COMBO",
     "repo": "googleapis/python-aiplatform",

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,10 @@
-Python Client for Cloud AI Platform
+Python Client for Vertex AI
 =================================================
 
 |beta| |pypi| |versions|
 
 
-`Cloud AI Platform`_: Google Cloud AI Platform is an integrated suite of machine learning tools and services for building and using ML models with AutoML or custom code. It offers both novices and experts the best workbench for the entire machine learning development lifecycle.
+`Vertex AI`_: Google Vertex AI is an integrated suite of machine learning tools and services for building and using ML models with AutoML or custom code. It offers both novices and experts the best workbench for the entire machine learning development lifecycle.
 
 - `Client Library Documentation`_
 - `Product Documentation`_
@@ -15,7 +15,7 @@ Python Client for Cloud AI Platform
    :target: https://pypi.org/project/google-cloud-aiplatform/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-aiplatform.svg
    :target: https://pypi.org/project/google-cloud-aiplatform/
-.. _Cloud AI Platform: https://cloud.google.com/ai-platform-unified/docs
+.. _Vertex AI: https://cloud.google.com/ai-platform-unified/docs
 .. _Client Library Documentation: https://googleapis.dev/python/aiplatform/latest
 .. _Product Documentation:  https://cloud.google.com/ai-platform-unified/docs
 
@@ -26,12 +26,12 @@ In order to use this library, you first need to go through the following steps:
 
 1. `Select or create a Cloud Platform project.`_
 2. `Enable billing for your project.`_
-3. `Enable the Cloud AI Platform API.`_
+3. `Enable the Vertex AI API.`_
 4. `Setup Authentication.`_
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
-.. _Enable the Cloud AI Platform API.:  https://cloud.google.com/ai-platform/docs
+.. _Enable the Vertex AI API.:  https://cloud.google.com/ai-platform/docs
 .. _Setup Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -72,12 +72,12 @@ Windows
 Next Steps
 ~~~~~~~~~~
 
--  Read the `Client Library Documentation`_ for Cloud AI Platform
+-  Read the `Client Library Documentation`_ for Vertex AI
    API to see other available methods on the client.
--  Read the `Cloud AI Platform API Product documentation`_ to learn
+-  Read the `Vertex AI API Product documentation`_ to learn
    more about the product and see How-to Guides.
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Cloud AI Platform API Product documentation:  https://cloud.google.com/ai-platform-unified/docs
+.. _Vertex AI API Product documentation:  https://cloud.google.com/ai-platform-unified/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Python Client for Vertex AI
+Vertex SDK for Python
 =================================================
 
 |beta| |pypi| |versions|

--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,9 @@ Python Client for Vertex AI
    :target: https://pypi.org/project/google-cloud-aiplatform/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-aiplatform.svg
    :target: https://pypi.org/project/google-cloud-aiplatform/
-.. _Vertex AI: https://cloud.google.com/ai-platform-unified/docs
+.. _Vertex AI: https://cloud.google.com/vertex-ai/docs
 .. _Client Library Documentation: https://googleapis.dev/python/aiplatform/latest
-.. _Product Documentation:  https://cloud.google.com/ai-platform-unified/docs
+.. _Product Documentation:  https://cloud.google.com/vertex-ai/docs
 
 Quick Start
 -----------
@@ -79,5 +79,5 @@ Next Steps
 -  View this `README`_ to see the full list of Cloud
    APIs that we cover.
 
-.. _Vertex AI API Product documentation:  https://cloud.google.com/ai-platform-unified/docs
+.. _Vertex AI API Product documentation:  https://cloud.google.com/vertex-ai/docs
 .. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Vertex SDK for Python
 =================================================
 
-|beta| |pypi| |versions|
+|GA| |pypi| |versions|
 
 
 `Vertex AI`_: Google Vertex AI is an integrated suite of machine learning tools and services for building and using ML models with AutoML or custom code. It offers both novices and experts the best workbench for the entire machine learning development lifecycle.
@@ -9,8 +9,8 @@ Vertex SDK for Python
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |beta| image:: https://img.shields.io/badge/support-beta-orange.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#beta-support
+.. |GA| image:: https://img.shields.io/badge/support-ga-gold.svg
+   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-aiplatform.svg
    :target: https://pypi.org/project/google-cloud-aiplatform/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-aiplatform.svg

--- a/google/cloud/aiplatform/base.py
+++ b/google/cloud/aiplatform/base.py
@@ -60,13 +60,13 @@ class Logger:
 
     def log_create_with_lro(
         self,
-        cls: Type["AiPlatformResourceNoun"],
+        cls: Type["VertexAiResourceNoun"],
         lro: Optional[operation.Operation] = None,
     ):
         """Logs create event with LRO.
 
         Args:
-            cls (AiPlatformResourceNoune):
+            cls (VertexAiResourceNoun):
                 Vertex AI Resource Noun class that is being created.
             lro (operation.Operation):
                 Optional. Backing LRO for creation.
@@ -80,7 +80,7 @@ class Logger:
 
     def log_create_complete(
         self,
-        cls: Type["AiPlatformResourceNoun"],
+        cls: Type["VertexAiResourceNoun"],
         resource: proto.Message,
         variable_name: str,
     ):
@@ -89,7 +89,7 @@ class Logger:
         Will also include code snippet to instantiate resource in SDK.
 
         Args:
-            cls (AiPlatformResourceNoun):
+            cls (VertexAiResourceNoun):
                 Vertex AI Resource Noun class that is being created.
             resource (proto.Message):
                 Vertex AI Resourc proto.Message
@@ -103,7 +103,7 @@ class Logger:
 
     def log_create_complete_with_getter(
         self,
-        cls: Type["AiPlatformResourceNoun"],
+        cls: Type["VertexAiResourceNoun"],
         resource: proto.Message,
         variable_name: str,
     ):
@@ -112,7 +112,7 @@ class Logger:
         Will also include code snippet to instantiate resource in SDK.
 
         Args:
-            cls (AiPlatformResourceNoun):
+            cls (VertexAiResourceNoun):
                 Vertex AI Resource Noun class that is being created.
             resource (proto.Message):
                 Vertex AI Resourc proto.Message
@@ -125,14 +125,14 @@ class Logger:
         )
 
     def log_action_start_against_resource(
-        self, action: str, noun: str, resource_noun_obj: "AiPlatformResourceNoun"
+        self, action: str, noun: str, resource_noun_obj: "VertexAiResourceNoun"
     ):
         """Logs intention to start an action against a resource.
 
         Args:
             action (str): Action to complete against the resource ie: "Deploying". Can be empty string.
             noun (str): Noun the action acts on against the resource. Can be empty string.
-            resource_noun_obj (AiPlatformResourceNoun):
+            resource_noun_obj (VertexAiResourceNoun):
                 Resource noun object the action is acting against.
         """
         self._logger.info(
@@ -143,7 +143,7 @@ class Logger:
         self,
         action: str,
         noun: str,
-        cls: Type["AiPlatformResourceNoun"],
+        cls: Type["VertexAiResourceNoun"],
         lro: operation.Operation,
     ):
         """Logs an action started against a resource with lro.
@@ -151,7 +151,7 @@ class Logger:
         Args:
             action (str): Action started against resource. ie: "Deploy". Can be empty string.
             noun (str): Noun the action acts on against the resource. Can be empty string.
-            cls (AiPlatformResourceNoun):
+            cls (VertexAiResourceNoun):
                 Resource noun object the action is acting against.
             lro (operation.Operation): Backing LRO for action.
         """
@@ -160,14 +160,14 @@ class Logger:
         )
 
     def log_action_completed_against_resource(
-        self, noun: str, action: str, resource_noun_obj: "AiPlatformResourceNoun"
+        self, noun: str, action: str, resource_noun_obj: "VertexAiResourceNoun"
     ):
         """Logs action completed against resource.
 
         Args:
             noun (str): Noun the action acts on against the resource. Can be empty string.
             action (str): Action started against resource. ie: "Deployed". Can be empty string.
-            resource_noun_obj (AiPlatformResourceNoun):
+            resource_noun_obj (VertexAiResourceNoun):
                 Resource noun object the action is acting against
         """
         self._logger.info(
@@ -385,7 +385,7 @@ class FutureManager(metaclass=abc.ABCMeta):
         return object.__repr__(self)
 
 
-class AiPlatformResourceNoun(metaclass=abc.ABCMeta):
+class VertexAiResourceNoun(metaclass=abc.ABCMeta):
     """Base class the Vertex AI resource nouns.
 
     Subclasses require two class attributes:
@@ -400,7 +400,7 @@ class AiPlatformResourceNoun(metaclass=abc.ABCMeta):
     @property
     @classmethod
     @abc.abstractmethod
-    def client_class(cls) -> Type[utils.AiPlatformServiceClientWithOverride]:
+    def client_class(cls) -> Type[utils.VertexAiServiceClientWithOverride]:
         """Client class required to interact with resource with optional
         overrides."""
         pass
@@ -464,7 +464,7 @@ class AiPlatformResourceNoun(metaclass=abc.ABCMeta):
         cls,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
-    ) -> utils.AiPlatformServiceClientWithOverride:
+    ) -> utils.VertexAiServiceClientWithOverride:
         """Helper method to instantiate service client for resource noun.
 
         Args:
@@ -473,7 +473,7 @@ class AiPlatformResourceNoun(metaclass=abc.ABCMeta):
                 Optional custom credentials to use when accessing interacting with
                 resource noun.
         Returns:
-            client (utils.AiPlatformServiceClientWithOverride):
+            client (utils.VertexAiServiceClientWithOverride):
                 Initialized service client for this service noun with optional overrides.
         """
         return initializer.global_config.create_client(
@@ -580,7 +580,7 @@ def optional_sync(
     return_input_arg: Optional[str] = None,
     bind_future_to_self: bool = True,
 ):
-    """Decorator for AiPlatformResourceNounWithFutureManager with optional sync
+    """Decorator for VertexAIResourceNounWithFutureManager with optional sync
     support.
 
     Methods with this decorator should include a "sync" argument that defaults to
@@ -714,7 +714,7 @@ def optional_sync(
     return optional_run_in_thread
 
 
-class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureManager):
+class VertexAIResourceNounWithFutureManager(VertexAiResourceNoun, FutureManager):
     """Allows optional asynchronous calls to this Vertex AI Resource
     Nouns."""
 
@@ -735,7 +735,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
                 resource noun.
             resource_name(str): A fully-qualified resource name or ID.
         """
-        AiPlatformResourceNoun.__init__(
+        VertexAiResourceNoun.__init__(
             self,
             project=project,
             location=location,
@@ -751,7 +751,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         resource_name: Optional[str] = None,
-    ) -> "AiPlatformResourceNounWithFutureManager":
+    ) -> "VertexAIResourceNounWithFutureManager":
         """Initializes with all attributes set to None.
 
         The attributes should be populated after a future is complete. This allows
@@ -768,7 +768,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
             An instance of this class with attributes set to None.
         """
         self = cls.__new__(cls)
-        AiPlatformResourceNoun.__init__(
+        VertexAiResourceNoun.__init__(
             self,
             project=project,
             location=location,
@@ -780,12 +780,12 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
         return self
 
     def _sync_object_with_future_result(
-        self, result: "AiPlatformResourceNounWithFutureManager"
+        self, result: "VertexAIResourceNounWithFutureManager"
     ):
         """Populates attributes from a Future result to this object.
 
         Args:
-            result: AiPlatformResourceNounWithFutureManager
+            result: VertexAIResourceNounWithFutureManager
                 Required. Result of future with same type as this object.
         """
         sync_attributes = [
@@ -811,7 +811,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
-    ) -> AiPlatformResourceNoun:
+    ) -> VertexAiResourceNoun:
         """Given a GAPIC resource object, return the SDK representation.
 
         Args:
@@ -829,7 +829,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
                 Overrides credentials set in aiplatform.init.
 
         Returns:
-            AiPlatformResourceNoun:
+            VertexAiResourceNoun:
                 An initialized SDK object that represents GAPIC type.
         """
         sdk_resource = self._empty_constructor(
@@ -849,7 +849,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
-    ) -> List[AiPlatformResourceNoun]:
+    ) -> List[VertexAiResourceNoun]:
         """Private method to list all instances of this Vertex AI Resource,
         takes a `cls_filter` arg to filter to a particular SDK resource
         subclass.
@@ -878,7 +878,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
                 credentials set in aiplatform.init.
 
         Returns:
-            List[AiPlatformResourceNoun] - A list of SDK resource objects
+            List[VertexAiResourceNoun] - A list of SDK resource objects
         """
         self = cls._empty_constructor(
             project=project, location=location, credentials=credentials
@@ -918,7 +918,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
-    ) -> List[AiPlatformResourceNoun]:
+    ) -> List[VertexAiResourceNoun]:
         """Private method to list all instances of this Vertex AI Resource,
         takes a `cls_filter` arg to filter to a particular SDK resource
         subclass. Provides client-side sorting when a list API doesn't support
@@ -948,7 +948,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
                 credentials set in aiplatform.init.
 
         Returns:
-            List[AiPlatformResourceNoun] - A list of SDK resource objects
+            List[VertexAiResourceNoun] - A list of SDK resource objects
         """
 
         li = cls._list(
@@ -980,7 +980,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
-    ) -> List[AiPlatformResourceNoun]:
+    ) -> List[VertexAiResourceNoun]:
         """List all instances of this Vertex AI Resource.
 
         Example Usage:
@@ -1010,7 +1010,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
                 credentials set in aiplatform.init.
 
         Returns:
-            List[AiPlatformResourceNoun] - A list of SDK resource objects
+            List[VertexAiResourceNoun] - A list of SDK resource objects
         """
 
         return cls._list(
@@ -1042,7 +1042,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
 
     def __repr__(self) -> str:
         if self._gca_resource:
-            return AiPlatformResourceNoun.__repr__(self)
+            return VertexAiResourceNoun.__repr__(self)
 
         return FutureManager.__repr__(self)
 

--- a/google/cloud/aiplatform/base.py
+++ b/google/cloud/aiplatform/base.py
@@ -67,7 +67,7 @@ class Logger:
 
         Args:
             cls (AiPlatformResourceNoune):
-                AI Platform Resource Noun class that is being created.
+                Vertex AI Resource Noun class that is being created.
             lro (operation.Operation):
                 Optional. Backing LRO for creation.
         """
@@ -90,9 +90,9 @@ class Logger:
 
         Args:
             cls (AiPlatformResourceNoun):
-                AI Platform Resource Noun class that is being created.
+                Vertex AI Resource Noun class that is being created.
             resource (proto.Message):
-                AI Platform Resourc proto.Message
+                Vertex AI Resourc proto.Message
             variable_name (str): Name of variable to use for code snippet
         """
         self._logger.info(f"{cls.__name__} created. Resource name: {resource.name}")
@@ -113,9 +113,9 @@ class Logger:
 
         Args:
             cls (AiPlatformResourceNoun):
-                AI Platform Resource Noun class that is being created.
+                Vertex AI Resource Noun class that is being created.
             resource (proto.Message):
-                AI Platform Resourc proto.Message
+                Vertex AI Resourc proto.Message
             variable_name (str): Name of variable to use for code snippet
         """
         self._logger.info(f"{cls.__name__} created. Resource name: {resource.name}")
@@ -386,7 +386,7 @@ class FutureManager(metaclass=abc.ABCMeta):
 
 
 class AiPlatformResourceNoun(metaclass=abc.ABCMeta):
-    """Base class the AI Platform resource nouns.
+    """Base class the Vertex AI resource nouns.
 
     Subclasses require two class attributes:
 
@@ -715,7 +715,7 @@ def optional_sync(
 
 
 class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureManager):
-    """Allows optional asynchronous calls to this AI Platform Resource
+    """Allows optional asynchronous calls to this Vertex AI Resource
     Nouns."""
 
     def __init__(
@@ -816,7 +816,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
 
         Args:
             gapic_resource (proto.Message):
-                A GAPIC representation of an AI Platform resource, usually
+                A GAPIC representation of an Vertex AI resource, usually
                 retrieved by a get_* or in a list_* API call.
             project (str):
                 Optional. Project to construct SDK object from. If not set,
@@ -850,7 +850,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
     ) -> List[AiPlatformResourceNoun]:
-        """Private method to list all instances of this AI Platform Resource,
+        """Private method to list all instances of this Vertex AI Resource,
         takes a `cls_filter` arg to filter to a particular SDK resource
         subclass.
 
@@ -919,7 +919,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
     ) -> List[AiPlatformResourceNoun]:
-        """Private method to list all instances of this AI Platform Resource,
+        """Private method to list all instances of this Vertex AI Resource,
         takes a `cls_filter` arg to filter to a particular SDK resource
         subclass. Provides client-side sorting when a list API doesn't support
         `order_by`.
@@ -981,7 +981,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
     ) -> List[AiPlatformResourceNoun]:
-        """List all instances of this AI Platform Resource.
+        """List all instances of this Vertex AI Resource.
 
         Example Usage:
 
@@ -1023,7 +1023,7 @@ class AiPlatformResourceNounWithFutureManager(AiPlatformResourceNoun, FutureMana
 
     @optional_sync()
     def delete(self, sync: bool = True) -> None:
-        """Deletes this AI Platform resource. WARNING: This deletion is
+        """Deletes this Vertex AI resource. WARNING: This deletion is
         permament.
 
         Args:

--- a/google/cloud/aiplatform/base.py
+++ b/google/cloud/aiplatform/base.py
@@ -580,7 +580,7 @@ def optional_sync(
     return_input_arg: Optional[str] = None,
     bind_future_to_self: bool = True,
 ):
-    """Decorator for VertexAIResourceNounWithFutureManager with optional sync
+    """Decorator for VertexAiResourceNounWithFutureManager with optional sync
     support.
 
     Methods with this decorator should include a "sync" argument that defaults to
@@ -714,7 +714,7 @@ def optional_sync(
     return optional_run_in_thread
 
 
-class VertexAIResourceNounWithFutureManager(VertexAiResourceNoun, FutureManager):
+class VertexAiResourceNounWithFutureManager(VertexAiResourceNoun, FutureManager):
     """Allows optional asynchronous calls to this Vertex AI Resource
     Nouns."""
 
@@ -751,7 +751,7 @@ class VertexAIResourceNounWithFutureManager(VertexAiResourceNoun, FutureManager)
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         resource_name: Optional[str] = None,
-    ) -> "VertexAIResourceNounWithFutureManager":
+    ) -> "VertexAiResourceNounWithFutureManager":
         """Initializes with all attributes set to None.
 
         The attributes should be populated after a future is complete. This allows
@@ -780,12 +780,12 @@ class VertexAIResourceNounWithFutureManager(VertexAiResourceNoun, FutureManager)
         return self
 
     def _sync_object_with_future_result(
-        self, result: "VertexAIResourceNounWithFutureManager"
+        self, result: "VertexAiResourceNounWithFutureManager"
     ):
         """Populates attributes from a Future result to this object.
 
         Args:
-            result: VertexAIResourceNounWithFutureManager
+            result: VertexAiResourceNounWithFutureManager
                 Required. Result of future with same type as this object.
         """
         sync_attributes = [

--- a/google/cloud/aiplatform/datasets/_datasources.py
+++ b/google/cloud/aiplatform/datasets/_datasources.py
@@ -46,7 +46,7 @@ class DatasourceImportable(abc.ABC):
 
 
 class TabularDatasource(Datasource):
-    """Datasource for creating a tabular dataset for AI Platform."""
+    """Datasource for creating a tabular dataset for Vertex AI."""
 
     def __init__(
         self,
@@ -99,7 +99,7 @@ class TabularDatasource(Datasource):
 
 
 class NonTabularDatasource(Datasource):
-    """Datasource for creating an empty non-tabular dataset for AI Platform."""
+    """Datasource for creating an empty non-tabular dataset for Vertex AI."""
 
     @property
     def dataset_metadata(self) -> Optional[Dict]:
@@ -107,7 +107,7 @@ class NonTabularDatasource(Datasource):
 
 
 class NonTabularDatasourceImportable(NonTabularDatasource, DatasourceImportable):
-    """Datasource for creating a non-tabular dataset for AI Platform and
+    """Datasource for creating a non-tabular dataset for Vertex AI and
     importing data to the dataset."""
 
     def __init__(

--- a/google/cloud/aiplatform/datasets/dataset.py
+++ b/google/cloud/aiplatform/datasets/dataset.py
@@ -35,7 +35,7 @@ from google.cloud.aiplatform.datasets import _datasources
 _LOGGER = base.Logger(__name__)
 
 
-class _Dataset(base.AiPlatformResourceNounWithFutureManager):
+class _Dataset(base.VertexAIResourceNounWithFutureManager):
     """Managed dataset resource for Vertex AI."""
 
     client_class = utils.DatasetClientWithOverride
@@ -528,7 +528,7 @@ class _Dataset(base.AiPlatformResourceNounWithFutureManager):
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
-    ) -> List[base.AiPlatformResourceNoun]:
+    ) -> List[base.VertexAiResourceNoun]:
         """List all instances of this Dataset resource.
 
         Example Usage:
@@ -557,7 +557,7 @@ class _Dataset(base.AiPlatformResourceNounWithFutureManager):
                 credentials set in aiplatform.init.
 
         Returns:
-            List[base.AiPlatformResourceNoun] - A list of Dataset resource objects
+            List[base.VertexAiResourceNoun] - A list of Dataset resource objects
         """
 
         dataset_subclass_filter = (

--- a/google/cloud/aiplatform/datasets/dataset.py
+++ b/google/cloud/aiplatform/datasets/dataset.py
@@ -36,7 +36,7 @@ _LOGGER = base.Logger(__name__)
 
 
 class _Dataset(base.AiPlatformResourceNounWithFutureManager):
-    """Managed dataset resource for AI Platform."""
+    """Managed dataset resource for Vertex AI."""
 
     client_class = utils.DatasetClientWithOverride
     _is_client_prediction_client = False
@@ -264,7 +264,7 @@ class _Dataset(base.AiPlatformResourceNounWithFutureManager):
                 that can be used here are found in gs://google-cloud-
                 aiplatform/schema/dataset/metadata/.
             datasource (_datasources.Datasource):
-                Required. Datasource for creating a dataset for AI Platform.
+                Required. Datasource for creating a dataset for Vertex AI.
             project (str):
                 Required. Project to upload this model to. Overrides project set in
                 aiplatform.init.
@@ -368,7 +368,7 @@ class _Dataset(base.AiPlatformResourceNounWithFutureManager):
                 that can be used here are found in gs://google-cloud-
                 aiplatform/schema/dataset/metadata/.
             datasource (_datasources.Datasource):
-                Required. Datasource for creating a dataset for AI Platform.
+                Required. Datasource for creating a dataset for Vertex AI.
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the create_dataset
                 request as metadata. Usually to specify special dataset config.
@@ -401,7 +401,7 @@ class _Dataset(base.AiPlatformResourceNounWithFutureManager):
 
         Args:
             datasource (_datasources.DatasourceImportable):
-                Required. Datasource for importing data to an existing dataset for AI Platform.
+                Required. Datasource for importing data to an existing dataset for Vertex AI.
 
         Returns:
             operation (Operation):

--- a/google/cloud/aiplatform/datasets/dataset.py
+++ b/google/cloud/aiplatform/datasets/dataset.py
@@ -35,7 +35,7 @@ from google.cloud.aiplatform.datasets import _datasources
 _LOGGER = base.Logger(__name__)
 
 
-class _Dataset(base.VertexAIResourceNounWithFutureManager):
+class _Dataset(base.VertexAiResourceNounWithFutureManager):
     """Managed dataset resource for Vertex AI."""
 
     client_class = utils.DatasetClientWithOverride

--- a/google/cloud/aiplatform/datasets/image_dataset.py
+++ b/google/cloud/aiplatform/datasets/image_dataset.py
@@ -27,7 +27,7 @@ from google.cloud.aiplatform import utils
 
 
 class ImageDataset(datasets._Dataset):
-    """Managed image dataset resource for AI Platform."""
+    """Managed image dataset resource for Vertex AI."""
 
     _supported_metadata_schema_uris: Optional[Tuple[str]] = (
         schema.dataset.metadata.image,

--- a/google/cloud/aiplatform/datasets/tabular_dataset.py
+++ b/google/cloud/aiplatform/datasets/tabular_dataset.py
@@ -33,7 +33,7 @@ from google.cloud.aiplatform import utils
 
 
 class TabularDataset(datasets._Dataset):
-    """Managed tabular dataset resource for AI Platform."""
+    """Managed tabular dataset resource for Vertex AI."""
 
     _supported_metadata_schema_uris: Optional[Tuple[str]] = (
         schema.dataset.metadata.tabular,

--- a/google/cloud/aiplatform/datasets/text_dataset.py
+++ b/google/cloud/aiplatform/datasets/text_dataset.py
@@ -27,7 +27,7 @@ from google.cloud.aiplatform import utils
 
 
 class TextDataset(datasets._Dataset):
-    """Managed text dataset resource for AI Platform."""
+    """Managed text dataset resource for Vertex AI."""
 
     _supported_metadata_schema_uris: Optional[Tuple[str]] = (
         schema.dataset.metadata.text,

--- a/google/cloud/aiplatform/datasets/time_series_dataset.py
+++ b/google/cloud/aiplatform/datasets/time_series_dataset.py
@@ -27,7 +27,7 @@ from google.cloud.aiplatform import utils
 
 
 class TimeSeriesDataset(datasets._Dataset):
-    """Managed time series dataset resource for AI Platform"""
+    """Managed time series dataset resource for Vertex AI"""
 
     _supported_metadata_schema_uris: Optional[Tuple[str]] = (
         schema.dataset.metadata.time_series,

--- a/google/cloud/aiplatform/datasets/video_dataset.py
+++ b/google/cloud/aiplatform/datasets/video_dataset.py
@@ -27,7 +27,7 @@ from google.cloud.aiplatform import utils
 
 
 class VideoDataset(datasets._Dataset):
-    """Managed video dataset resource for AI Platform."""
+    """Managed video dataset resource for Vertex AI."""
 
     _supported_metadata_schema_uris: Optional[Tuple[str]] = (
         schema.dataset.metadata.video,

--- a/google/cloud/aiplatform/initializer.py
+++ b/google/cloud/aiplatform/initializer.py
@@ -257,13 +257,13 @@ class _Config:
 
         Args:
             client_class (utils.AiPlatformServiceClientWithOverride):
-                (Required) An AI Platform Service Client with optional overrides.
+                (Required) An Vertex AI Service Client with optional overrides.
             credentials (auth_credentials.Credentials):
                 Custom auth credentials. If not provided will use the current config.
             location_override (str): Optional location override.
             prediction_client (str): Optional flag to use a prediction endpoint.
         Returns:
-            client: Instantiated AI Platform Service client with optional overrides
+            client: Instantiated Vertex AI Service client with optional overrides
         """
         gapic_version = pkg_resources.get_distribution(
             "google-cloud-aiplatform",

--- a/google/cloud/aiplatform/initializer.py
+++ b/google/cloud/aiplatform/initializer.py
@@ -247,16 +247,16 @@ class _Config:
 
     def create_client(
         self,
-        client_class: Type[utils.AiPlatformServiceClientWithOverride],
+        client_class: Type[utils.VertexAiServiceClientWithOverride],
         credentials: Optional[auth_credentials.Credentials] = None,
         location_override: Optional[str] = None,
         prediction_client: bool = False,
-    ) -> utils.AiPlatformServiceClientWithOverride:
-        """Instantiates a given AiPlatformServiceClient with optional
+    ) -> utils.VertexAiServiceClientWithOverride:
+        """Instantiates a given VertexAiServiceClient with optional
         overrides.
 
         Args:
-            client_class (utils.AiPlatformServiceClientWithOverride):
+            client_class (utils.VertexAiServiceClientWithOverride):
                 (Required) An Vertex AI Service Client with optional overrides.
             credentials (auth_credentials.Credentials):
                 Custom auth credentials. If not provided will use the current config.

--- a/google/cloud/aiplatform/jobs.py
+++ b/google/cloud/aiplatform/jobs.py
@@ -74,7 +74,7 @@ _JOB_ERROR_STATES = (
 
 
 class _Job(base.AiPlatformResourceNounWithFutureManager):
-    """Class that represents a general Job resource in AI Platform (Unified).
+    """Class that represents a general Job resource in Vertex AI.
     Cannot be directly instantiated.
 
     Serves as base class to specific Job types, i.e. BatchPredictionJob or
@@ -130,7 +130,7 @@ class _Job(base.AiPlatformResourceNounWithFutureManager):
 
         Returns:
             state (job_state.JobState):
-                Enum that describes the state of a AI Platform job.
+                Enum that describes the state of a Vertex AI job.
         """
 
         # Fetch the Job again for most up-to-date job state
@@ -347,7 +347,7 @@ class BatchPredictionJob(_Job):
                 or "file-list". Default is "jsonl" when using `gcs_source`. If a
                 `bigquery_source` is provided, this is overriden to "bigquery".
             predictions_format (str):
-                Required. The format in which AI Platform gives the
+                Required. The format in which Vertex AI gives the
                 predictions, must be one of "jsonl", "csv", or "bigquery".
                 Default is "jsonl" when using `gcs_destination_prefix`. If a
                 `bigquery_destination_prefix` is provided, this is overriden to
@@ -417,7 +417,7 @@ class BatchPredictionJob(_Job):
                 `machine_type`. Only used if `machine_type` is set.
             starting_replica_count (Optional[int]):
                 The number of machine replicas used at the start of the batch
-                operation. If not set, AI Platform decides starting number, not
+                operation. If not set, Vertex AI decides starting number, not
                 greater than `max_replica_count`. Only used if `machine_type` is
                 set.
             max_replica_count (Optional[int]):
@@ -647,7 +647,7 @@ class BatchPredictionJob(_Job):
                 Required. An instance of DatasetServiceClient with the correct api_endpoint
                 already set based on user's preferences.
             batch_prediction_job (gca_bp_job.BatchPredictionJob):
-                Required. a batch prediction job proto for creating a batch prediction job on AI Platform.
+                Required. a batch prediction job proto for creating a batch prediction job on Vertex AI.
             generate_explanation (bool):
                 Required. Generate explanation along with the batch prediction
                 results.
@@ -673,7 +673,7 @@ class BatchPredictionJob(_Job):
             ValueError:
                 If no or multiple source or destinations are provided. Also, if
                 provided instances_format or predictions_format are not supported
-                by AI Platform.
+                by Vertex AI.
         """
         # select v1beta1 if explain else use default v1
         if generate_explanation:
@@ -841,7 +841,7 @@ class _RunnableJob(_Job):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
     ) -> "_RunnableJob":
-        """Get an AI Platform Job for the given resource_name.
+        """Get an Vertex AI Job for the given resource_name.
 
         Args:
             resource_name (str):
@@ -857,7 +857,7 @@ class _RunnableJob(_Job):
                 credentials set in aiplatform.init.
 
         Returns:
-            An AI Platform Job.
+            An Vertex AI Job.
         """
         self = cls._empty_constructor(
             project=project,
@@ -882,7 +882,7 @@ class DataLabelingJob(_Job):
 
 
 class CustomJob(_RunnableJob):
-    """AI Platform (Unified) Custom Job."""
+    """Vertex AI Custom Job."""
 
     _resource_noun = "customJobs"
     _getter_method = "get_custom_job"
@@ -1156,13 +1156,13 @@ class CustomJob(_RunnableJob):
                 distributed training jobs that are not resilient
                 to workers leaving and joining a job.
             tensorboard (str):
-                Optional. The name of an AI Platform
+                Optional. The name of an Vertex AI
                 [Tensorboard][google.cloud.aiplatform.v1beta1.Tensorboard]
                 resource to which this CustomJob will upload Tensorboard
                 logs. Format:
                 ``projects/{project}/locations/{location}/tensorboards/{tensorboard}``
 
-                The training script should write Tensorboard to following AI Platform environment
+                The training script should write Tensorboard to following Vertex AI environment
                 variable:
 
                 AIP_TENSORBOARD_LOG_DIR
@@ -1228,7 +1228,7 @@ _MEASUREMENT_SELECTION_TO_PROTO_VALUE = {
 
 
 class HyperparameterTuningJob(_RunnableJob):
-    """AI Platform (Unified) Hyperparameter Tuning Job."""
+    """Vertex AI Hyperparameter Tuning Job."""
 
     _resource_noun = "hyperparameterTuningJobs"
     _getter_method = "get_hyperparameter_tuning_job"
@@ -1348,13 +1348,13 @@ class HyperparameterTuningJob(_RunnableJob):
             max_failed_trial_count (int):
                 Optional. The number of failed Trials that need to be
                 seen before failing the HyperparameterTuningJob.
-                If set to 0, AI Platform decides how many Trials
+                If set to 0, Vertex AI decides how many Trials
                 must fail before the whole job fails.
             search_algorithm (str):
                 The search algorithm specified for the Study.
                 Accepts one of the following:
                     `None` - If you do not specify an algorithm, your job uses
-                    the default AI Platform algorithm. The default algorithm
+                    the default Vertex AI algorithm. The default algorithm
                     applies Bayesian optimization to arrive at the optimal
                     solution with a more effective search over the parameter space.
 
@@ -1362,7 +1362,7 @@ class HyperparameterTuningJob(_RunnableJob):
                     option is particularly useful if you want to specify a quantity
                     of trials that is greater than the number of points in the
                     feasible space. In such cases, if you do not specify a grid
-                    search, the AI Platform default algorithm may generate duplicate
+                    search, the Vertex AI default algorithm may generate duplicate
                     suggestions. To use grid search, all parameter specs must be
                     of type `IntegerParameterSpec`, `CategoricalParameterSpace`,
                     or `DiscreteParameterSpec`.
@@ -1463,13 +1463,13 @@ class HyperparameterTuningJob(_RunnableJob):
                 distributed training jobs that are not resilient
                 to workers leaving and joining a job.
             tensorboard (str):
-                Optional. The name of an AI Platform
+                Optional. The name of an Vertex AI
                 [Tensorboard][google.cloud.aiplatform.v1beta1.Tensorboard]
                 resource to which this CustomJob will upload Tensorboard
                 logs. Format:
                 ``projects/{project}/locations/{location}/tensorboards/{tensorboard}``
 
-                The training script should write Tensorboard to following AI Platform environment
+                The training script should write Tensorboard to following Vertex AI environment
                 variable:
 
                 AIP_TENSORBOARD_LOG_DIR

--- a/google/cloud/aiplatform/jobs.py
+++ b/google/cloud/aiplatform/jobs.py
@@ -73,7 +73,7 @@ _JOB_ERROR_STATES = (
 )
 
 
-class _Job(base.AiPlatformResourceNounWithFutureManager):
+class _Job(base.VertexAIResourceNounWithFutureManager):
     """Class that represents a general Job resource in Vertex AI.
     Cannot be directly instantiated.
 
@@ -209,7 +209,7 @@ class _Job(base.AiPlatformResourceNounWithFutureManager):
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
-    ) -> List[base.AiPlatformResourceNoun]:
+    ) -> List[base.VertexAiResourceNoun]:
         """List all instances of this Job Resource.
 
         Example Usage:
@@ -237,7 +237,7 @@ class _Job(base.AiPlatformResourceNounWithFutureManager):
                 credentials set in aiplatform.init.
 
         Returns:
-            List[AiPlatformResourceNoun] - A list of Job resource objects
+            List[VertexAiResourceNoun] - A list of Job resource objects
         """
 
         return cls._list_with_local_order(
@@ -804,7 +804,7 @@ class _RunnableJob(_Job):
                 credentials to use when accessing interacting with resource noun.
         """
 
-        base.AiPlatformResourceNounWithFutureManager.__init__(
+        base.VertexAIResourceNounWithFutureManager.__init__(
             self, project=project, location=location, credentials=credentials
         )
 

--- a/google/cloud/aiplatform/jobs.py
+++ b/google/cloud/aiplatform/jobs.py
@@ -73,8 +73,8 @@ _JOB_ERROR_STATES = (
 )
 
 
-class _Job(base.AiPlatformResourceNounWithFutureManager):
-    """Class that represents a general Job resource in AI Platform (Unified).
+class _Job(base.VertexAiResourceNounWithFutureManager):
+    """Class that represents a general Job resource in Vertex AI.
     Cannot be directly instantiated.
 
     Serves as base class to specific Job types, i.e. BatchPredictionJob or
@@ -130,7 +130,7 @@ class _Job(base.AiPlatformResourceNounWithFutureManager):
 
         Returns:
             state (job_state.JobState):
-                Enum that describes the state of a AI Platform job.
+                Enum that describes the state of a Vertex AI job.
         """
 
         # Fetch the Job again for most up-to-date job state
@@ -209,7 +209,7 @@ class _Job(base.AiPlatformResourceNounWithFutureManager):
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
-    ) -> List[base.AiPlatformResourceNoun]:
+    ) -> List[base.VertexAiResourceNoun]:
         """List all instances of this Job Resource.
 
         Example Usage:
@@ -237,7 +237,7 @@ class _Job(base.AiPlatformResourceNounWithFutureManager):
                 credentials set in aiplatform.init.
 
         Returns:
-            List[AiPlatformResourceNoun] - A list of Job resource objects
+            List[VertexAiResourceNoun] - A list of Job resource objects
         """
 
         return cls._list_with_local_order(
@@ -347,7 +347,7 @@ class BatchPredictionJob(_Job):
                 or "file-list". Default is "jsonl" when using `gcs_source`. If a
                 `bigquery_source` is provided, this is overriden to "bigquery".
             predictions_format (str):
-                Required. The format in which AI Platform gives the
+                Required. The format in which Vertex AI gives the
                 predictions, must be one of "jsonl", "csv", or "bigquery".
                 Default is "jsonl" when using `gcs_destination_prefix`. If a
                 `bigquery_destination_prefix` is provided, this is overriden to
@@ -417,7 +417,7 @@ class BatchPredictionJob(_Job):
                 `machine_type`. Only used if `machine_type` is set.
             starting_replica_count (Optional[int]):
                 The number of machine replicas used at the start of the batch
-                operation. If not set, AI Platform decides starting number, not
+                operation. If not set, Vertex AI decides starting number, not
                 greater than `max_replica_count`. Only used if `machine_type` is
                 set.
             max_replica_count (Optional[int]):
@@ -647,7 +647,7 @@ class BatchPredictionJob(_Job):
                 Required. An instance of DatasetServiceClient with the correct api_endpoint
                 already set based on user's preferences.
             batch_prediction_job (gca_bp_job.BatchPredictionJob):
-                Required. a batch prediction job proto for creating a batch prediction job on AI Platform.
+                Required. a batch prediction job proto for creating a batch prediction job on Vertex AI.
             generate_explanation (bool):
                 Required. Generate explanation along with the batch prediction
                 results.
@@ -673,7 +673,7 @@ class BatchPredictionJob(_Job):
             ValueError:
                 If no or multiple source or destinations are provided. Also, if
                 provided instances_format or predictions_format are not supported
-                by AI Platform.
+                by Vertex AI.
         """
         # select v1beta1 if explain else use default v1
         if generate_explanation:
@@ -804,7 +804,7 @@ class _RunnableJob(_Job):
                 credentials to use when accessing interacting with resource noun.
         """
 
-        base.AiPlatformResourceNounWithFutureManager.__init__(
+        base.VertexAiResourceNounWithFutureManager.__init__(
             self, project=project, location=location, credentials=credentials
         )
 
@@ -841,7 +841,7 @@ class _RunnableJob(_Job):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
     ) -> "_RunnableJob":
-        """Get an AI Platform Job for the given resource_name.
+        """Get an Vertex AI Job for the given resource_name.
 
         Args:
             resource_name (str):
@@ -857,7 +857,7 @@ class _RunnableJob(_Job):
                 credentials set in aiplatform.init.
 
         Returns:
-            An AI Platform Job.
+            An Vertex AI Job.
         """
         self = cls._empty_constructor(
             project=project,
@@ -882,7 +882,7 @@ class DataLabelingJob(_Job):
 
 
 class CustomJob(_RunnableJob):
-    """AI Platform (Unified) Custom Job."""
+    """Vertex AI Custom Job."""
 
     _resource_noun = "customJobs"
     _getter_method = "get_custom_job"
@@ -1156,13 +1156,13 @@ class CustomJob(_RunnableJob):
                 distributed training jobs that are not resilient
                 to workers leaving and joining a job.
             tensorboard (str):
-                Optional. The name of an AI Platform
+                Optional. The name of an Vertex AI
                 [Tensorboard][google.cloud.aiplatform.v1beta1.Tensorboard]
                 resource to which this CustomJob will upload Tensorboard
                 logs. Format:
                 ``projects/{project}/locations/{location}/tensorboards/{tensorboard}``
 
-                The training script should write Tensorboard to following AI Platform environment
+                The training script should write Tensorboard to following Vertex AI environment
                 variable:
 
                 AIP_TENSORBOARD_LOG_DIR
@@ -1229,7 +1229,7 @@ _MEASUREMENT_SELECTION_TO_PROTO_VALUE = {
 
 
 class HyperparameterTuningJob(_RunnableJob):
-    """AI Platform (Unified) Hyperparameter Tuning Job."""
+    """Vertex AI Hyperparameter Tuning Job."""
 
     _resource_noun = "hyperparameterTuningJobs"
     _getter_method = "get_hyperparameter_tuning_job"
@@ -1349,13 +1349,13 @@ class HyperparameterTuningJob(_RunnableJob):
             max_failed_trial_count (int):
                 Optional. The number of failed Trials that need to be
                 seen before failing the HyperparameterTuningJob.
-                If set to 0, AI Platform decides how many Trials
+                If set to 0, Vertex AI decides how many Trials
                 must fail before the whole job fails.
             search_algorithm (str):
                 The search algorithm specified for the Study.
                 Accepts one of the following:
                     `None` - If you do not specify an algorithm, your job uses
-                    the default AI Platform algorithm. The default algorithm
+                    the default Vertex AI algorithm. The default algorithm
                     applies Bayesian optimization to arrive at the optimal
                     solution with a more effective search over the parameter space.
 
@@ -1363,7 +1363,7 @@ class HyperparameterTuningJob(_RunnableJob):
                     option is particularly useful if you want to specify a quantity
                     of trials that is greater than the number of points in the
                     feasible space. In such cases, if you do not specify a grid
-                    search, the AI Platform default algorithm may generate duplicate
+                    search, the Vertex AI default algorithm may generate duplicate
                     suggestions. To use grid search, all parameter specs must be
                     of type `IntegerParameterSpec`, `CategoricalParameterSpace`,
                     or `DiscreteParameterSpec`.
@@ -1464,13 +1464,13 @@ class HyperparameterTuningJob(_RunnableJob):
                 distributed training jobs that are not resilient
                 to workers leaving and joining a job.
             tensorboard (str):
-                Optional. The name of an AI Platform
+                Optional. The name of an Vertex AI
                 [Tensorboard][google.cloud.aiplatform.v1beta1.Tensorboard]
                 resource to which this CustomJob will upload Tensorboard
                 logs. Format:
                 ``projects/{project}/locations/{location}/tensorboards/{tensorboard}``
 
-                The training script should write Tensorboard to following AI Platform environment
+                The training script should write Tensorboard to following Vertex AI environment
                 variable:
 
                 AIP_TENSORBOARD_LOG_DIR

--- a/google/cloud/aiplatform/metadata/artifact.py
+++ b/google/cloud/aiplatform/metadata/artifact.py
@@ -26,7 +26,7 @@ from google.cloud.aiplatform_v1beta1.types import artifact as gca_artifact
 
 
 class _Artifact(_Resource):
-    """Metadata Artifact resource for AI Platform"""
+    """Metadata Artifact resource for Vertex AI"""
 
     _resource_noun = "artifacts"
     _getter_method = "get_artifact"

--- a/google/cloud/aiplatform/metadata/context.py
+++ b/google/cloud/aiplatform/metadata/context.py
@@ -26,7 +26,7 @@ from google.cloud.aiplatform_v1beta1.types import context as gca_context
 
 
 class _Context(_Resource):
-    """Metadata Context resource for AI Platform"""
+    """Metadata Context resource for Vertex AI"""
 
     _resource_noun = "contexts"
     _getter_method = "get_context"

--- a/google/cloud/aiplatform/metadata/execution.py
+++ b/google/cloud/aiplatform/metadata/execution.py
@@ -29,7 +29,7 @@ from google.cloud.aiplatform_v1beta1.types.metadata_service import ListExecution
 
 
 class _Execution(_Resource):
-    """Metadata Execution resource for AI Platform"""
+    """Metadata Execution resource for Vertex AI"""
 
     _resource_noun = "executions"
     _getter_method = "get_execution"

--- a/google/cloud/aiplatform/metadata/metadata_store.py
+++ b/google/cloud/aiplatform/metadata/metadata_store.py
@@ -28,7 +28,7 @@ from google.cloud.aiplatform_v1beta1.types import metadata_store as gca_metadata
 
 
 class _MetadataStore(base.AiPlatformResourceNounWithFutureManager):
-    """Managed MetadataStore resource for AI Platform"""
+    """Managed MetadataStore resource for Vertex AI"""
 
     client_class = utils.MetadataClientWithOverride
     _is_client_prediction_client = False

--- a/google/cloud/aiplatform/metadata/metadata_store.py
+++ b/google/cloud/aiplatform/metadata/metadata_store.py
@@ -27,7 +27,7 @@ from google.cloud.aiplatform import utils
 from google.cloud.aiplatform_v1beta1.types import metadata_store as gca_metadata_store
 
 
-class _MetadataStore(base.AiPlatformResourceNounWithFutureManager):
+class _MetadataStore(base.VertexAIResourceNounWithFutureManager):
     """Managed MetadataStore resource for Vertex AI"""
 
     client_class = utils.MetadataClientWithOverride

--- a/google/cloud/aiplatform/metadata/metadata_store.py
+++ b/google/cloud/aiplatform/metadata/metadata_store.py
@@ -27,7 +27,7 @@ from google.cloud.aiplatform import utils
 from google.cloud.aiplatform_v1beta1.types import metadata_store as gca_metadata_store
 
 
-class _MetadataStore(base.VertexAIResourceNounWithFutureManager):
+class _MetadataStore(base.VertexAiResourceNounWithFutureManager):
     """Managed MetadataStore resource for Vertex AI"""
 
     client_class = utils.MetadataClientWithOverride

--- a/google/cloud/aiplatform/metadata/resource.py
+++ b/google/cloud/aiplatform/metadata/resource.py
@@ -33,7 +33,7 @@ from google.cloud.aiplatform_v1beta1 import Context as GapicContext
 from google.cloud.aiplatform_v1beta1 import Execution as GapicExecution
 
 
-class _Resource(base.VertexAIResourceNounWithFutureManager, abc.ABC):
+class _Resource(base.VertexAiResourceNounWithFutureManager, abc.ABC):
     """Metadata Resource for Vertex AI"""
 
     client_class = utils.MetadataClientWithOverride

--- a/google/cloud/aiplatform/metadata/resource.py
+++ b/google/cloud/aiplatform/metadata/resource.py
@@ -34,7 +34,7 @@ from google.cloud.aiplatform_v1beta1 import Execution as GapicExecution
 
 
 class _Resource(base.AiPlatformResourceNounWithFutureManager, abc.ABC):
-    """Metadata Resource for AI Platform"""
+    """Metadata Resource for Vertex AI"""
 
     client_class = utils.MetadataClientWithOverride
     _is_client_prediction_client = False

--- a/google/cloud/aiplatform/metadata/resource.py
+++ b/google/cloud/aiplatform/metadata/resource.py
@@ -33,7 +33,7 @@ from google.cloud.aiplatform_v1beta1 import Context as GapicContext
 from google.cloud.aiplatform_v1beta1 import Execution as GapicExecution
 
 
-class _Resource(base.AiPlatformResourceNounWithFutureManager, abc.ABC):
+class _Resource(base.VertexAIResourceNounWithFutureManager, abc.ABC):
     """Metadata Resource for Vertex AI"""
 
     client_class = utils.MetadataClientWithOverride

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1181,7 +1181,7 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
         return self
 
     def delete(self, force: bool = False, sync: bool = True) -> None:
-        """Deletes this AI Platform Endpoint resource. If force is set to True,
+        """Deletes this Vertex AI Endpoint resource. If force is set to True,
         all models on this Endpoint will be undeployed prior to deletion.
 
         Args:
@@ -1325,11 +1325,11 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
             serving_container_predict_route (str):
                 Optional. An HTTP path to send prediction requests to the container, and
                 which must be supported by it. If not specified a default HTTP path will
-                be used by AI Platform.
+                be used by Vertex AI.
             serving_container_health_route (str):
                 Optional. An HTTP path to send health check requests to the container, and which
                 must be supported by it. If not specified a standard HTTP path will be
-                used by AI Platform.
+                used by Vertex AI.
             description (str):
                 The description of the model.
             serving_container_command: Optional[Sequence[str]]=None,
@@ -1353,7 +1353,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
                 and values are environment variable values for those names.
             serving_container_ports: Optional[Sequence[int]]=None,
                 Declaration of ports that are exposed by the container. This field is
-                primarily informational, it gives AI Platform information about the
+                primarily informational, it gives Vertex AI information about the
                 network connections the container uses. Listing or not a port here has
                 no impact on whether the port is actually exposed, any port listening on
                 the default "0.0.0.0" address inside a container will be accessible from
@@ -1898,7 +1898,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
                 ```google.rpc.Status`` <Status>`__ represented as a STRUCT,
                 and containing only ``code`` and ``message``.
             predictions_format: str = "jsonl"
-                Required. The format in which AI Platform gives the
+                Required. The format in which Vertex AI gives the
                 predictions, must be one of "jsonl", "csv", or "bigquery".
                 Default is "jsonl" when using `gcs_destination_prefix`. If a
                 `bigquery_destination_prefix` is provided, this is overriden to
@@ -1919,7 +1919,7 @@ class Model(base.AiPlatformResourceNounWithFutureManager):
                 `machine_type`. Only used if `machine_type` is set.
             starting_replica_count: Optional[int] = None
                 The number of machine replicas used at the start of the batch
-                operation. If not set, AI Platform decides starting number, not
+                operation. If not set, Vertex AI decides starting number, not
                 greater than `max_replica_count`. Only used if `machine_type` is
                 set.
             max_replica_count: Optional[int] = None

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -73,7 +73,7 @@ class Prediction(NamedTuple):
     explanations: Optional[Sequence[gca_explanation_v1beta1.Explanation]] = None
 
 
-class Endpoint(base.VertexAIResourceNounWithFutureManager):
+class Endpoint(base.VertexAiResourceNounWithFutureManager):
 
     client_class = utils.EndpointClientWithOverride
     _is_client_prediction_client = False
@@ -1201,7 +1201,7 @@ class Endpoint(base.VertexAIResourceNounWithFutureManager):
         super().delete(sync=sync)
 
 
-class Model(base.VertexAIResourceNounWithFutureManager):
+class Model(base.VertexAiResourceNounWithFutureManager):
 
     client_class = utils.ModelClientWithOverride
     _is_client_prediction_client = False

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -73,7 +73,7 @@ class Prediction(NamedTuple):
     explanations: Optional[Sequence[gca_explanation_v1beta1.Explanation]] = None
 
 
-class Endpoint(base.AiPlatformResourceNounWithFutureManager):
+class Endpoint(base.VertexAIResourceNounWithFutureManager):
 
     client_class = utils.EndpointClientWithOverride
     _is_client_prediction_client = False
@@ -1201,7 +1201,7 @@ class Endpoint(base.AiPlatformResourceNounWithFutureManager):
         super().delete(sync=sync)
 
 
-class Model(base.AiPlatformResourceNounWithFutureManager):
+class Model(base.VertexAIResourceNounWithFutureManager):
 
     client_class = utils.ModelClientWithOverride
     _is_client_prediction_client = False

--- a/google/cloud/aiplatform/schema.py
+++ b/google/cloud/aiplatform/schema.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-"""Namespaced AI Platform Schemas."""
+"""Namespaced Vertex AI Schemas."""
 
 
 class training_job:

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -61,7 +61,7 @@ _PIPELINE_COMPLETE_STATES = set(
 )
 
 
-class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
+class _TrainingJob(base.VertexAIResourceNounWithFutureManager):
 
     client_class = utils.PipelineClientWithOverride
     _is_client_prediction_client = False
@@ -709,7 +709,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
-    ) -> List["base.AiPlatformResourceNoune"]:
+    ) -> List["base.VertexAiResourceNoun"]:
         """List all instances of this TrainingJob resource.
 
         Example Usage:
@@ -738,7 +738,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
                 credentials set in aiplatform.init.
 
         Returns:
-            List[AiPlatformResourceNoun] - A list of TrainingJob resource objects
+            List[VertexAiResourceNoun] - A list of TrainingJob resource objects
         """
 
         training_job_subclass_filter = (

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -61,7 +61,7 @@ _PIPELINE_COMPLETE_STATES = set(
 )
 
 
-class _TrainingJob(base.VertexAIResourceNounWithFutureManager):
+class _TrainingJob(base.VertexAiResourceNounWithFutureManager):
 
     client_class = utils.PipelineClientWithOverride
     _is_client_prediction_client = False

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -166,7 +166,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
                 doesn't match the custom training task definition.
 
         Returns:
-            An AI Platform Training Job
+            An Vertex AI Training Job
         """
 
         # Create job with dummy parameters
@@ -277,7 +277,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
             gcs_destination_uri_prefix (str):
                 Optional. The Google Cloud Storage location.
 
-                The AI Platform environment variables representing Google
+                The Vertex AI environment variables representing Google
                 Cloud Storage data URIs will always be represented in the
                 Google Cloud Storage wildcard format to support sharded
                 data.
@@ -449,14 +449,14 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
                 does not support uploading a Model as part of the pipeline.
                 When the Pipeline's state becomes
                 ``PIPELINE_STATE_SUCCEEDED`` and the trained Model had been
-                uploaded into AI Platform, then the model_to_upload's
+                uploaded into Vertex AI, then the model_to_upload's
                 resource ``name``
                 is populated. The Model is always uploaded into the Project
                 and Location in which this pipeline is.
             gcs_destination_uri_prefix (str):
                 Optional. The Google Cloud Storage location.
 
-                The AI Platform environment variables representing Google
+                The Vertex AI environment variables representing Google
                 Cloud Storage data URIs will always be represented in the
                 Google Cloud Storage wildcard format to support sharded
                 data.
@@ -546,7 +546,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
         return self._gca_resource.state
 
     def get_model(self, sync=True) -> models.Model:
-        """AI Platform Model produced by this training, if one was produced.
+        """Vertex AI Model produced by this training, if one was produced.
 
         Args:
             sync (bool):
@@ -555,7 +555,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
                 be immediately returned and synced when the Future has completed.
 
         Returns:
-            model: AI Platform Model produced by this training
+            model: Vertex AI Model produced by this training
 
         Raises:
             RuntimeError: If training failed or if a model was not produced by this training.
@@ -569,7 +569,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
 
     @base.optional_sync()
     def _force_get_model(self, sync: bool = True) -> models.Model:
-        """AI Platform Model produced by this training, if one was produced.
+        """Vertex AI Model produced by this training, if one was produced.
 
         Args:
             sync (bool):
@@ -578,7 +578,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
                 be immediately returned and synced when the Future has completed.
 
         Returns:
-            model: AI Platform Model produced by this training
+            model: Vertex AI Model produced by this training
 
         Raises:
             RuntimeError: If training failed or if a model was not produced by this training.
@@ -594,7 +594,7 @@ class _TrainingJob(base.AiPlatformResourceNounWithFutureManager):
         """Helper method to get and instantiate the Model to Upload.
 
         Returns:
-            model: AI Platform Model if training succeeded and produced an AI Platform
+            model: Vertex AI Model if training succeeded and produced an Vertex AI
                 Model. None otherwise.
 
         Raises:
@@ -806,15 +806,15 @@ class _CustomTrainingJob(_TrainingJob):
             container_uri (str):
                 Required: Uri of the training container image in the GCR.
             model_serving_container_image_uri (str):
-                If the training produces a managed AI Platform Model, the URI of the
+                If the training produces a managed Vertex AI Model, the URI of the
                 Model serving container suitable for serving the model produced by the
                 training script.
             model_serving_container_predict_route (str):
-                If the training produces a managed AI Platform Model, An HTTP path to
+                If the training produces a managed Vertex AI Model, An HTTP path to
                 send prediction requests to the container, and which must be supported
-                by it. If not specified a default HTTP path will be used by AI Platform.
+                by it. If not specified a default HTTP path will be used by Vertex AI.
             model_serving_container_health_route (str):
-                If the training produces a managed AI Platform Model, an HTTP path to
+                If the training produces a managed Vertex AI Model, an HTTP path to
                 send health check requests to the container, and which must be supported
                 by it. If not specified a standard HTTP path will be used by AI
                 Platform.
@@ -839,7 +839,7 @@ class _CustomTrainingJob(_TrainingJob):
                 and values are environment variable values for those names.
             model_serving_container_ports (Sequence[int]):
                 Declaration of ports that are exposed by the container. This field is
-                primarily informational, it gives AI Platform information about the
+                primarily informational, it gives Vertex AI information about the
                 network connections the container uses. Listing or not a port here has
                 no impact on whether the port is actually exposed, any port listening on
                 the default "0.0.0.0" address inside a container will be accessible from
@@ -1010,7 +1010,7 @@ class _CustomTrainingJob(_TrainingJob):
 
         Args:
             model_display_name (str):
-                If the script produces a managed AI Platform Model. The display name of
+                If the script produces a managed Vertex AI Model. The display name of
                 the Model. The name can be up to 128 characters long and can be consist
                 of any UTF-8 characters.
 
@@ -1130,10 +1130,10 @@ class _CustomTrainingJob(_TrainingJob):
 
 # TODO(b/172368325) add scheduling, custom_job.Scheduling
 class CustomTrainingJob(_CustomTrainingJob):
-    """Class to launch a Custom Training Job in AI Platform using a script.
+    """Class to launch a Custom Training Job in Vertex AI using a script.
 
     Takes a training implementation as a python script and executes that
-    script in Cloud AI Platform Training.
+    script in Cloud Vertex AI Training.
     """
 
     def __init__(
@@ -1184,7 +1184,7 @@ class CustomTrainingJob(_CustomTrainingJob):
 
 
         TODO(b/169782082) add documentation about traning utilities
-        To ensure your model gets saved in AI Platform, write your saved model to
+        To ensure your model gets saved in Vertex AI, write your saved model to
         os.environ["AIP_MODEL_DIR"] in your provided training script.
 
 
@@ -1197,15 +1197,15 @@ class CustomTrainingJob(_CustomTrainingJob):
             requirements (Sequence[str]):
                 List of python packages dependencies of script.
             model_serving_container_image_uri (str):
-                If the training produces a managed AI Platform Model, the URI of the
+                If the training produces a managed Vertex AI Model, the URI of the
                 Model serving container suitable for serving the model produced by the
                 training script.
             model_serving_container_predict_route (str):
-                If the training produces a managed AI Platform Model, An HTTP path to
+                If the training produces a managed Vertex AI Model, An HTTP path to
                 send prediction requests to the container, and which must be supported
-                by it. If not specified a default HTTP path will be used by AI Platform.
+                by it. If not specified a default HTTP path will be used by Vertex AI.
             model_serving_container_health_route (str):
-                If the training produces a managed AI Platform Model, an HTTP path to
+                If the training produces a managed Vertex AI Model, an HTTP path to
                 send health check requests to the container, and which must be supported
                 by it. If not specified a standard HTTP path will be used by AI
                 Platform.
@@ -1230,7 +1230,7 @@ class CustomTrainingJob(_CustomTrainingJob):
                 and values are environment variable values for those names.
             model_serving_container_ports (Sequence[int]):
                 Declaration of ports that are exposed by the container. This field is
-                primarily informational, it gives AI Platform information about the
+                primarily informational, it gives Vertex AI information about the
                 network connections the container uses. Listing or not a port here has
                 no impact on whether the port is actually exposed, any port listening on
                 the default "0.0.0.0" address inside a container will be accessible from
@@ -1386,7 +1386,7 @@ class CustomTrainingJob(_CustomTrainingJob):
         Any of ``training_fraction_split``, ``validation_fraction_split`` and
         ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
         the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by AI Platform.If none of the fractions are set, by default roughly 80%
+        decided by Vertex AI.If none of the fractions are set, by default roughly 80%
         of data will be used for training, 10% for validation, and 10% for test.
 
         Args:
@@ -1398,7 +1398,7 @@ class CustomTrainingJob(_CustomTrainingJob):
                     datasets.VideoDataset,
                 ]
             ):
-                AI Platform to fit this training against. Custom training script should
+                Vertex AI to fit this training against. Custom training script should
                 retrieve datasets through passed in environment variables uris:
 
                 os.environ["AIP_TRAINING_DATA_URI"]
@@ -1431,7 +1431,7 @@ class CustomTrainingJob(_CustomTrainingJob):
                 and
                 ``annotation_schema_uri``.
             model_display_name (str):
-                If the script produces a managed AI Platform Model. The display name of
+                If the script produces a managed Vertex AI Model. The display name of
                 the Model. The name can be up to 128 characters long and can be consist
                 of any UTF-8 characters.
 
@@ -1440,7 +1440,7 @@ class CustomTrainingJob(_CustomTrainingJob):
                 GCS output directory of job. If not provided a
                 timestamped directory in the staging directory will be used.
 
-                AI Platform sets the following environment variables when it runs your training code:
+                Vertex AI sets the following environment variables when it runs your training code:
 
                 -  AIP_MODEL_DIR: a Cloud Storage URI of a directory intended for saving model artifacts, i.e. <base_output_dir>/model/
                 -  AIP_CHECKPOINT_DIR: a Cloud Storage URI of a directory intended for saving checkpoints, i.e. <base_output_dir>/checkpoints/
@@ -1518,8 +1518,8 @@ class CustomTrainingJob(_CustomTrainingJob):
                 be immediately returned and synced when the Future has completed.
 
         Returns:
-            model: The trained AI Platform Model resource or None if training did not
-                produce an AI Platform Model.
+            model: The trained Vertex AI Model resource or None if training did not
+                produce an Vertex AI Model.
         """
         worker_pool_specs, managed_model = self._prepare_and_validate_run(
             model_display_name=model_display_name,
@@ -1593,7 +1593,7 @@ class CustomTrainingJob(_CustomTrainingJob):
                     datasets.VideoDataset,
                 ]
             ):
-                AI Platform to fit this training against.
+                Vertex AI to fit this training against.
             annotation_schema_uri (str):
                 Google Cloud Storage URI points to a YAML file describing
                 annotation schema.
@@ -1617,7 +1617,7 @@ class CustomTrainingJob(_CustomTrainingJob):
                 GCS output directory of job. If not provided a
                 timestamped directory in the staging directory will be used.
 
-                AI Platform sets the following environment variables when it runs your training code:
+                Vertex AI sets the following environment variables when it runs your training code:
 
                 -  AIP_MODEL_DIR: a Cloud Storage URI of a directory intended for saving model artifacts, i.e. <base_output_dir>/model/
                 -  AIP_CHECKPOINT_DIR: a Cloud Storage URI of a directory intended for saving checkpoints, i.e. <base_output_dir>/checkpoints/
@@ -1671,8 +1671,8 @@ class CustomTrainingJob(_CustomTrainingJob):
                 be immediately returned and synced when the Future has completed.
 
         Returns:
-            model: The trained AI Platform Model resource or None if training did not
-                produce an AI Platform Model.
+            model: The trained Vertex AI Model resource or None if training did not
+                produce an Vertex AI Model.
         """
         package_gcs_uri = python_packager.package_and_copy_to_gcs(
             gcs_staging_dir=self._staging_bucket,
@@ -1724,7 +1724,7 @@ class CustomTrainingJob(_CustomTrainingJob):
 
 
 class CustomContainerTrainingJob(_CustomTrainingJob):
-    """Class to launch a Custom Training Job in AI Platform using a
+    """Class to launch a Custom Training Job in Vertex AI using a
     Container."""
 
     def __init__(
@@ -1773,7 +1773,7 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
 
 
         TODO(b/169782082) add documentation about traning utilities
-        To ensure your model gets saved in AI Platform, write your saved model to
+        To ensure your model gets saved in Vertex AI, write your saved model to
         os.environ["AIP_MODEL_DIR"] in your provided training script.
 
 
@@ -1786,15 +1786,15 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
                 The command to be invoked when the container is started.
                 It overrides the entrypoint instruction in Dockerfile when provided
             model_serving_container_image_uri (str):
-                If the training produces a managed AI Platform Model, the URI of the
+                If the training produces a managed Vertex AI Model, the URI of the
                 Model serving container suitable for serving the model produced by the
                 training script.
             model_serving_container_predict_route (str):
-                If the training produces a managed AI Platform Model, An HTTP path to
+                If the training produces a managed Vertex AI Model, An HTTP path to
                 send prediction requests to the container, and which must be supported
-                by it. If not specified a default HTTP path will be used by AI Platform.
+                by it. If not specified a default HTTP path will be used by Vertex AI.
             model_serving_container_health_route (str):
-                If the training produces a managed AI Platform Model, an HTTP path to
+                If the training produces a managed Vertex AI Model, an HTTP path to
                 send health check requests to the container, and which must be supported
                 by it. If not specified a standard HTTP path will be used by AI
                 Platform.
@@ -1819,7 +1819,7 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
                 and values are environment variable values for those names.
             model_serving_container_ports (Sequence[int]):
                 Declaration of ports that are exposed by the container. This field is
-                primarily informational, it gives AI Platform information about the
+                primarily informational, it gives Vertex AI information about the
                 network connections the container uses. Listing or not a port here has
                 no impact on whether the port is actually exposed, any port listening on
                 the default "0.0.0.0" address inside a container will be accessible from
@@ -1974,12 +1974,12 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
         Any of ``training_fraction_split``, ``validation_fraction_split`` and
         ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
         the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by AI Platform. If none of the fractions are set, by default roughly 80%
+        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
         of data will be used for training, 10% for validation, and 10% for test.
 
         Args:
             dataset (Union[datasets.ImageDataset,datasets.TabularDataset,datasets.TextDataset,datasets.VideoDataset]):
-                AI Platform to fit this training against. Custom training script should
+                Vertex AI to fit this training against. Custom training script should
                 retrieve datasets through passed in environment variables uris:
 
                 os.environ["AIP_TRAINING_DATA_URI"]
@@ -2012,7 +2012,7 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
                 and
                 ``annotation_schema_uri``.
             model_display_name (str):
-                If the script produces a managed AI Platform Model. The display name of
+                If the script produces a managed Vertex AI Model. The display name of
                 the Model. The name can be up to 128 characters long and can be consist
                 of any UTF-8 characters.
 
@@ -2021,7 +2021,7 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
                 GCS output directory of job. If not provided a
                 timestamped directory in the staging directory will be used.
 
-                AI Platform sets the following environment variables when it runs your training code:
+                Vertex AI sets the following environment variables when it runs your training code:
 
                 -  AIP_MODEL_DIR: a Cloud Storage URI of a directory intended for saving model artifacts, i.e. <base_output_dir>/model/
                 -  AIP_CHECKPOINT_DIR: a Cloud Storage URI of a directory intended for saving checkpoints, i.e. <base_output_dir>/checkpoints/
@@ -2099,8 +2099,8 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
                 be immediately returned and synced when the Future has completed.
 
         Returns:
-            model: The trained AI Platform Model resource or None if training did not
-                produce an AI Platform Model.
+            model: The trained Vertex AI Model resource or None if training did not
+                produce an Vertex AI Model.
 
         Raises:
             RuntimeError: If Training job has already been run, staging_bucket has not
@@ -2169,7 +2169,7 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
                     datasets.VideoDataset,
                 ]
             ):
-                AI Platform to fit this training against.
+                Vertex AI to fit this training against.
             annotation_schema_uri (str):
                 Google Cloud Storage URI points to a YAML file describing
                 annotation schema.
@@ -2193,7 +2193,7 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
                 GCS output directory of job. If not provided a
                 timestamped directory in the staging directory will be used.
 
-                AI Platform sets the following environment variables when it runs your training code:
+                Vertex AI sets the following environment variables when it runs your training code:
 
                 -  AIP_MODEL_DIR: a Cloud Storage URI of a directory intended for saving model artifacts, i.e. <base_output_dir>/model/
                 -  AIP_CHECKPOINT_DIR: a Cloud Storage URI of a directory intended for saving checkpoints, i.e. <base_output_dir>/checkpoints/
@@ -2246,8 +2246,8 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
                 be immediately returned and synced when the Future has completed.
 
         Returns:
-            model: The trained AI Platform Model resource or None if training did not
-                produce an AI Platform Model.
+            model: The trained Vertex AI Model resource or None if training did not
+                produce an Vertex AI Model.
         """
 
         for spec in worker_pool_specs:
@@ -2440,7 +2440,7 @@ class AutoMLTabularTrainingJob(_TrainingJob):
         Any of ``training_fraction_split``, ``validation_fraction_split`` and
         ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
         the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by AI Platform. If none of the fractions are set, by default roughly 80%
+        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
         of data will be used for training, 10% for validation, and 10% for test.
 
         Args:
@@ -2491,7 +2491,7 @@ class AutoMLTabularTrainingJob(_TrainingJob):
                 will error.
                 The minimum value is 1000 and the maximum is 72000.
             model_display_name (str):
-                Optional. If the script produces a managed AI Platform Model. The display name of
+                Optional. If the script produces a managed Vertex AI Model. The display name of
                 the Model. The name can be up to 128 characters long and can be consist
                 of any UTF-8 characters.
 
@@ -2507,8 +2507,8 @@ class AutoMLTabularTrainingJob(_TrainingJob):
                 will be executed in concurrent Future and any downstream object will
                 be immediately returned and synced when the Future has completed.
         Returns:
-            model: The trained AI Platform Model resource or None if training did not
-                produce an AI Platform Model.
+            model: The trained Vertex AI Model resource or None if training did not
+                produce an Vertex AI Model.
 
         Raises:
             RuntimeError: If Training job has already been run or is waiting to run.
@@ -2555,7 +2555,7 @@ class AutoMLTabularTrainingJob(_TrainingJob):
         Any of ``training_fraction_split``, ``validation_fraction_split`` and
         ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
         the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by AI Platform. If none of the fractions are set, by default roughly 80%
+        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
         of data will be used for training, 10% for validation, and 10% for test.
 
         Args:
@@ -2606,7 +2606,7 @@ class AutoMLTabularTrainingJob(_TrainingJob):
                 will error.
                 The minimum value is 1000 and the maximum is 72000.
             model_display_name (str):
-                Optional. If the script produces a managed AI Platform Model. The display name of
+                Optional. If the script produces a managed Vertex AI Model. The display name of
                 the Model. The name can be up to 128 characters long and can be consist
                 of any UTF-8 characters.
 
@@ -2623,8 +2623,8 @@ class AutoMLTabularTrainingJob(_TrainingJob):
                 be immediately returned and synced when the Future has completed.
 
         Returns:
-            model: The trained AI Platform Model resource or None if training did not
-                produce an AI Platform Model.
+            model: The trained Vertex AI Model resource or None if training did not
+                produce an Vertex AI Model.
         """
 
         training_task_definition = schema.training_job.definition.automl_tabular
@@ -2883,7 +2883,7 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
                 will error.
                 The minimum value is 1000 and the maximum is 72000.
             model_display_name (str):
-                Optional. If the script produces a managed AI Platform Model. The display name of
+                Optional. If the script produces a managed Vertex AI Model. The display name of
                 the Model. The name can be up to 128 characters long and can be consist
                 of any UTF-8 characters.
 
@@ -2893,8 +2893,8 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
                 will be executed in concurrent Future and any downstream object will
                 be immediately returned and synced when the Future has completed.
         Returns:
-            model: The trained AI Platform Model resource or None if training did not
-                produce an AI Platform Model.
+            model: The trained Vertex AI Model resource or None if training did not
+                produce an Vertex AI Model.
 
         Raises:
             RuntimeError if Training job has already been run or is waiting to run.
@@ -3068,7 +3068,7 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
                 will error.
                 The minimum value is 1000 and the maximum is 72000.
             model_display_name (str):
-                Optional. If the script produces a managed AI Platform Model. The display name of
+                Optional. If the script produces a managed Vertex AI Model. The display name of
                 the Model. The name can be up to 128 characters long and can be consist
                 of any UTF-8 characters.
 
@@ -3078,8 +3078,8 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
                 will be executed in concurrent Future and any downstream object will
                 be immediately returned and synced when the Future has completed.
         Returns:
-            model: The trained AI Platform Model resource or None if training did not
-                produce an AI Platform Model.
+            model: The trained Vertex AI Model resource or None if training did not
+                produce an Vertex AI Model.
         """
 
         training_task_definition = schema.training_job.definition.automl_forecasting
@@ -3311,7 +3311,7 @@ class AutoMLImageTrainingJob(_TrainingJob):
         Any of ``training_fraction_split``, ``validation_fraction_split`` and
         ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
         the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by AI Platform. If none of the fractions are set, by default roughly 80%
+        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
         of data will be used for training, 10% for validation, and 10% for test.
 
         Args:
@@ -3345,7 +3345,7 @@ class AutoMLImageTrainingJob(_TrainingJob):
                 will error.
                 The minimum value is 1000 and the maximum is 72000.
             model_display_name (str):
-                Optional. The display name of the managed AI Platform Model. The name
+                Optional. The display name of the managed Vertex AI Model. The name
                 can be up to 128 characters long and can be consist of any UTF-8
                 characters. If not provided upon creation, the job's display_name is used.
             disable_early_stopping: bool = False
@@ -3359,8 +3359,8 @@ class AutoMLImageTrainingJob(_TrainingJob):
                 will be executed in concurrent Future and any downstream object will
                 be immediately returned and synced when the Future has completed.
         Returns:
-            model: The trained AI Platform Model resource or None if training did not
-                produce an AI Platform Model.
+            model: The trained Vertex AI Model resource or None if training did not
+                produce an Vertex AI Model.
 
         Raises:
             RuntimeError: If Training job has already been run or is waiting to run.
@@ -3403,7 +3403,7 @@ class AutoMLImageTrainingJob(_TrainingJob):
         Any of ``training_fraction_split``, ``validation_fraction_split`` and
         ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
         the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by AI Platform. If none of the fractions are set, by default roughly 80%
+        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
         of data will be used for training, 10% for validation, and 10% for test.
 
         Args:
@@ -3443,7 +3443,7 @@ class AutoMLImageTrainingJob(_TrainingJob):
                 will error.
                 The minimum value is 1000 and the maximum is 72000.
             model_display_name (str):
-                Optional. The display name of the managed AI Platform Model. The name
+                Optional. The display name of the managed Vertex AI Model. The name
                 can be up to 128 characters long and can be consist of any UTF-8
                 characters. If a `base_model` was provided, the display_name in the
                 base_model will be overritten with this value. If not provided upon
@@ -3460,8 +3460,8 @@ class AutoMLImageTrainingJob(_TrainingJob):
                 be immediately returned and synced when the Future has completed.
 
         Returns:
-            model: The trained AI Platform Model resource or None if training did not
-                produce an AI Platform Model.
+            model: The trained Vertex AI Model resource or None if training did not
+                produce an Vertex AI Model.
         """
 
         # Retrieve the objective-specific training task schema based on prediction_type
@@ -3491,7 +3491,7 @@ class AutoMLImageTrainingJob(_TrainingJob):
             model_tbt.description = getattr(base_model._gca_resource, "description")
             model_tbt.labels = getattr(base_model._gca_resource, "labels")
 
-            # Set ID of AI Platform Model to base this training job off of
+            # Set ID of Vertex AI Model to base this training job off of
             training_task_inputs_dict["baseModelId"] = base_model.name
 
         return self._run_job(
@@ -3514,11 +3514,11 @@ class AutoMLImageTrainingJob(_TrainingJob):
 
 
 class CustomPythonPackageTrainingJob(_CustomTrainingJob):
-    """Class to launch a Custom Training Job in AI Platform using a Python
+    """Class to launch a Custom Training Job in Vertex AI using a Python
     Package.
 
     Takes a training implementation as a python package and executes
-    that package in Cloud AI Platform Training.
+    that package in Cloud Vertex AI Training.
     """
 
     def __init__(
@@ -3576,7 +3576,7 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
                 model_display_name='my-trained-model'
             )
 
-        To ensure your model gets saved in AI Platform, write your saved model to
+        To ensure your model gets saved in Vertex AI, write your saved model to
         os.environ["AIP_MODEL_DIR"] in your provided training script.
 
         Args:
@@ -3589,15 +3589,15 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
             container_uri (str):
                 Required: Uri of the training container image in the GCR.
             model_serving_container_image_uri (str):
-                If the training produces a managed AI Platform Model, the URI of the
+                If the training produces a managed Vertex AI Model, the URI of the
                 Model serving container suitable for serving the model produced by the
                 training script.
             model_serving_container_predict_route (str):
-                If the training produces a managed AI Platform Model, An HTTP path to
+                If the training produces a managed Vertex AI Model, An HTTP path to
                 send prediction requests to the container, and which must be supported
-                by it. If not specified a default HTTP path will be used by AI Platform.
+                by it. If not specified a default HTTP path will be used by Vertex AI.
             model_serving_container_health_route (str):
-                If the training produces a managed AI Platform Model, an HTTP path to
+                If the training produces a managed Vertex AI Model, an HTTP path to
                 send health check requests to the container, and which must be supported
                 by it. If not specified a standard HTTP path will be used by AI
                 Platform.
@@ -3622,7 +3622,7 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
                 and values are environment variable values for those names.
             model_serving_container_ports (Sequence[int]):
                 Declaration of ports that are exposed by the container. This field is
-                primarily informational, it gives AI Platform information about the
+                primarily informational, it gives Vertex AI information about the
                 network connections the container uses. Listing or not a port here has
                 no impact on whether the port is actually exposed, any port listening on
                 the default "0.0.0.0" address inside a container will be accessible from
@@ -3776,12 +3776,12 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
         Any of ``training_fraction_split``, ``validation_fraction_split`` and
         ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
         the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by AI Platform.If none of the fractions are set, by default roughly 80%
+        decided by Vertex AI.If none of the fractions are set, by default roughly 80%
         of data will be used for training, 10% for validation, and 10% for test.
 
         Args:
             dataset (Union[datasets.ImageDataset,datasets.TabularDataset,datasets.TextDataset,datasets.VideoDataset,]):
-                AI Platform to fit this training against. Custom training script should
+                Vertex AI to fit this training against. Custom training script should
                 retrieve datasets through passed in environment variables uris:
 
                 os.environ["AIP_TRAINING_DATA_URI"]
@@ -3814,7 +3814,7 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
                 and
                 ``annotation_schema_uri``.
             model_display_name (str):
-                If the script produces a managed AI Platform Model. The display name of
+                If the script produces a managed Vertex AI Model. The display name of
                 the Model. The name can be up to 128 characters long and can be consist
                 of any UTF-8 characters.
 
@@ -3823,7 +3823,7 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
                 GCS output directory of job. If not provided a
                 timestamped directory in the staging directory will be used.
 
-                AI Platform sets the following environment variables when it runs your training code:
+                Vertex AI sets the following environment variables when it runs your training code:
 
                 -  AIP_MODEL_DIR: a Cloud Storage URI of a directory intended for saving model artifacts, i.e. <base_output_dir>/model/
                 -  AIP_CHECKPOINT_DIR: a Cloud Storage URI of a directory intended for saving checkpoints, i.e. <base_output_dir>/checkpoints/
@@ -3901,8 +3901,8 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
                 be immediately returned and synced when the Future has completed.
 
         Returns:
-            model: The trained AI Platform Model resource or None if training did not
-                produce an AI Platform Model.
+            model: The trained Vertex AI Model resource or None if training did not
+                produce an Vertex AI Model.
         """
         worker_pool_specs, managed_model = self._prepare_and_validate_run(
             model_display_name=model_display_name,
@@ -3967,7 +3967,7 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
                     datasets.VideoDataset,
                 ]
             ):
-                AI Platform to fit this training against.
+                Vertex AI to fit this training against.
             annotation_schema_uri (str):
                 Google Cloud Storage URI points to a YAML file describing
                 annotation schema.
@@ -3991,7 +3991,7 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
                 GCS output directory of job. If not provided a
                 timestamped directory in the staging directory will be used.
 
-                AI Platform sets the following environment variables when it runs your training code:
+                Vertex AI sets the following environment variables when it runs your training code:
 
                 -  AIP_MODEL_DIR: a Cloud Storage URI of a directory intended for saving model artifacts, i.e. <base_output_dir>/model/
                 -  AIP_CHECKPOINT_DIR: a Cloud Storage URI of a directory intended for saving checkpoints, i.e. <base_output_dir>/checkpoints/
@@ -4030,8 +4030,8 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
                 be immediately returned and synced when the Future has completed.
 
         Returns:
-            model: The trained AI Platform Model resource or None if training did not
-                produce an AI Platform Model.
+            model: The trained Vertex AI Model resource or None if training did not
+                produce an Vertex AI Model.
         """
         for spec in worker_pool_specs:
             spec["python_package_spec"] = {
@@ -4228,7 +4228,7 @@ class AutoMLVideoTrainingJob(_TrainingJob):
                 Required. The fraction of the input data that is to be
                 used to evaluate the Model. This is ignored if Dataset is not provided.
             model_display_name (str):
-                Optional. The display name of the managed AI Platform Model. The name
+                Optional. The display name of the managed Vertex AI Model. The name
                 can be up to 128 characters long and can be consist of any UTF-8
                 characters. If not provided upon creation, the job's display_name is used.
             sync: bool = True
@@ -4236,8 +4236,8 @@ class AutoMLVideoTrainingJob(_TrainingJob):
                 will be executed in concurrent Future and any downstream object will
                 be immediately returned and synced when the Future has completed.
         Returns:
-            model: The trained AI Platform Model resource or None if training did not
-                produce an AI Platform Model.
+            model: The trained Vertex AI Model resource or None if training did not
+                produce an Vertex AI Model.
 
         Raises:
             RuntimeError: If Training job has already been run or is waiting to run.
@@ -4289,7 +4289,7 @@ class AutoMLVideoTrainingJob(_TrainingJob):
                 Required. The fraction of the input data that is to be
                 used to evaluate the Model. This is ignored if Dataset is not provided.
             model_display_name (str):
-                Optional. The display name of the managed AI Platform Model. The name
+                Optional. The display name of the managed Vertex AI Model. The name
                 can be up to 128 characters long and can be consist of any UTF-8
                 characters. If a `base_model` was provided, the display_name in the
                 base_model will be overritten with this value. If not provided upon
@@ -4300,8 +4300,8 @@ class AutoMLVideoTrainingJob(_TrainingJob):
                 be immediately returned and synced when the Future has completed.
 
         Returns:
-            model: The trained AI Platform Model resource or None if training did not
-                produce an AI Platform Model.
+            model: The trained Vertex AI Model resource or None if training did not
+                produce an Vertex AI Model.
         """
 
         # Retrieve the objective-specific training task schema based on prediction_type
@@ -4364,7 +4364,7 @@ class AutoMLTextTrainingJob(_TrainingJob):
                 The type of prediction the Model is to produce, one of:
                     "classification" - A classification model analyzes text data and
                         returns a list of categories that apply to the text found in the data.
-                        AI Platform offers both single-label and multi-label text classification models.
+                        Vertex AI offers both single-label and multi-label text classification models.
                     "extraction" - An entity extraction model inspects text data
                         for known entities referenced in the data and
                         labels those entities in the text.
@@ -4478,7 +4478,7 @@ class AutoMLTextTrainingJob(_TrainingJob):
         Any of ``training_fraction_split``, ``validation_fraction_split`` and
         ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
         the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by AI Platform. If none of the fractions are set, by default roughly 80%
+        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
         of data will be used for training, 10% for validation, and 10% for test.
 
         Args:
@@ -4498,7 +4498,7 @@ class AutoMLTextTrainingJob(_TrainingJob):
                 Required. The fraction of the input data that is to be
                 used to evaluate the Model. This is ignored if Dataset is not provided.
             model_display_name (str):
-                Optional. The display name of the managed AI Platform Model.
+                Optional. The display name of the managed Vertex AI Model.
                 The name can be up to 128 characters long and can consist
                 of any UTF-8 characters.
 
@@ -4508,7 +4508,7 @@ class AutoMLTextTrainingJob(_TrainingJob):
                 will be executed in concurrent Future and any downstream object will
                 be immediately returned and synced when the Future has completed.
         Returns:
-            model: The trained AI Platform Model resource.
+            model: The trained Vertex AI Model resource.
 
         Raises:
             RuntimeError: If Training job has already been run or is waiting to run.
@@ -4545,7 +4545,7 @@ class AutoMLTextTrainingJob(_TrainingJob):
         Any of ``training_fraction_split``, ``validation_fraction_split`` and
         ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
         the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by AI Platform. If none of the fractions are set, by default roughly 80%
+        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
         of data will be used for training, 10% for validation, and 10% for test.
 
         Args:
@@ -4567,7 +4567,7 @@ class AutoMLTextTrainingJob(_TrainingJob):
                 Required. The fraction of the input data that is to be
                 used to evaluate the Model. This is ignored if Dataset is not provided.
             model_display_name (str):
-                Optional. If the script produces a managed AI Platform Model. The display name of
+                Optional. If the script produces a managed Vertex AI Model. The display name of
                 the Model. The name can be up to 128 characters long and can be consist
                 of any UTF-8 characters.
 
@@ -4578,8 +4578,8 @@ class AutoMLTextTrainingJob(_TrainingJob):
                 be immediately returned and synced when the Future has completed.
 
         Returns:
-            model: The trained AI Platform Model resource or None if training did not
-                produce an AI Platform Model.
+            model: The trained Vertex AI Model resource or None if training did not
+                produce an Vertex AI Model.
         """
 
         if model_display_name is None:

--- a/google/cloud/aiplatform/utils/__init__.py
+++ b/google/cloud/aiplatform/utils/__init__.py
@@ -110,7 +110,7 @@ def extract_fields_from_resource_name(
 
     Args:
         resource_name (str):
-            Required. A fully-qualified AI Platform (Unified) resource name
+            Required. A fully-qualified Vertex AI resource name
 
         resource_noun (str):
             A resource noun to validate the resource name against.
@@ -145,7 +145,7 @@ def full_resource_name(
 
     Args:
         resource_name (str):
-            Required. A fully-qualified AI Platform (Unified) resource name or
+            Required. A fully-qualified Vertex AI resource name or
             resource ID.
         resource_noun (str):
             A resource noun to validate the resource name against.
@@ -163,7 +163,7 @@ def full_resource_name(
 
     Returns:
         resource_name (str):
-            A fully-qualified AI Platform (Unified) resource name.
+            A fully-qualified Vertex AI resource name.
 
     Raises:
         ValueError:
@@ -257,7 +257,7 @@ def validate_region(region: str) -> bool:
     region = region.lower()
     if region not in constants.SUPPORTED_REGIONS:
         raise ValueError(
-            f"Unsupported region for AI Platform, select from {constants.SUPPORTED_REGIONS}"
+            f"Unsupported region for Vertex AI, select from {constants.SUPPORTED_REGIONS}"
         )
 
     return True

--- a/google/cloud/aiplatform/utils/__init__.py
+++ b/google/cloud/aiplatform/utils/__init__.py
@@ -56,8 +56,8 @@ from google.cloud.aiplatform.compat.types import (
     accelerator_type as gca_accelerator_type,
 )
 
-AiPlatformServiceClient = TypeVar(
-    "AiPlatformServiceClient",
+VertexAiServiceClient = TypeVar(
+    "VertexAiServiceClient",
     # v1beta1
     dataset_service_client_v1beta1.DatasetServiceClient,
     endpoint_service_client_v1beta1.EndpointServiceClient,
@@ -324,7 +324,7 @@ class ClientWithOverride:
 
         def __init__(
             self,
-            client_class: Type[AiPlatformServiceClient],
+            client_class: Type[VertexAiServiceClient],
             client_options: client_options.ClientOptions,
             client_info: gapic_v1.client_info.ClientInfo,
             credentials: Optional[auth_credentials.Credentials] = None,
@@ -332,7 +332,7 @@ class ClientWithOverride:
             """Stores parameters needed to instantiate client.
 
             Args:
-                client_class (AiPlatformServiceClient):
+                client_class (VertexAiServiceClient):
                     Required. Class of the client to use.
                 client_options (client_options.ClientOptions):
                     Required. Client options to pass to client.
@@ -410,7 +410,7 @@ class ClientWithOverride:
         """Instantiates client and returns attribute of the client."""
         return getattr(self._clients[self._default_version], name)
 
-    def select_version(self, version: str) -> AiPlatformServiceClient:
+    def select_version(self, version: str) -> VertexAiServiceClient:
         return self._clients[version]
 
 
@@ -484,8 +484,8 @@ class TensorboardClientWithOverride(ClientWithOverride):
     )
 
 
-AiPlatformServiceClientWithOverride = TypeVar(
-    "AiPlatformServiceClientWithOverride",
+VertexAiServiceClientWithOverride = TypeVar(
+    "VertexAiServiceClientWithOverride",
     DatasetClientWithOverride,
     EndpointClientWithOverride,
     JobClientWithOverride,

--- a/google/cloud/aiplatform/utils/worker_spec_utils.py
+++ b/google/cloud/aiplatform/utils/worker_spec_utils.py
@@ -87,7 +87,7 @@ class _MachineSpec(NamedTuple):
 class _DistributedTrainingSpec(NamedTuple):
     """Configuration for distributed training worker pool specs.
 
-    AI Platform Training expects configuration in this order:
+    Vertex AI Training expects configuration in this order:
     [
         chief spec, # can only have one replica
         worker spec,
@@ -122,15 +122,15 @@ class _DistributedTrainingSpec(NamedTuple):
     def pool_specs(
         self,
     ) -> List[Dict[str, Union[int, str, Dict[str, Union[int, str]]]]]:
-        """Return each pools spec in correct order for AI Platform as a list of
+        """Return each pools spec in correct order for Vertex AI as a list of
         dicts.
 
         Also removes specs if they are empty but leaves specs in if there unusual
-        specifications to not break the ordering in AI Platform Training.
+        specifications to not break the ordering in Vertex AI Training.
         ie. 0 chief replica, 10 worker replica, 3 ps replica
 
         Returns:
-            Order list of worker pool specs suitable for AI Platform Training.
+            Order list of worker pool specs suitable for Vertex AI Training.
         """
         if self.chief_spec.replica_count > 1:
             raise ValueError("Chief spec replica count cannot be greater than 1.")

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setuptools.setup(
     python_requires=">=3.6",
     scripts=[],
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.6",

--- a/tests/unit/aiplatform/test_hyperparameter_tuning_job.py
+++ b/tests/unit/aiplatform/test_hyperparameter_tuning_job.py
@@ -31,9 +31,13 @@ from google.cloud.aiplatform.compat.types import (
 )
 from google.cloud.aiplatform.compat.types import (
     hyperparameter_tuning_job as gca_hyperparameter_tuning_job_compat,
+    hyperparameter_tuning_job_v1beta1 as gca_hyperparameter_tuning_job_v1beta1,
 )
 from google.cloud.aiplatform.compat.types import study as gca_study_compat
 from google.cloud.aiplatform_v1.services.job_service import client as job_service_client
+from google.cloud.aiplatform_v1beta1.services.job_service import (
+    client as job_service_client_v1beta1,
+)
 
 import test_custom_job
 
@@ -122,12 +126,29 @@ _TEST_BASE_HYPERPARAMETER_TUNING_JOB_PROTO = gca_hyperparameter_tuning_job_compa
 )
 
 
-def _get_hyperparameter_tuning_job_proto(state=None, name=None, error=None):
-    custom_job_proto = copy.deepcopy(_TEST_BASE_HYPERPARAMETER_TUNING_JOB_PROTO)
-    custom_job_proto.name = name
-    custom_job_proto.state = state
-    custom_job_proto.error = error
-    return custom_job_proto
+def _get_hyperparameter_tuning_job_proto(
+    state=None, name=None, error=None, version="v1"
+):
+    hyperparameter_tuning_job_proto = copy.deepcopy(
+        _TEST_BASE_HYPERPARAMETER_TUNING_JOB_PROTO
+    )
+    hyperparameter_tuning_job_proto.name = name
+    hyperparameter_tuning_job_proto.state = state
+    hyperparameter_tuning_job_proto.error = error
+
+    if version == "v1beta1":
+        v1beta1_hyperparameter_tuning_job_proto = (
+            gca_hyperparameter_tuning_job_v1beta1.HyperparameterTuningJob()
+        )
+        v1beta1_hyperparameter_tuning_job_proto._pb.MergeFromString(
+            hyperparameter_tuning_job_proto._pb.SerializeToString()
+        )
+        hyperparameter_tuning_job_proto = v1beta1_hyperparameter_tuning_job_proto
+        hyperparameter_tuning_job_proto.trial_job_spec.tensorboard = (
+            test_custom_job._TEST_TENSORBOARD_NAME
+        )
+
+    return hyperparameter_tuning_job_proto
 
 
 @pytest.fixture
@@ -187,7 +208,20 @@ def create_hyperparameter_tuning_job_mock():
         yield create_hyperparameter_tuning_job_mock
 
 
-class TestCustomJob:
+@pytest.fixture
+def create_hyperparameter_tuning_job_v1beta1_mock():
+    with mock.patch.object(
+        job_service_client_v1beta1.JobServiceClient, "create_hyperparameter_tuning_job"
+    ) as create_hyperparameter_tuning_job_mock:
+        create_hyperparameter_tuning_job_mock.return_value = _get_hyperparameter_tuning_job_proto(
+            name=_TEST_HYPERPARAMETERTUNING_JOB_NAME,
+            state=gca_job_state_compat.JobState.JOB_STATE_PENDING,
+            version="v1beta1",
+        )
+        yield create_hyperparameter_tuning_job_mock
+
+
+class TestHyperparameterTuningJob:
     def setup_method(self):
         reload(aiplatform.initializer)
         reload(aiplatform)
@@ -365,4 +399,69 @@ class TestCustomJob:
         )
         assert (
             job._gca_resource.state == gca_job_state_compat.JobState.JOB_STATE_PENDING
+        )
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_create_hyperparameter_tuning_job_with_tensorboard(
+        self,
+        create_hyperparameter_tuning_job_v1beta1_mock,
+        get_hyperparameter_tuning_job_mock,
+        sync,
+    ):
+
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            location=_TEST_LOCATION,
+            staging_bucket=_TEST_STAGING_BUCKET,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
+        )
+
+        custom_job = aiplatform.CustomJob(
+            display_name=test_custom_job._TEST_DISPLAY_NAME,
+            worker_pool_specs=test_custom_job._TEST_WORKER_POOL_SPEC,
+        )
+
+        job = aiplatform.HyperparameterTuningJob(
+            display_name=_TEST_DISPLAY_NAME,
+            custom_job=custom_job,
+            metric_spec={_TEST_METRIC_SPEC_KEY: _TEST_METRIC_SPEC_VALUE},
+            parameter_spec={
+                "lr": hpt.DoubleParameterSpec(min=0.001, max=0.1, scale="log"),
+                "units": hpt.IntegerParameterSpec(min=4, max=1028, scale="linear"),
+                "activation": hpt.CategoricalParameterSpec(
+                    values=["relu", "sigmoid", "elu", "selu", "tanh"]
+                ),
+                "batch_size": hpt.DiscreteParameterSpec(
+                    values=[16, 32], scale="linear"
+                ),
+            },
+            parallel_trial_count=_TEST_PARALLEL_TRIAL_COUNT,
+            max_trial_count=_TEST_MAX_TRIAL_COUNT,
+            max_failed_trial_count=_TEST_MAX_FAILED_TRIAL_COUNT,
+            search_algorithm=_TEST_SEARCH_ALGORITHM,
+            measurement_selection=_TEST_MEASUREMENT_SELECTION,
+        )
+
+        job.run(
+            service_account=_TEST_SERVICE_ACCOUNT,
+            network=_TEST_NETWORK,
+            timeout=_TEST_TIMEOUT,
+            restart_job_on_worker_restart=_TEST_RESTART_JOB_ON_WORKER_RESTART,
+            tensorboard=test_custom_job._TEST_TENSORBOARD_NAME,
+            sync=sync,
+        )
+
+        job.wait()
+
+        expected_hyperparameter_tuning_job = _get_hyperparameter_tuning_job_proto(
+            version="v1beta1"
+        )
+
+        create_hyperparameter_tuning_job_v1beta1_mock.assert_called_once_with(
+            parent=_TEST_PARENT,
+            hyperparameter_tuning_job=expected_hyperparameter_tuning_job,
+        )
+
+        assert (
+            job._gca_resource.state == gca_job_state_compat.JobState.JOB_STATE_SUCCEEDED
         )


### PR DESCRIPTION
- This is branched off of https://github.com/googleapis/python-aiplatform/pull/404. Hold merging until that is in.
- Docstrings and documentation contain renames.
- Class names for Vertex SDK have been renamed.