### PR TITLE
fix: Remove URI attribute from Endpoint sample

### DIFF
--- a/samples/model-builder/create_endpoint_sample.py
+++ b/samples/model-builder/create_endpoint_sample.py
@@ -27,7 +27,6 @@ def create_endpoint_sample(
 
     print(endpoint.display_name)
     print(endpoint.resource_name)
-    print(endpoint.uri)
     return endpoint
 
 


### PR DESCRIPTION
Remove the `endpoint.uri` attribute from `create_endpoint_sample.py`.

Resolves Buganizer [issue](http://b/189844848)

Fixes #189844848🦕
