### PR TITLE
chore: skip samples checks for python 3.6/8/9

### DIFF
--- a/samples/snippets/noxfile_config.py
+++ b/samples/snippets/noxfile_config.py
@@ -19,7 +19,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7"],
+    "ignored_versions": ["2.7", "3.6", "3.8", "3.9"],
     # An envvar key for determining the project id to use. Change it
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string


### PR DESCRIPTION
cl/356265286 removed samples checks for python 3.6 and 3.8 for `python-aiplatform`. The Yoshi Core python team would like to standardize samples checks among all python googleapis repos. This PR will ensure that when the required samples checks are re-enabled, the samples checks for python 3.6 and 3.8 will be skipped. 