### PR TITLE
Feat: add labels to all resource creation apis

### DIFF
--- a/google/cloud/aiplatform/datasets/dataset.py
+++ b/google/cloud/aiplatform/datasets/dataset.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import Optional, Sequence, Dict, Tuple, Union, List
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 from google.api_core import operation
 from google.auth import credentials as auth_credentials
@@ -115,6 +115,7 @@ class _Dataset(base.VertexAiResourceNounWithFutureManager):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         request_metadata: Optional[Sequence[Tuple[str, str]]] = (),
+        labels: Optional[Dict[str, str]] = None,
         encryption_spec_key_name: Optional[str] = None,
         sync: bool = True,
     ) -> "_Dataset":
@@ -176,6 +177,16 @@ class _Dataset(base.VertexAiResourceNounWithFutureManager):
                 credentials set in aiplatform.init.
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the request as metadata.
+            labels (Dict[str, str]):
+                Optional. Labels with user-defined metadata to organize your Tensorboards.
+                Label keys and values can be no longer than 64 characters
+                (Unicode codepoints), can only contain lowercase letters, numeric
+                characters, underscores and dashes. International characters are allowed.
+                No more than 64 user labels can be associated with one Tensorboard
+                (System labels are excluded).
+                See https://goo.gl/xmQnxf for more information and examples of labels.
+                System reserved label keys are prefixed with "aiplatform.googleapis.com/"
+                and are immutable.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
                 managed encryption key used to protect the dataset. Has the
@@ -198,6 +209,8 @@ class _Dataset(base.VertexAiResourceNounWithFutureManager):
         """
 
         utils.validate_display_name(display_name)
+        if labels:
+            utils.validate_labels(labels)
 
         api_client = cls._instantiate_client(location=location, credentials=credentials)
 
@@ -221,6 +234,7 @@ class _Dataset(base.VertexAiResourceNounWithFutureManager):
             location=location or initializer.global_config.location,
             credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
+            labels=labels,
             encryption_spec=initializer.global_config.get_encryption_spec(
                 encryption_spec_key_name=encryption_spec_key_name
             ),
@@ -240,6 +254,7 @@ class _Dataset(base.VertexAiResourceNounWithFutureManager):
         location: str,
         credentials: Optional[auth_credentials.Credentials],
         request_metadata: Optional[Sequence[Tuple[str, str]]] = (),
+        labels: Optional[Dict[str, str]] = None,
         encryption_spec: Optional[gca_encryption_spec.EncryptionSpec] = None,
         sync: bool = True,
     ) -> "_Dataset":
@@ -277,6 +292,16 @@ class _Dataset(base.VertexAiResourceNounWithFutureManager):
                 credentials set in aiplatform.init.
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the request as metadata.
+            labels (Dict[str, str]):
+                Optional. Labels with user-defined metadata to organize your Tensorboards.
+                Label keys and values can be no longer than 64 characters
+                (Unicode codepoints), can only contain lowercase letters, numeric
+                characters, underscores and dashes. International characters are allowed.
+                No more than 64 user labels can be associated with one Tensorboard
+                (System labels are excluded).
+                See https://goo.gl/xmQnxf for more information and examples of labels.
+                System reserved label keys are prefixed with "aiplatform.googleapis.com/"
+                and are immutable.
             encryption_spec (Optional[gca_encryption_spec.EncryptionSpec]):
                 Optional. The Cloud KMS customer managed encryption key used to protect the dataset.
                 The key needs to be in the same region as where the compute
@@ -300,6 +325,7 @@ class _Dataset(base.VertexAiResourceNounWithFutureManager):
             metadata_schema_uri=metadata_schema_uri,
             datasource=datasource,
             request_metadata=request_metadata,
+            labels=labels,
             encryption_spec=encryption_spec,
         )
 
@@ -346,6 +372,7 @@ class _Dataset(base.VertexAiResourceNounWithFutureManager):
         metadata_schema_uri: str,
         datasource: _datasources.Datasource,
         request_metadata: Sequence[Tuple[str, str]] = (),
+        labels: Optional[Dict[str, str]] = None,
         encryption_spec: Optional[gca_encryption_spec.EncryptionSpec] = None,
     ) -> operation.Operation:
         """Creates a new managed dataset by directly calling API client.
@@ -373,6 +400,16 @@ class _Dataset(base.VertexAiResourceNounWithFutureManager):
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the create_dataset
                 request as metadata. Usually to specify special dataset config.
+            labels (Dict[str, str]):
+                Optional. Labels with user-defined metadata to organize your Tensorboards.
+                Label keys and values can be no longer than 64 characters
+                (Unicode codepoints), can only contain lowercase letters, numeric
+                characters, underscores and dashes. International characters are allowed.
+                No more than 64 user labels can be associated with one Tensorboard
+                (System labels are excluded).
+                See https://goo.gl/xmQnxf for more information and examples of labels.
+                System reserved label keys are prefixed with "aiplatform.googleapis.com/"
+                and are immutable.
             encryption_spec (Optional[gca_encryption_spec.EncryptionSpec]):
                 Optional. The Cloud KMS customer managed encryption key used to protect the dataset.
                 The key needs to be in the same region as where the compute
@@ -388,6 +425,7 @@ class _Dataset(base.VertexAiResourceNounWithFutureManager):
             display_name=display_name,
             metadata_schema_uri=metadata_schema_uri,
             metadata=datasource.dataset_metadata,
+            labels=labels,
             encryption_spec=encryption_spec,
         )
 

--- a/google/cloud/aiplatform/datasets/image_dataset.py
+++ b/google/cloud/aiplatform/datasets/image_dataset.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import Optional, Sequence, Dict, Tuple, Union
+from typing import Dict, Optional, Sequence, Tuple, Union
 
 from google.auth import credentials as auth_credentials
 
@@ -44,6 +44,7 @@ class ImageDataset(datasets._Dataset):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         request_metadata: Optional[Sequence[Tuple[str, str]]] = (),
+        labels: Optional[Dict[str, str]] = None,
         encryption_spec_key_name: Optional[str] = None,
         sync: bool = True,
     ) -> "ImageDataset":
@@ -95,6 +96,16 @@ class ImageDataset(datasets._Dataset):
                 credentials set in aiplatform.init.
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the request as metadata.
+            labels (Dict[str, str]):
+                Optional. Labels with user-defined metadata to organize your Tensorboards.
+                Label keys and values can be no longer than 64 characters
+                (Unicode codepoints), can only contain lowercase letters, numeric
+                characters, underscores and dashes. International characters are allowed.
+                No more than 64 user labels can be associated with one Tensorboard
+                (System labels are excluded).
+                See https://goo.gl/xmQnxf for more information and examples of labels.
+                System reserved label keys are prefixed with "aiplatform.googleapis.com/"
+                and are immutable.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
                 managed encryption key used to protect the dataset. Has the
@@ -117,6 +128,8 @@ class ImageDataset(datasets._Dataset):
         """
 
         utils.validate_display_name(display_name)
+        if labels:
+            utils.validate_labels(labels)
 
         api_client = cls._instantiate_client(location=location, credentials=credentials)
 
@@ -141,6 +154,7 @@ class ImageDataset(datasets._Dataset):
             location=location or initializer.global_config.location,
             credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
+            labels=labels,
             encryption_spec=initializer.global_config.get_encryption_spec(
                 encryption_spec_key_name=encryption_spec_key_name
             ),

--- a/google/cloud/aiplatform/datasets/tabular_dataset.py
+++ b/google/cloud/aiplatform/datasets/tabular_dataset.py
@@ -18,7 +18,7 @@
 import csv
 import logging
 
-from typing import List, Optional, Sequence, Set, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Set, Tuple, Union
 
 from google.auth import credentials as auth_credentials
 
@@ -269,6 +269,7 @@ class TabularDataset(datasets._Dataset):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         request_metadata: Optional[Sequence[Tuple[str, str]]] = (),
+        labels: Optional[Dict[str, str]] = None,
         encryption_spec_key_name: Optional[str] = None,
         sync: bool = True,
     ) -> "TabularDataset":
@@ -302,6 +303,16 @@ class TabularDataset(datasets._Dataset):
                 credentials set in aiplatform.init.
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the request as metadata.
+            labels (Dict[str, str]):
+                Optional. Labels with user-defined metadata to organize your Tensorboards.
+                Label keys and values can be no longer than 64 characters
+                (Unicode codepoints), can only contain lowercase letters, numeric
+                characters, underscores and dashes. International characters are allowed.
+                No more than 64 user labels can be associated with one Tensorboard
+                (System labels are excluded).
+                See https://goo.gl/xmQnxf for more information and examples of labels.
+                System reserved label keys are prefixed with "aiplatform.googleapis.com/"
+                and are immutable.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
                 managed encryption key used to protect the dataset. Has the
@@ -324,6 +335,8 @@ class TabularDataset(datasets._Dataset):
         """
 
         utils.validate_display_name(display_name)
