### PR TITLE
fix: making the uploader depend on tensorflow-proper

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,14 +29,10 @@ readme_filename = os.path.join(package_root, "README.rst")
 with io.open(readme_filename, encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-tensorboard_extra_require = [
-    "tensorflow-cpu>=2.3.0, <=2.5.0",
-    "grpcio~=1.38.1",
-    "six~=1.15.0",
-]
+tensorboard_extra_require = ["tensorflow >=2.3.0, <=2.5.0"]
 metadata_extra_require = ["pandas >= 1.0.0"]
 full_extra_require = tensorboard_extra_require + metadata_extra_require
-testing_extra_require = full_extra_require + ["grpcio-testing~=1.38.1"]
+testing_extra_require = full_extra_require + ["grpcio-testing"]
 
 
 setuptools.setup(


### PR DESCRIPTION
Fixes b/191305567.

Vertex notebooks, and (I suppose) the majority of users have "tensorflow" installed, instead of "tensorflow-cpu", which doesn't play nice with "tensorflow" and forces to pin on weird specific dependency versions.

Tried on notebooks with TF 2.3 and 2.5, as well as brand-new conda envs. All seemed working fine.