### PR TITLE
fix: Handle nested fields from BigQuery source when getting default column_names

### DIFF
--- a/google/cloud/aiplatform/datasets/tabular_dataset.py
+++ b/google/cloud/aiplatform/datasets/tabular_dataset.py
@@ -165,7 +165,7 @@ class TabularDataset(datasets._Dataset):
         finally:
             logger.removeFilter(logging_warning_filter)
 
-        return Set(next(csv_reader))
+        return set(next(csv_reader))
 
     @staticmethod
     def _get_bq_schema_field_names_recursively(schema_field: SchemaField) -> Set[str]:
@@ -187,13 +187,13 @@ class TabularDataset(datasets._Dataset):
                 A set of columns names in the BigQuery table.
         """
 
-        ancestor_names = [
+        ancestor_names = {
             nested_field_name
             for field in schema_field.fields
             for nested_field_name in TabularDataset._get_bq_schema_field_names_recursively(
                 field
             )
-        ]
+        }
 
         # Only return "leaf nodes", basically any field that doesn't have children
         if len(ancestor_names) == 0:

--- a/google/cloud/aiplatform/datasets/tabular_dataset.py
+++ b/google/cloud/aiplatform/datasets/tabular_dataset.py
@@ -195,6 +195,7 @@ class TabularDataset(datasets._Dataset):
             )
         ]
 
+        # Only return "leaf nodes", basically any field that doesn't have children
         if len(ancestor_names) == 0:
             return {schema_field.name}
         else:

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -375,6 +375,59 @@ def bigquery_table_schema_mock():
         bigquery_table_schema_mock.return_value = [
             bigquery.SchemaField("column_1", "FLOAT", "NULLABLE", "", (), None),
             bigquery.SchemaField("column_2", "FLOAT", "NULLABLE", "", (), None),
+            bigquery.SchemaField(
+                "column_3",
+                "FLOAT",
+                "NULLABLE",
+                "",
+                (
+                    bigquery.SchemaField(
+                        "nested_3_1",
+                        "FLOAT",
+                        "NULLABLE",
+                        "",
+                        (
+                            bigquery.SchemaField(
+                                "nested_3_1_1", "FLOAT", "NULLABLE", "", (), None
+                            ),
+                            bigquery.SchemaField(
+                                "nested_3_1_2", "FLOAT", "NULLABLE", "", (), None
+                            ),
+                        ),
+                        None,
+                    ),
+                    bigquery.SchemaField(
+                        "nested_3_2", "FLOAT", "NULLABLE", "", (), None
+                    ),
+                    bigquery.SchemaField(
+                        "nested_3_3",
+                        "FLOAT",
+                        "NULLABLE",
+                        "",
+                        (
+                            bigquery.SchemaField(
+                                "nested_3_3_1",
+                                "FLOAT",
+                                "NULLABLE",
+                                "",
+                                (
+                                    bigquery.SchemaField(
+                                        "nested_3_3_1_1",
+                                        "FLOAT",
+                                        "NULLABLE",
+                                        "",
+                                        (),
+                                        None,
+                                    ),
+                                ),
+                                None,
+                            ),
+                        ),
+                        None,
+                    ),
+                ),
+                None,
+            ),
         ]
         yield bigquery_table_schema_mock
 
@@ -1045,7 +1098,16 @@ class TestTabularDataset:
     def test_tabular_dataset_column_name_bigquery(self):
         my_dataset = datasets.TabularDataset(dataset_name=_TEST_NAME)
 
-        assert my_dataset.column_names == ["column_1", "column_2"]
+        assert my_dataset.column_names == set(
+            [
+                "column_1",
+                "column_2",
+                "column_3.nested_3_1.nested_3_1_1",
+                "column_3.nested_3_1.nested_3_1_2",
+                "column_3.nested_3_2",
+                "column_3.nested_3_3.nested_3_3_1.nested_3_3_1_1",
+            ]
+        )
 
 
 class TestTextDataset:

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -1060,7 +1060,7 @@ class TestTabularDataset:
     def test_tabular_dataset_column_name_gcs(self):
         my_dataset = datasets.TabularDataset(dataset_name=_TEST_NAME)
 
-        assert my_dataset.column_names == ["column_1", "column_2"]
+        assert set(my_dataset.column_names) == {"column_1", "column_2"}
 
     @pytest.mark.usefixtures("get_dataset_tabular_gcs_mock")
     def test_tabular_dataset_column_name_gcs_with_creds(self, gcs_client_mock):
@@ -1098,7 +1098,7 @@ class TestTabularDataset:
     def test_tabular_dataset_column_name_bigquery(self):
         my_dataset = datasets.TabularDataset(dataset_name=_TEST_NAME)
 
-        assert my_dataset.column_names == set(
+        assert set(my_dataset.column_names) == set(
             [
                 "column_1",
                 "column_2",

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -377,13 +377,13 @@ def bigquery_table_schema_mock():
             bigquery.SchemaField("column_2", "FLOAT", "NULLABLE", "", (), None),
             bigquery.SchemaField(
                 "column_3",
-                "FLOAT",
+                "RECORD",
                 "NULLABLE",
                 "",
                 (
                     bigquery.SchemaField(
                         "nested_3_1",
-                        "FLOAT",
+                        "RECORD",
                         "NULLABLE",
                         "",
                         (
@@ -401,13 +401,13 @@ def bigquery_table_schema_mock():
                     ),
                     bigquery.SchemaField(
                         "nested_3_3",
-                        "FLOAT",
+                        "RECORD",
                         "NULLABLE",
                         "",
                         (
                             bigquery.SchemaField(
                                 "nested_3_3_1",
-                                "FLOAT",
+                                "RECORD",
                                 "NULLABLE",
                                 "",
                                 (


### PR DESCRIPTION
Fixes '`ds.column_names` doesn't contain nested fields in BigQuery table' issue.

According to the product team, only "leaf node" fields should be passed to AutoML tabular.

Added unit test for it.

Fixes b/191864144 🦕