+        if labels:
+            utils.validate_labels(labels)
 
         api_client = cls._instantiate_client(location=location, credentials=credentials)
 
@@ -347,6 +360,7 @@ class TabularDataset(datasets._Dataset):
             location=location or initializer.global_config.location,
             credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
+            labels=labels,
             encryption_spec=initializer.global_config.get_encryption_spec(
                 encryption_spec_key_name=encryption_spec_key_name
             ),

--- a/google/cloud/aiplatform/datasets/text_dataset.py
+++ b/google/cloud/aiplatform/datasets/text_dataset.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import Optional, Sequence, Dict, Tuple, Union
+from typing import Dict, Optional, Sequence, Tuple, Union
 
 from google.auth import credentials as auth_credentials
 
@@ -44,6 +44,7 @@ class TextDataset(datasets._Dataset):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         request_metadata: Optional[Sequence[Tuple[str, str]]] = (),
+        labels: Optional[Dict[str, str]] = None,
         encryption_spec_key_name: Optional[str] = None,
         sync: bool = True,
     ) -> "TextDataset":
@@ -102,6 +103,16 @@ class TextDataset(datasets._Dataset):
                 credentials set in aiplatform.init.
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the request as metadata.
+            labels (Dict[str, str]):
+                Optional. Labels with user-defined metadata to organize your Tensorboards.
+                Label keys and values can be no longer than 64 characters
+                (Unicode codepoints), can only contain lowercase letters, numeric
+                characters, underscores and dashes. International characters are allowed.
+                No more than 64 user labels can be associated with one Tensorboard
+                (System labels are excluded).
+                See https://goo.gl/xmQnxf for more information and examples of labels.
+                System reserved label keys are prefixed with "aiplatform.googleapis.com/"
+                and are immutable.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
                 managed encryption key used to protect the dataset. Has the
@@ -124,6 +135,8 @@ class TextDataset(datasets._Dataset):
         """
 
         utils.validate_display_name(display_name)
+        if labels:
+            utils.validate_labels(labels)
 
         api_client = cls._instantiate_client(location=location, credentials=credentials)
 
@@ -148,6 +161,7 @@ class TextDataset(datasets._Dataset):
             location=location or initializer.global_config.location,
             credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
+            labels=labels,
             encryption_spec=initializer.global_config.get_encryption_spec(
                 encryption_spec_key_name=encryption_spec_key_name
             ),

--- a/google/cloud/aiplatform/datasets/time_series_dataset.py
+++ b/google/cloud/aiplatform/datasets/time_series_dataset.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import Optional, Sequence, Tuple, Union
+from typing import Dict, Optional, Sequence, Tuple, Union
 
 from google.auth import credentials as auth_credentials
 
@@ -43,6 +43,7 @@ class TimeSeriesDataset(datasets._Dataset):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         request_metadata: Optional[Sequence[Tuple[str, str]]] = (),
+        labels: Optional[Dict[str, str]] = None,
         encryption_spec_key_name: Optional[str] = None,
         sync: bool = True,
     ) -> "TimeSeriesDataset":
@@ -76,6 +77,16 @@ class TimeSeriesDataset(datasets._Dataset):
                 credentials set in aiplatform.init.
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the request as metadata.
+            labels (Dict[str, str]):
+                Optional. Labels with user-defined metadata to organize your Tensorboards.
+                Label keys and values can be no longer than 64 characters
+                (Unicode codepoints), can only contain lowercase letters, numeric
+                characters, underscores and dashes. International characters are allowed.
+                No more than 64 user labels can be associated with one Tensorboard
+                (System labels are excluded).
+                See https://goo.gl/xmQnxf for more information and examples of labels.
+                System reserved label keys are prefixed with "aiplatform.googleapis.com/"
+                and are immutable.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
                 managed encryption key used to protect the dataset. Has the
@@ -99,6 +110,8 @@ class TimeSeriesDataset(datasets._Dataset):
         """
 
         utils.validate_display_name(display_name)
+        if labels:
+            utils.validate_labels(labels)
 
         api_client = cls._instantiate_client(location=location, credentials=credentials)
 
@@ -122,6 +135,7 @@ class TimeSeriesDataset(datasets._Dataset):
             location=location or initializer.global_config.location,
             credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
+            labels=labels,
             encryption_spec=initializer.global_config.get_encryption_spec(
                 encryption_spec_key_name=encryption_spec_key_name
             ),

--- a/google/cloud/aiplatform/datasets/video_dataset.py
+++ b/google/cloud/aiplatform/datasets/video_dataset.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from typing import Optional, Sequence, Dict, Tuple, Union
+from typing import Dict, Optional, Sequence, Tuple, Union
 
 from google.auth import credentials as auth_credentials
 
@@ -44,6 +44,7 @@ class VideoDataset(datasets._Dataset):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         request_metadata: Optional[Sequence[Tuple[str, str]]] = (),
+        labels: Optional[Dict[str, str]] = None,
         encryption_spec_key_name: Optional[str] = None,
         sync: bool = True,
     ) -> "VideoDataset":
@@ -95,6 +96,16 @@ class VideoDataset(datasets._Dataset):
                 credentials set in aiplatform.init.
             request_metadata (Sequence[Tuple[str, str]]):
                 Strings which should be sent along with the request as metadata.
+            labels (Dict[str, str]):
+                Optional. Labels with user-defined metadata to organize your Tensorboards.
+                Label keys and values can be no longer than 64 characters
+                (Unicode codepoints), can only contain lowercase letters, numeric
+                characters, underscores and dashes. International characters are allowed.
+                No more than 64 user labels can be associated with one Tensorboard
+                (System labels are excluded).
+                See https://goo.gl/xmQnxf for more information and examples of labels.
+                System reserved label keys are prefixed with "aiplatform.googleapis.com/"
+                and are immutable.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
                 managed encryption key used to protect the dataset. Has the
@@ -117,6 +128,8 @@ class VideoDataset(datasets._Dataset):
         """
 
         utils.validate_display_name(display_name)
+        if labels:
+            utils.validate_labels(labels)
 
         api_client = cls._instantiate_client(location=location, credentials=credentials)
 
@@ -141,6 +154,7 @@ class VideoDataset(datasets._Dataset):
             location=location or initializer.global_config.location,
             credentials=credentials or initializer.global_config.credentials,
             request_metadata=request_metadata,
+            labels=labels,
             encryption_spec=initializer.global_config.get_encryption_spec(
                 encryption_spec_key_name=encryption_spec_key_name
             ),

--- a/google/cloud/aiplatform/jobs.py
+++ b/google/cloud/aiplatform/jobs.py
@@ -370,7 +370,7 @@ class BatchPredictionJob(_Job):
         explanation_parameters: Optional[
             "aiplatform.explain.ExplanationParameters"
         ] = None,
-        labels: Optional[dict] = None,
+        labels: Optional[Dict[str, str]] = None,
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
@@ -499,8 +499,8 @@ class BatchPredictionJob(_Job):
                 a field of the `explanation_parameters` object is not populated, the
                 corresponding field of the `Model.explanation_parameters` object is inherited.
                 For more details, see `Ref docs <http://tinyurl.com/1an4zake>`
-            labels (Optional[dict]):
-                The labels with user-defined metadata to organize your
+            labels (Dict[str, str]):
+                Optional. The labels with user-defined metadata to organize your
                 BatchPredictionJobs. Label keys and values can be no longer than
                 64 characters (Unicode codepoints), can only contain lowercase
                 letters, numeric characters, underscores and dashes.
@@ -533,6 +533,8 @@ class BatchPredictionJob(_Job):
         """
 
         utils.validate_display_name(job_display_name)
+        if labels:
+            utils.validate_labels(labels)
 
         model_name = utils.full_resource_name(
             resource_name=model_name,
@@ -935,6 +937,7 @@ class CustomJob(_RunnableJob):
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
+        labels: Optional[Dict[str, str]] = None,
         encryption_spec_key_name: Optional[str] = None,
         staging_bucket: Optional[str] = None,
     ):
@@ -960,7 +963,8 @@ class CustomJob(_RunnableJob):
 
         my_job = aiplatform.CustomJob(
             display_name='my_job',
-            worker_pool_specs=worker_pool_specs
+            worker_pool_specs=worker_pool_specs,
+            labels={'my_key': 'my_value'},
         )
 
         my_job.run()
@@ -989,6 +993,16 @@ class CustomJob(_RunnableJob):
             credentials (auth_credentials.Credentials):
                 Optional.Custom credentials to use to run call custom job service. Overrides
                 credentials set in aiplatform.init.
+            labels (Dict[str, str]):
+                Optional. The labels with user-defined metadata to
+                organize CustomJobs.
+                Label keys and values can be no longer than 64
+                characters (Unicode codepoints), can only
+                contain lowercase letters, numeric characters,
+                underscores and dashes. International characters
+                are allowed.
+                See https://goo.gl/xmQnxf for more information
+                and examples of labels.
             encryption_spec_key_name (str):
                 Optional.Customer-managed encryption key name for a
                 CustomJob. If this is set, then all resources
@@ -1013,6 +1027,9 @@ class CustomJob(_RunnableJob):
                 "should be set using aiplatform.init(staging_bucket='gs://my-bucket')"
             )
 
+        if labels:
+            utils.validate_labels(labels)
+
         # default directory if not given
         base_output_dir = base_output_dir or utils._timestamped_gcs_dir(
             staging_bucket, "aiplatform-custom-job"
@@ -1026,6 +1043,7 @@ class CustomJob(_RunnableJob):
                     output_uri_prefix=base_output_dir
                 ),
             ),
+            labels=labels,
             encryption_spec=initializer.global_config.get_encryption_spec(
                 encryption_spec_key_name=encryption_spec_key_name
             ),
@@ -1063,6 +1081,7 @@ class CustomJob(_RunnableJob):
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
+        labels: Optional[Dict[str, str]] = None,
         encryption_spec_key_name: Optional[str] = None,
         staging_bucket: Optional[str] = None,
     ) -> "CustomJob":
@@ -1078,6 +1097,7 @@ class CustomJob(_RunnableJob):
             replica_count=1,
             args=['--dataset', 'gs://my-bucket/my-dataset',
             '--model_output_uri', 'gs://my-bucket/model']
+            labels={'my_key': 'my_value'},
         )
 
         job.run()
@@ -1126,6 +1146,16 @@ class CustomJob(_RunnableJob):
             credentials (auth_credentials.Credentials):
                 Optional. Custom credentials to use to run call custom job service. Overrides
                 credentials set in aiplatform.init.
+            labels (Dict[str, str]):
+                Optional. The labels with user-defined metadata to
+                organize CustomJobs.
+                Label keys and values can be no longer than 64
+                characters (Unicode codepoints), can only
+                contain lowercase letters, numeric characters,
+                underscores and dashes. International characters
+                are allowed.
+                See https://goo.gl/xmQnxf for more information
+                and examples of labels.
             encryption_spec_key_name (str):
                 Optional. Customer-managed encryption key name for a
                 CustomJob. If this is set, then all resources
@@ -1149,6 +1179,9 @@ class CustomJob(_RunnableJob):
                 "staging_bucket should be passed to CustomJob.from_local_script or "
                 "should be set using aiplatform.init(staging_bucket='gs://my-bucket')"
             )
+
+        if labels:
+            utils.validate_labels(labels)
 
         worker_pool_specs = worker_spec_utils._DistributedTrainingSpec.chief_worker_pool(
             replica_count=replica_count,
@@ -1188,6 +1221,7 @@ class CustomJob(_RunnableJob):
             project=project,
             location=location,
             credentials=credentials,
+            labels=labels,
             encryption_spec_key_name=encryption_spec_key_name,
             staging_bucket=staging_bucket,
         )
@@ -1325,6 +1359,7 @@ class HyperparameterTuningJob(_RunnableJob):
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
+        labels: Optional[Dict[str, str]] = None,
         encryption_spec_key_name: Optional[str] = None,
     ):
         """
@@ -1353,7 +1388,8 @@ class HyperparameterTuningJob(_RunnableJob):
 
         custom_job = aiplatform.CustomJob(
             display_name='my_job',
-            worker_pool_specs=worker_pool_specs
+            worker_pool_specs=worker_pool_specs,
+            labels={'my_key': 'my_value'},
         )
 
 
@@ -1371,6 +1407,7 @@ class HyperparameterTuningJob(_RunnableJob):
             },
             max_trial_count=128,
             parallel_trial_count=8,
+            labels={'my_key': 'my_value'},
             )
 
         hp_job.run()
@@ -1466,6 +1503,16 @@ class HyperparameterTuningJob(_RunnableJob):
             credentials (auth_credentials.Credentials):
                 Optional. Custom credentials to use to run call HyperparameterTuning service. Overrides
                 credentials set in aiplatform.init.
+            labels (Dict[str, str]):
+                Optional. The labels with user-defined metadata to
+                organize HyperparameterTuningJobs.
+                Label keys and values can be no longer than 64
+                characters (Unicode codepoints), can only
+                contain lowercase letters, numeric characters,
+                underscores and dashes. International characters
+                are allowed.
+                See https://goo.gl/xmQnxf for more information
+                and examples of labels.
             encryption_spec_key_name (str):
                 Optional. Customer-managed encryption key options for a
                 HyperparameterTuningJob. If this is set, then
@@ -1503,6 +1550,7 @@ class HyperparameterTuningJob(_RunnableJob):
             parallel_trial_count=parallel_trial_count,
             max_failed_trial_count=max_failed_trial_count,
             trial_job_spec=copy.deepcopy(custom_job.job_spec),
+            labels=labels,
             encryption_spec=initializer.global_config.get_encryption_spec(
                 encryption_spec_key_name=encryption_spec_key_name
             ),

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -154,7 +154,7 @@ class Endpoint(base.VertexAiResourceNounWithFutureManager):
         cls,
         display_name: str,
         description: Optional[str] = None,
-        labels: Optional[Dict] = None,
+        labels: Optional[Dict[str, str]] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = (),
         project: Optional[str] = None,
         location: Optional[str] = None,
@@ -177,7 +177,7 @@ class Endpoint(base.VertexAiResourceNounWithFutureManager):
                 set in aiplatform.init will be used.
             description (str):
                 Optional. The description of the Endpoint.
-            labels (Dict):
+            labels (Dict[str, str]):
                 Optional. The labels with user-defined metadata to
                 organize your Endpoints.
                 Label keys and values can be no longer than 64
@@ -216,6 +216,8 @@ class Endpoint(base.VertexAiResourceNounWithFutureManager):
         api_client = cls._instantiate_client(location=location, credentials=credentials)
 
         utils.validate_display_name(display_name)
+        if labels:
+            utils.validate_labels(labels)
 
         project = project or initializer.global_config.project
         location = location or initializer.global_config.location
@@ -244,7 +246,7 @@ class Endpoint(base.VertexAiResourceNounWithFutureManager):
         project: str,
         location: str,
         description: Optional[str] = None,
-        labels: Optional[Dict] = None,
+        labels: Optional[Dict[str, str]] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = (),
         credentials: Optional[auth_credentials.Credentials] = None,
         encryption_spec: Optional[gca_encryption_spec.EncryptionSpec] = None,
@@ -268,7 +270,7 @@ class Endpoint(base.VertexAiResourceNounWithFutureManager):
                 set in aiplatform.init will be used.
             description (str):
                 Optional. The description of the Endpoint.
-            labels (Dict):
+            labels (Dict[str, str]):
                 Optional. The labels with user-defined metadata to
                 organize your Endpoints.
                 Label keys and values can be no longer than 64
@@ -1470,6 +1472,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
+        labels: Optional[Dict[str, str]] = None,
         encryption_spec_key_name: Optional[str] = None,
         sync=True,
     ) -> "Model":
@@ -1593,6 +1596,16 @@ class Model(base.VertexAiResourceNounWithFutureManager):
             credentials: Optional[auth_credentials.Credentials]=None,
                 Custom credentials to use to upload this model. Overrides credentials
                 set in aiplatform.init.
+            labels (Dict[str, str]):
+                Optional. The labels with user-defined metadata to
+                organize your Models.
+                Label keys and values can be no longer than 64
+                characters (Unicode codepoints), can only
+                contain lowercase letters, numeric characters,
+                underscores and dashes. International characters
+                are allowed.
+                See https://goo.gl/xmQnxf for more information
+                and examples of labels.
             encryption_spec_key_name (Optional[str]):
                 Optional. The Cloud KMS resource identifier of the customer
                 managed encryption key used to protect the model. Has the
@@ -1611,6 +1624,8 @@ class Model(base.VertexAiResourceNounWithFutureManager):
                 is specified.
         """
         utils.validate_display_name(display_name)
+        if labels:
+            utils.validate_labels(labels)
 
         if bool(explanation_metadata) != bool(explanation_parameters):
             raise ValueError(
@@ -1667,6 +1682,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
             description=description,
             container_spec=container_spec,
             predict_schemata=model_predict_schemata,
+            labels=labels,
             encryption_spec=encryption_spec,
         )
 
@@ -1991,7 +2007,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         generate_explanation: Optional[bool] = False,
         explanation_metadata: Optional[explain.ExplanationMetadata] = None,
         explanation_parameters: Optional[explain.ExplanationParameters] = None,
-        labels: Optional[dict] = None,
+        labels: Optional[Dict[str, str]] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
         encryption_spec_key_name: Optional[str] = None,
         sync: bool = True,
@@ -2126,7 +2142,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
                 a field of the `explanation_parameters` object is not populated, the
                 corresponding field of the `Model.explanation_parameters` object is inherited.
                 For more details, see `Ref docs <http://tinyurl.com/1an4zake>`
-            labels: Optional[dict] = None
+            labels: Optional[Dict[str, str]] = None
                 Optional. The labels with user-defined metadata to organize your
                 BatchPredictionJobs. Label keys and values can be no longer than
                 64 characters (Unicode codepoints), can only contain lowercase

--- a/google/cloud/aiplatform/pipeline_jobs.py
+++ b/google/cloud/aiplatform/pipeline_jobs.py
@@ -161,12 +161,7 @@ class PipelineJob(base.VertexAiResourceNounWithFutureManager):
         utils.validate_display_name(display_name)
 
         if labels:
-            for k, v in labels.items():
-                if not isinstance(k, str) or not isinstance(v, str):
-                    raise ValueError(
-                        "Expect labels to be a mapping of string key value pairs. "
-                        'Got "{}".'.format(labels)
-                    )
+            utils.validate_labels(labels)
 
         super().__init__(project=project, location=location, credentials=credentials)
 

--- a/google/cloud/aiplatform/tensorboard/tensorboard.py
+++ b/google/cloud/aiplatform/tensorboard/tensorboard.py
@@ -146,6 +146,8 @@ class Tensorboard(base.VertexAiResourceNounWithFutureManager):
         """
 
         utils.validate_display_name(display_name)
+        if labels:
+            utils.validate_labels(labels)
 
         api_client = cls._instantiate_client(location=location, credentials=credentials)
 
@@ -245,6 +247,7 @@ class Tensorboard(base.VertexAiResourceNounWithFutureManager):
             update_mask.append("description")
 
         if labels:
+            utils.validate_labels(labels)
             update_mask.append("labels")
 
         encryption_spec = None

--- a/google/cloud/aiplatform/utils/__init__.py
+++ b/google/cloud/aiplatform/utils/__init__.py
@@ -22,7 +22,7 @@ import pathlib
 from collections import namedtuple
 import logging
 import re
-from typing import Any, Match, Optional, Type, TypeVar, Tuple
+from typing import Any, Dict, Match, Optional, Type, TypeVar, Tuple
 
 from google.api_core import client_options
 from google.api_core import gapic_v1
@@ -237,6 +237,22 @@ def validate_display_name(display_name: str):
     """
     if len(display_name) > 128:
         raise ValueError("Display name needs to be less than 128 characters.")
+
+
+def validate_labels(labels: Dict[str, str]):
+    """Validate labels.
+
+    Args:
+        labels: labels to verify
+    Raises:
+        ValueError: if labels is not a mapping of string key value pairs.
+    """
+    for k, v in labels.items():
+        if not isinstance(k, str) or not isinstance(v, str):
+            raise ValueError(
+                "Expect labels to be a mapping of string key value pairs. "
+                'Got "{}".'.format(labels)
+            )
 
 
 def validate_region(region: str) -> bool:

--- a/tests/unit/aiplatform/test_automl_forecasting_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_forecasting_training_jobs.py
@@ -103,6 +103,8 @@ _TEST_TRAINING_TASK_INPUTS_WITH_ADDITIONAL_EXPERIMENTS = json_format.ParseDict(
 _TEST_DATASET_NAME = "test-dataset-name"
 
 _TEST_MODEL_DISPLAY_NAME = "model-display-name"
+_TEST_LABELS = {"key": "value"}
+_TEST_MODEL_LABELS = {"model_key": "model_value"}
 _TEST_TRAINING_FRACTION_SPLIT = 0.8
 _TEST_VALIDATION_FRACTION_SPLIT = 0.1
 _TEST_TEST_FRACTION_SPLIT = 0.1
@@ -228,6 +230,7 @@ class TestAutoMLForecastingTrainingJob:
             display_name=_TEST_DISPLAY_NAME,
             optimization_objective=_TEST_TRAINING_OPTIMIZATION_OBJECTIVE_NAME,
             column_transformations=_TEST_TRAINING_COLUMN_TRANSFORMATIONS,
+            labels=_TEST_LABELS,
         )
 
         model_from_job = job.run(
@@ -241,6 +244,7 @@ class TestAutoMLForecastingTrainingJob:
             data_granularity_unit=_TEST_TRAINING_DATA_GRANULARITY_UNIT,
             data_granularity_count=_TEST_TRAINING_DATA_GRANULARITY_COUNT,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            model_labels=_TEST_MODEL_LABELS,
             predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
             weight_column=_TEST_TRAINING_WEIGHT_COLUMN,
             time_series_attribute_columns=_TEST_TRAINING_TIME_SERIES_ATTRIBUTE_COLUMNS,
@@ -263,7 +267,9 @@ class TestAutoMLForecastingTrainingJob:
             test_fraction=_TEST_TEST_FRACTION_SPLIT,
         )
 
-        true_managed_model = gca_model.Model(display_name=_TEST_MODEL_DISPLAY_NAME)
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME, labels=_TEST_MODEL_LABELS
+        )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
             fraction_split=true_fraction_split,
@@ -275,6 +281,7 @@ class TestAutoMLForecastingTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.automl_forecasting,
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
             model_to_upload=true_managed_model,
@@ -300,7 +307,7 @@ class TestAutoMLForecastingTrainingJob:
 
     @pytest.mark.usefixtures("mock_pipeline_service_get")
     @pytest.mark.parametrize("sync", [True, False])
-    def test_run_call_pipeline_if_no_model_display_name(
+    def test_run_call_pipeline_if_no_model_display_name_nor_model_labels(
         self,
         mock_pipeline_service_create,
         mock_dataset_time_series,
@@ -313,6 +320,7 @@ class TestAutoMLForecastingTrainingJob:
             display_name=_TEST_DISPLAY_NAME,
             optimization_objective=_TEST_TRAINING_OPTIMIZATION_OBJECTIVE_NAME,
             column_transformations=_TEST_TRAINING_COLUMN_TRANSFORMATIONS,
+            labels=_TEST_LABELS,
         )
 
         model_from_job = job.run(
@@ -347,7 +355,9 @@ class TestAutoMLForecastingTrainingJob:
         )
 
         # Test that if defaults to the job display name
-        true_managed_model = gca_model.Model(display_name=_TEST_DISPLAY_NAME)
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_DISPLAY_NAME, labels=_TEST_LABELS,
+        )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
             fraction_split=true_fraction_split,
@@ -356,6 +366,7 @@ class TestAutoMLForecastingTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.automl_forecasting,
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
             model_to_upload=true_managed_model,

--- a/tests/unit/aiplatform/test_automl_image_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_image_training_jobs.py
@@ -46,6 +46,9 @@ _TEST_DATASET_NAME = "test-dataset-name"
 _TEST_MODEL_DISPLAY_NAME = "model-display-name"
 _TEST_MODEL_ID = "98777645321"
 
+_TEST_LABELS = {"key": "value"}
+_TEST_MODEL_LABELS = {"model_key": "model_value"}
+
 _TEST_TRAINING_TASK_INPUTS = json_format.ParseDict(
     {
         "modelType": "CLOUD",
@@ -251,12 +254,15 @@ class TestAutoMLImageTrainingJob:
         )
 
         job = training_jobs.AutoMLImageTrainingJob(
-            display_name=_TEST_DISPLAY_NAME, base_model=mock_model_image
+            display_name=_TEST_DISPLAY_NAME,
+            base_model=mock_model_image,
+            labels=_TEST_LABELS,
         )
 
         model_from_job = job.run(
             dataset=mock_dataset_image,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            model_labels=_TEST_MODEL_LABELS,
             training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
             validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
             test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
@@ -276,6 +282,7 @@ class TestAutoMLImageTrainingJob:
 
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
+            labels=mock_model_image._gca_resource.labels,
             description=mock_model_image._gca_resource.description,
             encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
@@ -286,6 +293,7 @@ class TestAutoMLImageTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.automl_image_classification,
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS_WITH_BASE_MODEL,
             model_to_upload=true_managed_model,
@@ -307,7 +315,7 @@ class TestAutoMLImageTrainingJob:
 
     @pytest.mark.usefixtures("mock_pipeline_service_get")
     @pytest.mark.parametrize("sync", [True, False])
-    def test_run_call_pipeline_if_no_model_display_name(
+    def test_run_call_pipeline_if_no_model_display_name_nor_model_labels(
         self,
         mock_pipeline_service_create,
         mock_dataset_image,
@@ -318,6 +326,7 @@ class TestAutoMLImageTrainingJob:
 
         job = training_jobs.AutoMLImageTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
             model_encryption_spec_key_name=_TEST_MODEL_ENCRYPTION_KEY_NAME,
         )
@@ -342,7 +351,9 @@ class TestAutoMLImageTrainingJob:
 
         # Test that if defaults to the job display name
         true_managed_model = gca_model.Model(
-            display_name=_TEST_DISPLAY_NAME, encryption_spec=_TEST_MODEL_ENCRYPTION_SPEC
+            display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
+            encryption_spec=_TEST_MODEL_ENCRYPTION_SPEC,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
@@ -351,6 +362,7 @@ class TestAutoMLImageTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.automl_image_classification,
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
             model_to_upload=true_managed_model,

--- a/tests/unit/aiplatform/test_automl_tabular_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_tabular_training_jobs.py
@@ -136,6 +136,10 @@ _TEST_TRAINING_TASK_INPUTS_WITH_EXPORT_EVAL_DATA_ITEMS = json_format.ParseDict(
 _TEST_DATASET_NAME = "test-dataset-name"
 
 _TEST_MODEL_DISPLAY_NAME = "model-display-name"
+
+_TEST_LABELS = {"key": "value"}
+_TEST_MODEL_LABELS = {"model_key": "model_value"}
+
 _TEST_TRAINING_FRACTION_SPLIT = 0.6
 _TEST_VALIDATION_FRACTION_SPLIT = 0.2
 _TEST_TEST_FRACTION_SPLIT = 0.2
@@ -308,6 +312,7 @@ class TestAutoMLTabularTrainingJob:
 
         job = training_jobs.AutoMLTabularTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             optimization_objective=_TEST_TRAINING_OPTIMIZATION_OBJECTIVE_NAME,
             optimization_prediction_type=_TEST_TRAINING_OPTIMIZATION_PREDICTION_TYPE,
             column_transformations=_TEST_TRAINING_COLUMN_TRANSFORMATIONS,
@@ -319,6 +324,7 @@ class TestAutoMLTabularTrainingJob:
             dataset=mock_dataset_tabular,
             target_column=_TEST_TRAINING_TARGET_COLUMN,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            model_labels=_TEST_MODEL_LABELS,
             training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
             validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
             test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
@@ -344,6 +350,7 @@ class TestAutoMLTabularTrainingJob:
 
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
+            labels=_TEST_MODEL_LABELS,
             encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
@@ -357,6 +364,7 @@ class TestAutoMLTabularTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.automl_tabular,
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
             model_to_upload=true_managed_model,
@@ -476,7 +484,7 @@ class TestAutoMLTabularTrainingJob:
 
     @pytest.mark.usefixtures("mock_pipeline_service_get")
     @pytest.mark.parametrize("sync", [True, False])
-    def test_run_call_pipeline_if_no_model_display_name(
+    def test_run_call_pipeline_if_no_model_display_name_nor_model_labels(
         self,
         mock_pipeline_service_create,
         mock_dataset_tabular,
@@ -487,6 +495,7 @@ class TestAutoMLTabularTrainingJob:
 
         job = training_jobs.AutoMLTabularTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             optimization_objective=_TEST_TRAINING_OPTIMIZATION_OBJECTIVE_NAME,
             optimization_prediction_type=_TEST_TRAINING_OPTIMIZATION_PREDICTION_TYPE,
             column_transformations=_TEST_TRAINING_COLUMN_TRANSFORMATIONS,
@@ -522,7 +531,9 @@ class TestAutoMLTabularTrainingJob:
 
         # Test that if defaults to the job display name
         true_managed_model = gca_model.Model(
-            display_name=_TEST_DISPLAY_NAME, encryption_spec=_TEST_MODEL_ENCRYPTION_SPEC
+            display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
+            encryption_spec=_TEST_MODEL_ENCRYPTION_SPEC,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
@@ -531,6 +542,7 @@ class TestAutoMLTabularTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.automl_tabular,
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
             model_to_upload=true_managed_model,

--- a/tests/unit/aiplatform/test_automl_text_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_text_training_jobs.py
@@ -42,6 +42,10 @@ _TEST_SENTIMENT_MAX = 10
 
 _TEST_DATASET_NAME = "test-dataset-name"
 _TEST_MODEL_DISPLAY_NAME = "model-display-name"
+
+_TEST_LABELS = {"key": "value"}
+_TEST_MODEL_LABELS = {"model_key": "model_value"}
+
 _TEST_MODEL_ID = "98777645321"
 
 _TEST_TRAINING_TASK_INPUTS_CLASSIFICATION = training_job_inputs.AutoMlTextClassificationInputs(
@@ -319,6 +323,7 @@ class TestAutoMLTextTrainingJob:
 
         job = training_jobs.AutoMLTextTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             prediction_type=_TEST_PREDICTION_TYPE_CLASSIFICATION,
             multi_label=_TEST_CLASSIFICATION_MULTILABEL,
             training_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
@@ -328,6 +333,7 @@ class TestAutoMLTextTrainingJob:
         model_from_job = job.run(
             dataset=mock_dataset_text,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            model_labels=_TEST_MODEL_LABELS,
             training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
             validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
             test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
@@ -345,6 +351,7 @@ class TestAutoMLTextTrainingJob:
 
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
+            labels=_TEST_MODEL_LABELS,
             encryption_spec=_TEST_MODEL_ENCRYPTION_SPEC,
         )
 
@@ -354,6 +361,7 @@ class TestAutoMLTextTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.automl_text_classification,
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS_CLASSIFICATION,
             model_to_upload=true_managed_model,
@@ -388,12 +396,14 @@ class TestAutoMLTextTrainingJob:
 
         job = training_jobs.AutoMLTextTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             prediction_type=_TEST_PREDICTION_TYPE_EXTRACTION,
         )
 
         model_from_job = job.run(
             dataset=mock_dataset_text,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            model_labels=_TEST_MODEL_LABELS,
             training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
             validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
             test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
@@ -409,7 +419,9 @@ class TestAutoMLTextTrainingJob:
             test_fraction=_TEST_FRACTION_SPLIT_TEST,
         )
 
-        true_managed_model = gca_model.Model(display_name=_TEST_MODEL_DISPLAY_NAME)
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME, labels=_TEST_MODEL_LABELS,
+        )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
             fraction_split=true_fraction_split, dataset_id=mock_dataset_text.name,
@@ -417,6 +429,7 @@ class TestAutoMLTextTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.automl_text_extraction,
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS_EXTRACTION,
             model_to_upload=true_managed_model,
@@ -450,6 +463,7 @@ class TestAutoMLTextTrainingJob:
 
         job = training_jobs.AutoMLTextTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             prediction_type=_TEST_PREDICTION_TYPE_SENTIMENT,
             sentiment_max=10,
         )
@@ -457,6 +471,7 @@ class TestAutoMLTextTrainingJob:
         model_from_job = job.run(
             dataset=mock_dataset_text,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            model_labels=_TEST_MODEL_LABELS,
             training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
             validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
             test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
@@ -472,7 +487,9 @@ class TestAutoMLTextTrainingJob:
             test_fraction=_TEST_FRACTION_SPLIT_TEST,
         )
 
-        true_managed_model = gca_model.Model(display_name=_TEST_MODEL_DISPLAY_NAME)
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME, labels=_TEST_MODEL_LABELS
+        )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
             fraction_split=true_fraction_split, dataset_id=mock_dataset_text.name,
@@ -480,6 +497,7 @@ class TestAutoMLTextTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.automl_text_sentiment,
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS_SENTIMENT,
             model_to_upload=true_managed_model,
@@ -500,7 +518,7 @@ class TestAutoMLTextTrainingJob:
 
     @pytest.mark.usefixtures("mock_pipeline_service_get")
     @pytest.mark.parametrize("sync", [True, False])
-    def test_run_call_pipeline_if_no_model_display_name(
+    def test_run_call_pipeline_if_no_model_display_name_nor_model_labels(
         self,
         mock_pipeline_service_create,
         mock_dataset_text,
@@ -514,6 +532,7 @@ class TestAutoMLTextTrainingJob:
             display_name=_TEST_DISPLAY_NAME,
             prediction_type="classification",
             multi_label=True,
+            labels=_TEST_LABELS,
         )
 
         model_from_job = job.run(
@@ -535,7 +554,9 @@ class TestAutoMLTextTrainingJob:
         )
 
         # Test that if defaults to the job display name
-        true_managed_model = gca_model.Model(display_name=_TEST_DISPLAY_NAME)
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_DISPLAY_NAME, labels=_TEST_LABELS,
+        )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
             fraction_split=true_fraction_split, dataset_id=mock_dataset_text.name,
@@ -543,6 +564,7 @@ class TestAutoMLTextTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.automl_text_classification,
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS_CLASSIFICATION,
             model_to_upload=true_managed_model,

--- a/tests/unit/aiplatform/test_automl_video_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_video_training_jobs.py
@@ -43,6 +43,10 @@ _TEST_PREDICTION_TYPE_VOR = "object_tracking"
 
 _TEST_DATASET_NAME = "test-dataset-name"
 _TEST_MODEL_DISPLAY_NAME = "model-display-name"
+
+_TEST_LABELS = {"key": "value"}
+_TEST_MODEL_LABELS = {"model_key": "model_value"}
+
 _TEST_MODEL_ID = "98777645321"  # TODO
 
 _TEST_TRAINING_TASK_INPUTS = json_format.ParseDict(
@@ -290,6 +294,7 @@ class TestAutoMLVideoTrainingJob:
 
         job = training_jobs.AutoMLVideoTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             prediction_type=_TEST_PREDICTION_TYPE_VCN,
             model_type=_TEST_MODEL_TYPE_CLOUD,
             training_encryption_spec_key_name=_TEST_PIPELINE_ENCRYPTION_KEY_NAME,
@@ -299,6 +304,7 @@ class TestAutoMLVideoTrainingJob:
         model_from_job = job.run(
             dataset=mock_dataset_video,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            model_labels=_TEST_MODEL_LABELS,
             training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
             test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
             sync=sync,
@@ -314,6 +320,7 @@ class TestAutoMLVideoTrainingJob:
 
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
+            labels=_TEST_MODEL_LABELS,
             description=mock_model._gca_resource.description,
             encryption_spec=_TEST_MODEL_ENCRYPTION_SPEC,
         )
@@ -324,6 +331,7 @@ class TestAutoMLVideoTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.automl_video_classification,
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
             model_to_upload=true_managed_model,
@@ -345,7 +353,7 @@ class TestAutoMLVideoTrainingJob:
 
     @pytest.mark.usefixtures("mock_pipeline_service_get")
     @pytest.mark.parametrize("sync", [True, False])
-    def test_run_call_pipeline_if_no_model_display_name(
+    def test_run_call_pipeline_if_no_model_display_name_nor_model_labels(
         self,
         mock_pipeline_service_create,
         mock_dataset_video,
@@ -356,6 +364,7 @@ class TestAutoMLVideoTrainingJob:
 
         job = training_jobs.AutoMLVideoTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             prediction_type=_TEST_PREDICTION_TYPE_VCN,
             model_type=_TEST_MODEL_TYPE_CLOUD,
         )
@@ -375,7 +384,9 @@ class TestAutoMLVideoTrainingJob:
         )
 
         # Test that if defaults to the job display name
-        true_managed_model = gca_model.Model(display_name=_TEST_DISPLAY_NAME)
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_DISPLAY_NAME, labels=_TEST_LABELS,
+        )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
             fraction_split=true_fraction_split, dataset_id=mock_dataset_video.name,
@@ -383,6 +394,7 @@ class TestAutoMLVideoTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.automl_video_classification,
             training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
             model_to_upload=true_managed_model,

--- a/tests/unit/aiplatform/test_custom_job.py
+++ b/tests/unit/aiplatform/test_custom_job.py
@@ -87,6 +87,8 @@ _TEST_NETWORK = f"projects/{_TEST_PROJECT}/global/networks/{_TEST_ID}"
 _TEST_TIMEOUT = 8000
 _TEST_RESTART_JOB_ON_WORKER_RESTART = True
 
+_TEST_LABELS = {"my_key": "my_value"}
+
 _TEST_BASE_CUSTOM_JOB_PROTO = gca_custom_job_compat.CustomJob(
     display_name=_TEST_DISPLAY_NAME,
     job_spec=gca_custom_job_compat.CustomJobSpec(
@@ -101,6 +103,7 @@ _TEST_BASE_CUSTOM_JOB_PROTO = gca_custom_job_compat.CustomJob(
         service_account=_TEST_SERVICE_ACCOUNT,
         network=_TEST_NETWORK,
     ),
+    labels=_TEST_LABELS,
     encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
 )
 
@@ -228,6 +231,7 @@ class TestCustomJob:
             display_name=_TEST_DISPLAY_NAME,
             worker_pool_specs=_TEST_WORKER_POOL_SPEC,
             base_output_dir=_TEST_BASE_OUTPUT_DIR,
+            labels=_TEST_LABELS,
         )
 
         job.run(
@@ -271,6 +275,7 @@ class TestCustomJob:
             display_name=_TEST_DISPLAY_NAME,
             worker_pool_specs=_TEST_WORKER_POOL_SPEC,
             base_output_dir=_TEST_BASE_OUTPUT_DIR,
+            labels=_TEST_LABELS,
         )
 
         with pytest.raises(RuntimeError) as e:
@@ -395,6 +400,7 @@ class TestCustomJob:
             script_path=test_training_jobs._TEST_LOCAL_SCRIPT_FILE_NAME,
             container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
             base_output_dir=_TEST_BASE_OUTPUT_DIR,
+            labels=_TEST_LABELS,
         )
 
         job.run(sync=sync)
@@ -441,6 +447,7 @@ class TestCustomJob:
             display_name=_TEST_DISPLAY_NAME,
             worker_pool_specs=_TEST_WORKER_POOL_SPEC,
             base_output_dir=_TEST_BASE_OUTPUT_DIR,
+            labels=_TEST_LABELS,
         )
 
         job.run(

--- a/tests/unit/aiplatform/test_datasets.py
+++ b/tests/unit/aiplatform/test_datasets.py
@@ -144,6 +144,8 @@ _TEST_DATASET_LIST = [
 _TEST_LIST_FILTER = 'display_name="abc"'
 _TEST_LIST_ORDER_BY = "create_time desc"
 
+_TEST_LABELS = {"my_key": "my_value"}
+
 
 @pytest.fixture
 def get_dataset_mock():
@@ -946,6 +948,34 @@ class TestImageDataset:
         expected_dataset.name = _TEST_NAME
         assert my_dataset._gca_resource == expected_dataset
 
+    @pytest.mark.usefixtures("get_dataset_image_mock")
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_create_dataset_with_labels(self, create_dataset_mock, sync):
+        aiplatform.init(
+            project=_TEST_PROJECT, encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+        )
+
+        my_dataset = datasets.ImageDataset.create(
+            display_name=_TEST_DISPLAY_NAME, labels=_TEST_LABELS, sync=sync,
+        )
+
+        if not sync:
+            my_dataset.wait()
+
+        expected_dataset = gca_dataset.Dataset(
+            display_name=_TEST_DISPLAY_NAME,
+            metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_IMAGE,
+            metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            labels=_TEST_LABELS,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
+        )
+
+        create_dataset_mock.assert_called_once_with(
+            parent=_TEST_PARENT,
+            dataset=expected_dataset,
+            metadata=_TEST_REQUEST_METADATA,
+        )
+
 
 class TestTabularDataset:
     def setup_method(self):
@@ -1165,6 +1195,35 @@ class TestTabularDataset:
             ]
         )
 
+    @pytest.mark.usefixtures("get_dataset_tabular_bq_mock")
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_create_dataset_with_labels(self, create_dataset_mock, sync):
+
+        my_dataset = datasets.TabularDataset.create(
+            display_name=_TEST_DISPLAY_NAME,
+            bq_source=_TEST_SOURCE_URI_BQ,
+            labels=_TEST_LABELS,
+            encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+            sync=sync,
+        )
+
+        if not sync:
+            my_dataset.wait()
+
+        expected_dataset = gca_dataset.Dataset(
+            display_name=_TEST_DISPLAY_NAME,
+            metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_TABULAR,
+            metadata=_TEST_METADATA_TABULAR_BQ,
+            labels=_TEST_LABELS,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
+        )
+
+        create_dataset_mock.assert_called_once_with(
+            parent=_TEST_PARENT,
+            dataset=expected_dataset,
+            metadata=_TEST_REQUEST_METADATA,
+        )
+
 
 class TestTextDataset:
     def setup_method(self):
@@ -1364,6 +1423,34 @@ class TestTextDataset:
         expected_dataset.name = _TEST_NAME
         assert my_dataset._gca_resource == expected_dataset
 
+    @pytest.mark.usefixtures("get_dataset_text_mock")
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_create_dataset_with_labels(self, create_dataset_mock, sync):
+        aiplatform.init(
+            project=_TEST_PROJECT, encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME,
+        )
+
+        my_dataset = datasets.TextDataset.create(
+            display_name=_TEST_DISPLAY_NAME, labels=_TEST_LABELS, sync=sync,
+        )
+
+        if not sync:
+            my_dataset.wait()
+
+        expected_dataset = gca_dataset.Dataset(
+            display_name=_TEST_DISPLAY_NAME,
+            metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_TEXT,
+            metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            labels=_TEST_LABELS,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
+        )
+
+        create_dataset_mock.assert_called_once_with(
+            parent=_TEST_PARENT,
+            dataset=expected_dataset,
+            metadata=_TEST_REQUEST_METADATA,
+        )
+
 
 class TestVideoDataset:
     def setup_method(self):
@@ -1525,3 +1612,31 @@ class TestVideoDataset:
 
         expected_dataset.name = _TEST_NAME
         assert my_dataset._gca_resource == expected_dataset
+
+    @pytest.mark.usefixtures("get_dataset_video_mock")
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_create_dataset_with_labels(self, create_dataset_mock, sync):
+        aiplatform.init(
+            project=_TEST_PROJECT, encryption_spec_key_name=_TEST_ENCRYPTION_KEY_NAME
+        )
+
+        my_dataset = datasets.VideoDataset.create(
+            display_name=_TEST_DISPLAY_NAME, labels=_TEST_LABELS, sync=sync,
+        )
+
+        if not sync:
+            my_dataset.wait()
+
+        expected_dataset = gca_dataset.Dataset(
+            display_name=_TEST_DISPLAY_NAME,
+            metadata_schema_uri=_TEST_METADATA_SCHEMA_URI_VIDEO,
+            metadata=_TEST_NONTABULAR_DATASET_METADATA,
+            labels=_TEST_LABELS,
+            encryption_spec=_TEST_ENCRYPTION_SPEC,
+        )
+
+        create_dataset_mock.assert_called_once_with(
+            parent=_TEST_PARENT,
+            dataset=expected_dataset,
+            metadata=_TEST_REQUEST_METADATA,
+        )

--- a/tests/unit/aiplatform/test_endpoints.py
+++ b/tests/unit/aiplatform/test_endpoints.py
@@ -167,6 +167,8 @@ _TEST_LIST_FILTER = 'display_name="abc"'
 _TEST_LIST_ORDER_BY_CREATE_TIME = "create_time desc"
 _TEST_LIST_ORDER_BY_DISPLAY_NAME = "display_name"
 
+_TEST_LABELS = {"my_key": "my_value"}
+
 
 @pytest.fixture
 def get_endpoint_mock():
@@ -522,6 +524,22 @@ class TestEndpoint:
 
         expected_endpoint = gca_endpoint.Endpoint(
             display_name=_TEST_DISPLAY_NAME, description=_TEST_DESCRIPTION,
+        )
+        create_endpoint_mock.assert_called_once_with(
+            parent=_TEST_PARENT, endpoint=expected_endpoint, metadata=(),
+        )
+
+    @pytest.mark.usefixtures("get_endpoint_mock")
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_create_with_labels(self, create_endpoint_mock, sync):
+        my_endpoint = models.Endpoint.create(
+            display_name=_TEST_DISPLAY_NAME, labels=_TEST_LABELS, sync=sync
+        )
+        if not sync:
+            my_endpoint.wait()
+
+        expected_endpoint = gca_endpoint.Endpoint(
+            display_name=_TEST_DISPLAY_NAME, labels=_TEST_LABELS,
         )
         create_endpoint_mock.assert_called_once_with(
             parent=_TEST_PARENT, endpoint=expected_endpoint, metadata=(),

--- a/tests/unit/aiplatform/test_hyperparameter_tuning_job.py
+++ b/tests/unit/aiplatform/test_hyperparameter_tuning_job.py
@@ -78,6 +78,7 @@ _TEST_MAX_FAILED_TRIAL_COUNT = 4
 _TEST_SEARCH_ALGORITHM = "random"
 _TEST_MEASUREMENT_SELECTION = "best"
 
+_TEST_LABELS = {"my_hp_key": "my_hp_value"}
 
 _TEST_BASE_HYPERPARAMETER_TUNING_JOB_PROTO = gca_hyperparameter_tuning_job_compat.HyperparameterTuningJob(
     display_name=_TEST_DISPLAY_NAME,
@@ -123,6 +124,7 @@ _TEST_BASE_HYPERPARAMETER_TUNING_JOB_PROTO = gca_hyperparameter_tuning_job_compa
     max_trial_count=_TEST_MAX_TRIAL_COUNT,
     max_failed_trial_count=_TEST_MAX_FAILED_TRIAL_COUNT,
     trial_job_spec=test_custom_job._TEST_BASE_CUSTOM_JOB_PROTO.job_spec,
+    labels=_TEST_LABELS,
     encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
 )
 
@@ -283,6 +285,7 @@ class TestHyperparameterTuningJob:
             max_failed_trial_count=_TEST_MAX_FAILED_TRIAL_COUNT,
             search_algorithm=_TEST_SEARCH_ALGORITHM,
             measurement_selection=_TEST_MEASUREMENT_SELECTION,
+            labels=_TEST_LABELS,
         )
 
         job.run(
@@ -345,6 +348,7 @@ class TestHyperparameterTuningJob:
             max_failed_trial_count=_TEST_MAX_FAILED_TRIAL_COUNT,
             search_algorithm=_TEST_SEARCH_ALGORITHM,
             measurement_selection=_TEST_MEASUREMENT_SELECTION,
+            labels=_TEST_LABELS,
         )
 
         with pytest.raises(RuntimeError):
@@ -524,6 +528,7 @@ class TestHyperparameterTuningJob:
             max_failed_trial_count=_TEST_MAX_FAILED_TRIAL_COUNT,
             search_algorithm=_TEST_SEARCH_ALGORITHM,
             measurement_selection=_TEST_MEASUREMENT_SELECTION,
+            labels=_TEST_LABELS,
         )
 
         job.run(

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -96,6 +96,9 @@ _TEST_ACCELERATOR_TYPE = "NVIDIA_TESLA_K80"
 _TEST_INVALID_ACCELERATOR_TYPE = "NVIDIA_DOES_NOT_EXIST"
 _TEST_ACCELERATOR_COUNT = 1
 _TEST_MODEL_DISPLAY_NAME = "model-display-name"
+_TEST_LABELS = {"key": "value"}
+_TEST_MODEL_LABELS = {"model_key": "model_value"}
+
 _TEST_DEFAULT_TRAINING_FRACTION_SPLIT = 0.8
 _TEST_DEFAULT_VALIDATION_FRACTION_SPLIT = 0.1
 _TEST_DEFAULT_TEST_FRACTION_SPLIT = 0.1
@@ -630,6 +633,7 @@ class TestCustomTrainingJob:
 
         job = training_jobs.CustomTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             script_path=_TEST_LOCAL_SCRIPT_FILE_NAME,
             container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
             model_serving_container_image_uri=_TEST_SERVING_CONTAINER_IMAGE,
@@ -656,6 +660,7 @@ class TestCustomTrainingJob:
             accelerator_type=_TEST_ACCELERATOR_TYPE,
             accelerator_count=_TEST_ACCELERATOR_COUNT,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            model_labels=_TEST_MODEL_LABELS,
             training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
             validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
             test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
@@ -723,6 +728,7 @@ class TestCustomTrainingJob:
 
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
+            labels=_TEST_MODEL_LABELS,
             description=_TEST_MODEL_DESCRIPTION,
             container_spec=true_container_spec,
             predict_schemata=gca_model.PredictSchemata(
@@ -761,6 +767,7 @@ class TestCustomTrainingJob:
             ),
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
+            labels=_TEST_LABELS,
             encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
@@ -1588,7 +1595,7 @@ class TestCustomTrainingJob:
         assert isinstance(subcls, aiplatform.training_jobs.CustomTrainingJob)
 
     @pytest.mark.parametrize("sync", [True, False])
-    def test_run_call_pipeline_service_create_with_nontabular_dataset(
+    def test_run_call_pipeline_service_create_with_nontabular_dataset_without_model_display_name_nor_model_labels(
         self,
         mock_pipeline_service_create,
         mock_pipeline_service_get,
@@ -1605,6 +1612,7 @@ class TestCustomTrainingJob:
 
         job = training_jobs.CustomTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             script_path=_TEST_LOCAL_SCRIPT_FILE_NAME,
             container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
             model_serving_container_image_uri=_TEST_SERVING_CONTAINER_IMAGE,
@@ -1628,7 +1636,6 @@ class TestCustomTrainingJob:
             machine_type=_TEST_MACHINE_TYPE,
             accelerator_type=_TEST_ACCELERATOR_TYPE,
             accelerator_count=_TEST_ACCELERATOR_COUNT,
-            model_display_name=_TEST_MODEL_DISPLAY_NAME,
             sync=sync,
         )
 
@@ -1685,7 +1692,8 @@ class TestCustomTrainingJob:
         )
 
         true_managed_model = gca_model.Model(
-            display_name=_TEST_MODEL_DISPLAY_NAME,
+            display_name=_TEST_DISPLAY_NAME + "-model",
+            labels=_TEST_LABELS,
             description=_TEST_MODEL_DESCRIPTION,
             container_spec=true_container_spec,
             predict_schemata=gca_model.PredictSchemata(
@@ -1706,6 +1714,7 @@ class TestCustomTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.custom_task,
             training_task_inputs=json_format.ParseDict(
                 {
@@ -1846,6 +1855,7 @@ class TestCustomContainerTrainingJob:
 
         job = training_jobs.CustomContainerTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
             command=_TEST_TRAINING_CONTAINER_CMD,
             model_serving_container_image_uri=_TEST_SERVING_CONTAINER_IMAGE,
@@ -1870,6 +1880,7 @@ class TestCustomContainerTrainingJob:
             accelerator_type=_TEST_ACCELERATOR_TYPE,
             accelerator_count=_TEST_ACCELERATOR_COUNT,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            model_labels=_TEST_MODEL_LABELS,
             training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
             validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
             test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
@@ -1931,6 +1942,7 @@ class TestCustomContainerTrainingJob:
 
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
+            labels=_TEST_MODEL_LABELS,
             description=_TEST_MODEL_DESCRIPTION,
             container_spec=true_container_spec,
             predict_schemata=gca_model.PredictSchemata(
@@ -1954,6 +1966,7 @@ class TestCustomContainerTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.custom_task,
             training_task_inputs=json_format.ParseDict(
                 {
@@ -2645,6 +2658,7 @@ class TestCustomContainerTrainingJob:
 
         job = training_jobs.CustomContainerTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
             command=_TEST_TRAINING_CONTAINER_CMD,
             model_serving_container_image_uri=_TEST_SERVING_CONTAINER_IMAGE,
@@ -2671,6 +2685,7 @@ class TestCustomContainerTrainingJob:
             accelerator_type=_TEST_ACCELERATOR_TYPE,
             accelerator_count=_TEST_ACCELERATOR_COUNT,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            model_labels=_TEST_MODEL_LABELS,
             sync=sync,
         )
 
@@ -2721,6 +2736,7 @@ class TestCustomContainerTrainingJob:
 
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
+            labels=_TEST_MODEL_LABELS,
             description=_TEST_MODEL_DESCRIPTION,
             container_spec=true_container_spec,
             predict_schemata=gca_model.PredictSchemata(
@@ -2755,6 +2771,7 @@ class TestCustomContainerTrainingJob:
             ),
             model_to_upload=true_managed_model,
             input_data_config=true_input_data_config,
+            labels=_TEST_LABELS,
         )
 
         mock_pipeline_service_create.assert_called_once_with(
@@ -3080,6 +3097,7 @@ class TestCustomPythonPackageTrainingJob:
 
         job = training_jobs.CustomPythonPackageTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             python_package_gcs_uri=_TEST_OUTPUT_PYTHON_PACKAGE_PATH,
             python_module_name=_TEST_PYTHON_MODULE_NAME,
             container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
@@ -3099,6 +3117,7 @@ class TestCustomPythonPackageTrainingJob:
         model_from_job = job.run(
             dataset=mock_tabular_dataset,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            model_labels=_TEST_MODEL_LABELS,
             base_output_dir=_TEST_BASE_OUTPUT_DIR,
             service_account=_TEST_SERVICE_ACCOUNT,
             network=_TEST_NETWORK,
@@ -3167,6 +3186,7 @@ class TestCustomPythonPackageTrainingJob:
 
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
+            labels=_TEST_MODEL_LABELS,
             description=_TEST_MODEL_DESCRIPTION,
             container_spec=true_container_spec,
             predict_schemata=gca_model.PredictSchemata(
@@ -3190,6 +3210,7 @@ class TestCustomPythonPackageTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.custom_task,
             training_task_inputs=json_format.ParseDict(
                 {
@@ -3227,7 +3248,7 @@ class TestCustomPythonPackageTrainingJob:
         assert job.state == gca_pipeline_state.PipelineState.PIPELINE_STATE_SUCCEEDED
 
     @pytest.mark.parametrize("sync", [True, False])
-    def test_run_call_pipeline_service_create_with_tabular_dataset_without_model_display_name(
+    def test_run_call_pipeline_service_create_with_tabular_dataset_without_model_display_name_nor_model_labels(
         self,
         mock_pipeline_service_create,
         mock_pipeline_service_get,
@@ -3243,6 +3264,7 @@ class TestCustomPythonPackageTrainingJob:
 
         job = training_jobs.CustomPythonPackageTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             python_package_gcs_uri=_TEST_OUTPUT_PYTHON_PACKAGE_PATH,
             python_module_name=_TEST_PYTHON_MODULE_NAME,
             container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
@@ -3322,6 +3344,7 @@ class TestCustomPythonPackageTrainingJob:
 
         true_managed_model = gca_model.Model(
             display_name=_TEST_DISPLAY_NAME + "-model",
+            labels=_TEST_LABELS,
             description=_TEST_MODEL_DESCRIPTION,
             container_spec=true_container_spec,
             predict_schemata=gca_model.PredictSchemata(
@@ -3345,6 +3368,7 @@ class TestCustomPythonPackageTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.custom_task,
             training_task_inputs=json_format.ParseDict(
                 {
@@ -4032,7 +4056,7 @@ class TestCustomPythonPackageTrainingJob:
         assert job.state == gca_pipeline_state.PipelineState.PIPELINE_STATE_SUCCEEDED
 
     @pytest.mark.parametrize("sync", [True, False])
-    def test_run_call_pipeline_service_create_with_nontabular_dataset(
+    def test_run_call_pipeline_service_create_with_nontabular_dataset_without_model_display_name_nor_model_labels(
         self,
         mock_pipeline_service_create,
         mock_pipeline_service_get,
@@ -4047,6 +4071,7 @@ class TestCustomPythonPackageTrainingJob:
 
         job = training_jobs.CustomPythonPackageTrainingJob(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             python_package_gcs_uri=_TEST_OUTPUT_PYTHON_PACKAGE_PATH,
             python_module_name=_TEST_PYTHON_MODULE_NAME,
             container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
@@ -4071,7 +4096,6 @@ class TestCustomPythonPackageTrainingJob:
             machine_type=_TEST_MACHINE_TYPE,
             accelerator_type=_TEST_ACCELERATOR_TYPE,
             accelerator_count=_TEST_ACCELERATOR_COUNT,
-            model_display_name=_TEST_MODEL_DISPLAY_NAME,
             service_account=_TEST_SERVICE_ACCOUNT,
             tensorboard=_TEST_TENSORBOARD_RESOURCE_NAME,
             sync=sync,
@@ -4124,7 +4148,8 @@ class TestCustomPythonPackageTrainingJob:
         )
 
         true_managed_model = gca_model.Model(
-            display_name=_TEST_MODEL_DISPLAY_NAME,
+            display_name=_TEST_DISPLAY_NAME + "-model",
+            labels=_TEST_LABELS,
             description=_TEST_MODEL_DESCRIPTION,
             container_spec=true_container_spec,
             predict_schemata=gca_model.PredictSchemata(
@@ -4145,6 +4170,7 @@ class TestCustomPythonPackageTrainingJob:
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
             display_name=_TEST_DISPLAY_NAME,
+            labels=_TEST_LABELS,
             training_task_definition=schema.training_job.definition.custom_task,
             training_task_inputs=json_format.ParseDict(
                 {

--- a/tests/unit/aiplatform/test_utils.py
+++ b/tests/unit/aiplatform/test_utils.py
@@ -257,6 +257,20 @@ def test_validate_display_name():
     aiplatform.utils.validate_display_name("my_model_abc")
 
 
+def test_validate_labels_raises_value_not_str():
+    with pytest.raises(ValueError):
+        aiplatform.utils.validate_labels({"my_key1": 1, "my_key2": 2})
+
+
+def test_validate_labels_raises_key_not_str():
+    with pytest.raises(ValueError):
+        aiplatform.utils.validate_labels({1: "my_value1", 2: "my_value2"})
+
+
+def test_validate_labels():
+    aiplatform.utils.validate_labels({"my_key1": "my_value1", "my_key2": "my_value2"})
+
+
 @pytest.mark.parametrize(
     "accelerator_type, expected",
     [


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #595, <b/191789899> 🦕

- Add support for labels in resources creation: 
    - datasets (`create`)
        - ImageDataset / TabularDataset / TextDataset / TimeSeriesDataset / VideoDataset
    - tensorboard 
        - `Tensorboard.create`
    - jobs
        - `BatchPredictionJob.create`
        - `CustomJob.__init__`
        - `HyperparameterTuningJob.__init__`
    - models
        - `Endpoint.create`
        - `Model.upload` / `Model.batch_predict`
    - training_jobs (`__init__` for training labels, `run` for model labels)
        - CustomTrainingJob / CustomContainerTrainingJob / CustomPythonPackageTrainingJob 
        - AutoMLTabularTrainingJob / AutoMLForecastingTrainingJob / AutoMLImageTrainingJob / AutoMLVideoTrainingJob / AutoMLTextTrainingJob 

- Modify `pipeline_jobs.py` and `utils.py` for `validate_labels` reusability
- Add / modify unit tests to verify:
    - standard resource creation with / without labels
    - training pipeline resource creation
        - when model labels is not provided
        - when base model labels is provided
