### PR TITLE
feat: add filter and timestamp splits 

### DIFF
--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -443,18 +443,29 @@ class _TrainingJob(base.VertexAiResourceNounWithFutureManager):
             fraction_split = None
 
             # Create filter split
-            if all(
+            if any(
                 [
                     training_filter_split is not None,
                     validation_filter_split is not None,
                     test_filter_split is not None,
                 ]
             ):
-                filter_split = gca_training_pipeline.FilterSplit(
-                    training_filter=training_filter_split,
-                    validation_filter=validation_filter_split,
-                    test_filter=test_filter_split,
-                )
+                if all(
+                    [
+                        training_filter_split is not None,
+                        validation_filter_split is not None,
+                        test_filter_split is not None,
+                    ]
+                ):
+                    filter_split = gca_training_pipeline.FilterSplit(
+                        training_filter=training_filter_split,
+                        validation_filter=validation_filter_split,
+                        test_filter=test_filter_split,
+                    )
+                else:
+                    raise ValueError(
+                        """All filter splits must be passed together or not at all"""
+                    )
 
             # Create predefined split
             if predefined_split_column_name:

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -513,9 +513,9 @@ class _TrainingJob(base.VertexAiResourceNounWithFutureManager):
             elif len(splits) > 1:
                 raise ValueError(
                     """Can only specify one of:
-                        1. training_filter_split, validation_filter_split, test_filter_split OR
-                        2. predefined_split_column_name OR
-                        3. timestamp_split_column_name, training_fraction_split, validation_fraction_split, test_fraction_split OR
+                        1. training_filter_split, validation_filter_split, test_filter_split
+                        2. predefined_split_column_name
+                        3. timestamp_split_column_name, training_fraction_split, validation_fraction_split, test_fraction_split
                         4. training_fraction_split, validation_fraction_split, test_fraction_split"""
                 )
 
@@ -558,9 +558,9 @@ class _TrainingJob(base.VertexAiResourceNounWithFutureManager):
         training_filter_split: Optional[str] = None,
         validation_filter_split: Optional[str] = None,
         test_filter_split: Optional[str] = None,
-        annotation_schema_uri: Optional[str] = None,
         predefined_split_column_name: Optional[str] = None,
         timestamp_split_column_name: Optional[str] = None,
+        annotation_schema_uri: Optional[str] = None,
         model: Optional[gca_model.Model] = None,
         gcs_destination_uri_prefix: Optional[str] = None,
         bigquery_destination: Optional[str] = None,
@@ -591,6 +591,28 @@ class _TrainingJob(base.VertexAiResourceNounWithFutureManager):
                 [google.cloud.aiplatform.v1beta1.TrainingPipeline.training_task_definition].
                 For tabular Datasets, all their data is exported to
                 training, to pick and choose from.
+            annotation_schema_uri (str):
+                Google Cloud Storage URI points to a YAML file describing
+                annotation schema. The schema is defined as an OpenAPI 3.0.2
+                [Schema Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schema-object) The schema files
+                that can be used here are found in
+                gs://google-cloud-aiplatform/schema/dataset/annotation/,
+                note that the chosen schema must be consistent with
+                ``metadata``
+                of the Dataset specified by
+                ``dataset_id``.
+
+                Only Annotations that both match this schema and belong to
+                DataItems not ignored by the split method are used in
+                respectively training, validation or test role, depending on
+                the role of the DataItem they are on.
+
+                When used in conjunction with
+                ``annotations_filter``,
+                the Annotations used for training are filtered by both
+                ``annotations_filter``
+                and
+                ``annotation_schema_uri``.                              
             training_fraction_split (float):
                 Optional. The fraction of the input data that is to be used to train
                 the Model. This is ignored if Dataset is not provided.
@@ -621,28 +643,6 @@ class _TrainingJob(base.VertexAiResourceNounWithFutureManager):
                 single DataItem is matched by more than one of the FilterSplit filters,
                 then it is assigned to the first set that applies to it in the training,
                 validation, test order. This is ignored if Dataset is not provided.
-            annotation_schema_uri (str):
-                Google Cloud Storage URI points to a YAML file describing
-                annotation schema. The schema is defined as an OpenAPI 3.0.2
-                [Schema Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schema-object) The schema files
-                that can be used here are found in
-                gs://google-cloud-aiplatform/schema/dataset/annotation/,
-                note that the chosen schema must be consistent with
-                ``metadata``
-                of the Dataset specified by
-                ``dataset_id``.
-
-                Only Annotations that both match this schema and belong to
-                DataItems not ignored by the split method are used in
-                respectively training, validation or test role, depending on
-                the role of the DataItem they are on.
-
-                When used in conjunction with
-                ``annotations_filter``,
-                the Annotations used for training are filtered by both
-                ``annotations_filter``
-                and
-                ``annotation_schema_uri``.
             predefined_split_column_name (str):
                 Optional. The key is a name of one of the Dataset's data
                 columns. The value of the key (either the label's value or
@@ -662,7 +662,7 @@ class _TrainingJob(base.VertexAiResourceNounWithFutureManager):
                 that piece is ignored by the pipeline.
 
                 Supported only for tabular and time series Datasets.
-                This parameter must be used with training_fraction_split, validation_fraction_split and test_fraction_split.
+                This parameter must be used with training_fraction_split, validation_fraction_split and test_fraction_split.  
             model (~.model.Model):
                 Optional. Describes the Model that may be uploaded (via
                 [ModelService.UploadMode][]) by this TrainingPipeline. The

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -21,7 +21,6 @@ from typing import Dict, List, Optional, Sequence, Tuple, Union
 import warnings
 
 import abc
-import logging
 
 from google.auth import credentials as auth_credentials
 from google.cloud.aiplatform import base
@@ -464,7 +463,7 @@ class _TrainingJob(base.VertexAiResourceNounWithFutureManager):
                     )
                 else:
                     raise ValueError(
-                        """All filter splits must be passed together or not at all"""
+                        "All filter splits must be passed together or not at all"
                     )
 
             # Create predefined split
@@ -507,7 +506,7 @@ class _TrainingJob(base.VertexAiResourceNounWithFutureManager):
 
             # Fallback to fraction split if nothing else is specified
             if len(splits) == 0:
-                logging.info(
+                _LOGGER.info(
                     "No dataset split provided. The service will use a default split."
                 )
             elif len(splits) > 1:
@@ -612,7 +611,7 @@ class _TrainingJob(base.VertexAiResourceNounWithFutureManager):
                 the Annotations used for training are filtered by both
                 ``annotations_filter``
                 and
-                ``annotation_schema_uri``.                              
+                ``annotation_schema_uri``.
             training_fraction_split (float):
                 Optional. The fraction of the input data that is to be used to train
                 the Model. This is ignored if Dataset is not provided.
@@ -662,7 +661,7 @@ class _TrainingJob(base.VertexAiResourceNounWithFutureManager):
                 that piece is ignored by the pipeline.
 
                 Supported only for tabular and time series Datasets.
-                This parameter must be used with training_fraction_split, validation_fraction_split and test_fraction_split.  
+                This parameter must be used with training_fraction_split, validation_fraction_split and test_fraction_split.
             model (~.model.Model):
                 Optional. Describes the Model that may be uploaded (via
                 [ModelService.UploadMode][]) by this TrainingPipeline. The
@@ -1756,32 +1755,36 @@ class CustomTrainingJob(_CustomTrainingJob):
         ie: replica_count = 10 will result in 1 chief and 9 workers
         All replicas have same machine_type, accelerator_type, and accelerator_count
 
-        Data fraction splits:
-        Any of ``training_fraction_split``, ``validation_fraction_split`` and
-        ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
-        the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
-        of data will be used for training, 10% for validation, and 10% for test.
+        If training on a Vertex AI dataset, you can use one of the following split configurations:
+            Data fraction splits:
+            Any of ``training_fraction_split``, ``validation_fraction_split`` and
+            ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
+            the provided ones sum to less than 1, the remainder is assigned to sets as
+            decided by Vertex AI. If none of the fractions are set, by default roughly 80%
+            of data will be used for training, 10% for validation, and 10% for test.
 
-        Data filter splits:
-        Assigns input data to training, validation, and test sets
-        based on the given filters, data pieces not matched by any
-        filter are ignored. Currently only supported for Datasets
-        containing DataItems.
-        If any of the filters in this message are to match nothing, then
-        they can be set as '-' (the minus sign).
-        Supported only for unstructured Datasets.
+            Data filter splits:
+            Assigns input data to training, validation, and test sets
+            based on the given filters, data pieces not matched by any
+            filter are ignored. Currently only supported for Datasets
+            containing DataItems.
+            If any of the filters in this message are to match nothing, then
+            they can be set as '-' (the minus sign).
+            If using filter splits, all of ``training_filter_split``, ``validation_filter_split`` and
+            ``test_filter_split`` must be provided.
+            Supported only for unstructured Datasets.
 
-        Predefined splits:
-        Assigns input data to training, validation, and test sets based on the value of a provided key.
-        Supported only for tabular Datasets.
+            Predefined splits:
+            Assigns input data to training, validation, and test sets based on the value of a provided key.
+            If using predefined splits, ``predefined_split_column_name`` must be provided.
+            Supported only for tabular Datasets.
 
-        Timestamp splits:
-        Assigns input data to training, validation, and test sets
-        based on a provided timestamps. The youngest data pieces are
-        assigned to training set, next to validation set, and the oldest
-        to the test set.
-        Supported only for tabular Datasets.
+            Timestamp splits:
+            Assigns input data to training, validation, and test sets
+            based on a provided timestamps. The youngest data pieces are
+            assigned to training set, next to validation set, and the oldest
+            to the test set.
+            Supported only for tabular Datasets.
 
         Args:
             dataset (
@@ -2514,32 +2517,36 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
         ie: replica_count = 10 will result in 1 chief and 9 workers
         All replicas have same machine_type, accelerator_type, and accelerator_count
 
-        Data fraction splits:
-        Any of ``training_fraction_split``, ``validation_fraction_split`` and
-        ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
-        the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
-        of data will be used for training, 10% for validation, and 10% for test.
+        If training on a Vertex AI dataset, you can use one of the following split configurations:
+            Data fraction splits:
+            Any of ``training_fraction_split``, ``validation_fraction_split`` and
+            ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
+            the provided ones sum to less than 1, the remainder is assigned to sets as
+            decided by Vertex AI. If none of the fractions are set, by default roughly 80%
+            of data will be used for training, 10% for validation, and 10% for test.
 
-        Data filter splits:
-        Assigns input data to training, validation, and test sets
-        based on the given filters, data pieces not matched by any
-        filter are ignored. Currently only supported for Datasets
-        containing DataItems.
-        If any of the filters in this message are to match nothing, then
-        they can be set as '-' (the minus sign).
-        Supported only for unstructured Datasets.
+            Data filter splits:
+            Assigns input data to training, validation, and test sets
+            based on the given filters, data pieces not matched by any
+            filter are ignored. Currently only supported for Datasets
+            containing DataItems.
+            If any of the filters in this message are to match nothing, then
+            they can be set as '-' (the minus sign).
+            If using filter splits, all of ``training_filter_split``, ``validation_filter_split`` and
+            ``test_filter_split`` must be provided.
+            Supported only for unstructured Datasets.
 
-        Predefined splits:
-        Assigns input data to training, validation, and test sets based on the value of a provided key.
-        Supported only for tabular Datasets.
+            Predefined splits:
+            Assigns input data to training, validation, and test sets based on the value of a provided key.
+            If using predefined splits, ``predefined_split_column_name`` must be provided.
+            Supported only for tabular Datasets.
 
-        Timestamp splits:
-        Assigns input data to training, validation, and test sets
-        based on a provided timestamps. The youngest data pieces are
-        assigned to training set, next to validation set, and the oldest
-        to the test set.
-        Supported only for tabular Datasets.
+            Timestamp splits:
+            Assigns input data to training, validation, and test sets
+            based on a provided timestamps. The youngest data pieces are
+            assigned to training set, next to validation set, and the oldest
+            to the test set.
+            Supported only for tabular Datasets.
 
         Args:
             dataset (Union[datasets.ImageDataset,datasets.TabularDataset,datasets.TextDataset,datasets.VideoDataset]):
@@ -3191,23 +3198,25 @@ class AutoMLTabularTrainingJob(_TrainingJob):
     ) -> models.Model:
         """Runs the training job and returns a model.
 
-        Data fraction splits:
-        Any of ``training_fraction_split``, ``validation_fraction_split`` and
-        ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
-        the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
-        of data will be used for training, 10% for validation, and 10% for test.
+        If training on a Vertex AI dataset, you can use one of the following split configurations:
+            Data fraction splits:
+            Any of ``training_fraction_split``, ``validation_fraction_split`` and
+            ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
+            the provided ones sum to less than 1, the remainder is assigned to sets as
+            decided by Vertex AI. If none of the fractions are set, by default roughly 80%
+            of data will be used for training, 10% for validation, and 10% for test.
 
-        Predefined splits:
-        Assigns input data to training, validation, and test sets based on the value of a provided key.
-        Supported only for tabular Datasets.
+            Predefined splits:
+            Assigns input data to training, validation, and test sets based on the value of a provided key.
+            If using predefined splits, ``predefined_split_column_name`` must be provided.
+            Supported only for tabular Datasets.
 
-        Timestamp splits:
-        Assigns input data to training, validation, and test sets
-        based on a provided timestamps. The youngest data pieces are
-        assigned to training set, next to validation set, and the oldest
-        to the test set.
-        Supported only for tabular Datasets.
+            Timestamp splits:
+            Assigns input data to training, validation, and test sets
+            based on a provided timestamps. The youngest data pieces are
+            assigned to training set, next to validation set, and the oldest
+            to the test set.
+            Supported only for tabular Datasets.
 
         Args:
             dataset (datasets.TabularDataset):
@@ -3374,12 +3383,25 @@ class AutoMLTabularTrainingJob(_TrainingJob):
     ) -> models.Model:
         """Runs the training job and returns a model.
 
-        Data fraction splits:
-        Any of ``training_fraction_split``, ``validation_fraction_split`` and
-        ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
-        the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
-        of data will be used for training, 10% for validation, and 10% for test.
+        If training on a Vertex AI dataset, you can use one of the following split configurations:
+            Data fraction splits:
+            Any of ``training_fraction_split``, ``validation_fraction_split`` and
+            ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
+            the provided ones sum to less than 1, the remainder is assigned to sets as
+            decided by Vertex AI. If none of the fractions are set, by default roughly 80%
+            of data will be used for training, 10% for validation, and 10% for test.
+
+            Predefined splits:
+            Assigns input data to training, validation, and test sets based on the value of a provided key.
+            If using predefined splits, ``predefined_split_column_name`` must be provided.
+            Supported only for tabular Datasets.
+
+            Timestamp splits:
+            Assigns input data to training, validation, and test sets
+            based on a provided timestamps. The youngest data pieces are
+            assigned to training set, next to validation set, and the oldest
+            to the test set.
+            Supported only for tabular Datasets.
 
         Args:
             dataset (datasets.TabularDataset):
@@ -4304,21 +4326,24 @@ class AutoMLImageTrainingJob(_TrainingJob):
     ) -> models.Model:
         """Runs the AutoML Image training job and returns a model.
 
-        Data fraction splits:
-        Any of ``training_fraction_split``, ``validation_fraction_split`` and
-        ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
-        the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
-        of data will be used for training, 10% for validation, and 10% for test.
+        If training on a Vertex AI dataset, you can use one of the following split configurations:
+            Data fraction splits:
+            Any of ``training_fraction_split``, ``validation_fraction_split`` and
+            ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
+            the provided ones sum to less than 1, the remainder is assigned to sets as
+            decided by Vertex AI. If none of the fractions are set, by default roughly 80%
+            of data will be used for training, 10% for validation, and 10% for test.
 
-        Data filter splits:
-        Assigns input data to training, validation, and test sets
-        based on the given filters, data pieces not matched by any
-        filter are ignored. Currently only supported for Datasets
-        containing DataItems.
-        If any of the filters in this message are to match nothing, then
-        they can be set as '-' (the minus sign).
-        Supported only for unstructured Datasets.
+            Data filter splits:
+            Assigns input data to training, validation, and test sets
+            based on the given filters, data pieces not matched by any
+            filter are ignored. Currently only supported for Datasets
+            containing DataItems.
+            If any of the filters in this message are to match nothing, then
+            they can be set as '-' (the minus sign).
+            If using filter splits, all of ``training_filter_split``, ``validation_filter_split`` and
+            ``test_filter_split`` must be provided.
+            Supported only for unstructured Datasets.
 
         Args:
             dataset (datasets.ImageDataset):
@@ -4449,21 +4474,24 @@ class AutoMLImageTrainingJob(_TrainingJob):
     ) -> models.Model:
         """Runs the training job and returns a model.
 
-        Data fraction splits:
-        Any of ``training_fraction_split``, ``validation_fraction_split`` and
-        ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
-        the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
-        of data will be used for training, 10% for validation, and 10% for test.
+        If training on a Vertex AI dataset, you can use one of the following split configurations:
+            Data fraction splits:
+            Any of ``training_fraction_split``, ``validation_fraction_split`` and
+            ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
+            the provided ones sum to less than 1, the remainder is assigned to sets as
+            decided by Vertex AI. If none of the fractions are set, by default roughly 80%
+            of data will be used for training, 10% for validation, and 10% for test.
 
-        Data filter splits:
-        Assigns input data to training, validation, and test sets
-        based on the given filters, data pieces not matched by any
-        filter are ignored. Currently only supported for Datasets
-        containing DataItems.
-        If any of the filters in this message are to match nothing, then
-        they can be set as '-' (the minus sign).
-        Supported only for unstructured Datasets.
+            Data filter splits:
+            Assigns input data to training, validation, and test sets
+            based on the given filters, data pieces not matched by any
+            filter are ignored. Currently only supported for Datasets
+            containing DataItems.
+            If any of the filters in this message are to match nothing, then
+            they can be set as '-' (the minus sign).
+            If using filter splits, all of ``training_filter_split``, ``validation_filter_split`` and
+            ``test_filter_split`` must be provided.
+            Supported only for unstructured Datasets.
 
         Args:
             dataset (datasets.ImageDataset):
@@ -4889,32 +4917,36 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
         ie: replica_count = 10 will result in 1 chief and 9 workers
         All replicas have same machine_type, accelerator_type, and accelerator_count
 
-        Data fraction splits:
-        Any of ``training_fraction_split``, ``validation_fraction_split`` and
-        ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
-        the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
-        of data will be used for training, 10% for validation, and 10% for test.
+        If training on a Vertex AI dataset, you can use one of the following split configurations:
+            Data fraction splits:
+            Any of ``training_fraction_split``, ``validation_fraction_split`` and
+            ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
+            the provided ones sum to less than 1, the remainder is assigned to sets as
+            decided by Vertex AI. If none of the fractions are set, by default roughly 80%
+            of data will be used for training, 10% for validation, and 10% for test.
 
-        Data filter splits:
-        Assigns input data to training, validation, and test sets
-        based on the given filters, data pieces not matched by any
-        filter are ignored. Currently only supported for Datasets
-        containing DataItems.
-        If any of the filters in this message are to match nothing, then
-        they can be set as '-' (the minus sign).
-        Supported only for unstructured Datasets.
+            Data filter splits:
+            Assigns input data to training, validation, and test sets
+            based on the given filters, data pieces not matched by any
+            filter are ignored. Currently only supported for Datasets
+            containing DataItems.
+            If any of the filters in this message are to match nothing, then
+            they can be set as '-' (the minus sign).
+            If using filter splits, all of ``training_filter_split``, ``validation_filter_split`` and
+            ``test_filter_split`` must be provided.
+            Supported only for unstructured Datasets.
 
-        Predefined splits:
-        Assigns input data to training, validation, and test sets based on the value of a provided key.
-        Supported only for tabular Datasets.
+            Predefined splits:
+            Assigns input data to training, validation, and test sets based on the value of a provided key.
+            If using predefined splits, ``predefined_split_column_name`` must be provided.
+            Supported only for tabular Datasets.
 
-        Timestamp splits:
-        Assigns input data to training, validation, and test sets
-        based on a provided timestamps. The youngest data pieces are
-        assigned to training set, next to validation set, and the oldest
-        to the test set.
-        Supported only for tabular Datasets.
+            Timestamp splits:
+            Assigns input data to training, validation, and test sets
+            based on a provided timestamps. The youngest data pieces are
+            assigned to training set, next to validation set, and the oldest
+            to the test set.
+            Supported only for tabular Datasets.
 
         Args:
             dataset (Union[datasets.ImageDataset,datasets.TabularDataset,datasets.TextDataset,datasets.VideoDataset,]):
@@ -5484,19 +5516,22 @@ class AutoMLVideoTrainingJob(_TrainingJob):
     ) -> models.Model:
         """Runs the AutoML Image training job and returns a model.
 
-        Data fraction splits:
-        ``training_fraction_split``, and ``test_fraction_split`` may optionally
-        be provided, they must sum to up to 1. If none of the fractions are set,
-        by default roughly 80% of data will be used for training, and 20% for test.
+        If training on a Vertex AI dataset, you can use one of the following split configurations:
+            Data fraction splits:
+            ``training_fraction_split``, and ``test_fraction_split`` may optionally
+            be provided, they must sum to up to 1. If none of the fractions are set,
+            by default roughly 80% of data will be used for training, and 20% for test.
 
-        Data filter splits:
-        Assigns input data to training, validation, and test sets
-        based on the given filters, data pieces not matched by any
-        filter are ignored. Currently only supported for Datasets
-        containing DataItems.
-        If any of the filters in this message are to match nothing, then
-        they can be set as '-' (the minus sign).
-        Supported only for unstructured Datasets.
+            Data filter splits:
+            Assigns input data to training, validation, and test sets
+            based on the given filters, data pieces not matched by any
+            filter are ignored. Currently only supported for Datasets
+            containing DataItems.
+            If any of the filters in this message are to match nothing, then
+            they can be set as '-' (the minus sign).
+            If using filter splits, all of ``training_filter_split``, ``validation_filter_split`` and
+            ``test_filter_split`` must be provided.
+            Supported only for unstructured Datasets.
 
         Args:
             dataset (datasets.VideoDataset):
@@ -5589,19 +5624,22 @@ class AutoMLVideoTrainingJob(_TrainingJob):
     ) -> models.Model:
         """Runs the training job and returns a model.
 
-        Data fraction splits:
-        Any of ``training_fraction_split``, and ``test_fraction_split`` may optionally
-        be provided, they must sum to up to 1. If none of the fractions are set,
-        by default roughly 80% of data will be used for training, and 20% for test.
+        If training on a Vertex AI dataset, you can use one of the following split configurations:
+            Data fraction splits:
+            Any of ``training_fraction_split``, and ``test_fraction_split`` may optionally
+            be provided, they must sum to up to 1. If none of the fractions are set,
+            by default roughly 80% of data will be used for training, and 20% for test.
 
-        Data filter splits:
-        Assigns input data to training, validation, and test sets
-        based on the given filters, data pieces not matched by any
-        filter are ignored. Currently only supported for Datasets
-        containing DataItems.
-        If any of the filters in this message are to match nothing, then
-        they can be set as '-' (the minus sign).
-        Supported only for unstructured Datasets.
+            Data filter splits:
+            Assigns input data to training, validation, and test sets
+            based on the given filters, data pieces not matched by any
+            filter are ignored. Currently only supported for Datasets
+            containing DataItems.
+            If any of the filters in this message are to match nothing, then
+            they can be set as '-' (the minus sign).
+            If using filter splits, all of ``training_filter_split``, ``validation_filter_split`` and
+            ``test_filter_split`` must be provided.
+            Supported only for unstructured Datasets.
 
         Args:
             dataset (datasets.VideoDataset):
@@ -5675,7 +5713,7 @@ class AutoMLVideoTrainingJob(_TrainingJob):
         # AutoMLVideo does not support validation, so pass in '-' if any other filter split is provided.
         validation_filter_split = (
             "-"
-            if any([training_filter_split is not None, test_filter_split is not None])
+            if all([training_filter_split is not None, test_filter_split is not None])
             else None
         )
 
@@ -5854,21 +5892,24 @@ class AutoMLTextTrainingJob(_TrainingJob):
     ) -> models.Model:
         """Runs the training job and returns a model.
 
-        Data fraction splits:
-        Any of ``training_fraction_split``, ``validation_fraction_split`` and
-        ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
-        the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
-        of data will be used for training, 10% for validation, and 10% for test.
+        If training on a Vertex AI dataset, you can use one of the following split configurations:
+            Data fraction splits:
+            Any of ``training_fraction_split``, ``validation_fraction_split`` and
+            ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
+            the provided ones sum to less than 1, the remainder is assigned to sets as
+            decided by Vertex AI. If none of the fractions are set, by default roughly 80%
+            of data will be used for training, 10% for validation, and 10% for test.
 
-        Data filter splits:
-        Assigns input data to training, validation, and test sets
-        based on the given filters, data pieces not matched by any
-        filter are ignored. Currently only supported for Datasets
-        containing DataItems.
-        If any of the filters in this message are to match nothing, then
-        they can be set as '-' (the minus sign).
-        Supported only for unstructured Datasets.
+            Data filter splits:
+            Assigns input data to training, validation, and test sets
+            based on the given filters, data pieces not matched by any
+            filter are ignored. Currently only supported for Datasets
+            containing DataItems.
+            If any of the filters in this message are to match nothing, then
+            they can be set as '-' (the minus sign).
+            If using filter splits, all of ``training_filter_split``, ``validation_filter_split`` and
+            ``test_filter_split`` must be provided.
+            Supported only for unstructured Datasets.
 
         Args:
             dataset (datasets.TextDataset):
@@ -5974,21 +6015,24 @@ class AutoMLTextTrainingJob(_TrainingJob):
     ) -> models.Model:
         """Runs the training job and returns a model.
 
-        Data fraction splits:
-        Any of ``training_fraction_split``, ``validation_fraction_split`` and
-        ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
-        the provided ones sum to less than 1, the remainder is assigned to sets as
-        decided by Vertex AI. If none of the fractions are set, by default roughly 80%
-        of data will be used for training, 10% for validation, and 10% for test.
+        If training on a Vertex AI dataset, you can use one of the following split configurations:
+            Data fraction splits:
+            Any of ``training_fraction_split``, ``validation_fraction_split`` and
+            ``test_fraction_split`` may optionally be provided, they must sum to up to 1. If
+            the provided ones sum to less than 1, the remainder is assigned to sets as
+            decided by Vertex AI. If none of the fractions are set, by default roughly 80%
+            of data will be used for training, 10% for validation, and 10% for test.
 
-        Data filter splits:
-        Assigns input data to training, validation, and test sets
-        based on the given filters, data pieces not matched by any
-        filter are ignored. Currently only supported for Datasets
-        containing DataItems.
-        If any of the filters in this message are to match nothing, then
-        they can be set as '-' (the minus sign).
-        Supported only for unstructured Datasets.
+            Data filter splits:
+            Assigns input data to training, validation, and test sets
+            based on the given filters, data pieces not matched by any
+            filter are ignored. Currently only supported for Datasets
+            containing DataItems.
+            If any of the filters in this message are to match nothing, then
+            they can be set as '-' (the minus sign).
+            If using filter splits, all of ``training_filter_split``, ``validation_filter_split`` and
+            ``test_filter_split`` must be provided.
+            Supported only for unstructured Datasets.
 
         Args:
             dataset (datasets.TextDataset):

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -5672,6 +5672,13 @@ class AutoMLVideoTrainingJob(_TrainingJob):
         model_tbt.display_name = model_display_name or self._display_name
         model_tbt.labels = model_labels or self._labels
 
+        # AutoMLVideo does not support validation, so pass in '-' if any other filter split is provided.
+        validation_filter_split = (
+            "-"
+            if any([training_filter_split is not None, test_filter_split is not None])
+            else None
+        )
+
         return self._run_job(
             training_task_definition=training_task_definition,
             training_task_inputs=training_task_inputs_dict,
@@ -5679,8 +5686,7 @@ class AutoMLVideoTrainingJob(_TrainingJob):
             training_fraction_split=training_fraction_split,
             test_fraction_split=test_fraction_split,
             training_filter_split=training_filter_split,
-            # AutoMLVideo does not support validation, so pass in '-'
-            validation_filter_split="-",
+            validation_filter_split=validation_filter_split,
             test_filter_split=test_filter_split,
             model=model_tbt,
         )

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -443,7 +443,6 @@ class _TrainingJob(base.VertexAiResourceNounWithFutureManager):
             fraction_split = None
 
             # Create filter split
-            filter_split = None
             if all(
                 [
                     training_filter_split is not None,
@@ -458,33 +457,31 @@ class _TrainingJob(base.VertexAiResourceNounWithFutureManager):
                 )
 
             # Create predefined split
-            predefined_split = None
             if predefined_split_column_name:
                 predefined_split = gca_training_pipeline.PredefinedSplit(
                     key=predefined_split_column_name
                 )
 
             # Create timestamp split or fraction split
-            if all(
+            if timestamp_split_column_name:
+                timestamp_split = gca_training_pipeline.TimestampSplit(
+                    training_fraction=training_fraction_split,
+                    validation_fraction=validation_fraction_split,
+                    test_fraction=test_fraction_split,
+                    key=timestamp_split_column_name,
+                )
+            elif any(
                 [
                     training_fraction_split is not None,
                     validation_fraction_split is not None,
                     test_fraction_split is not None,
                 ]
             ):
-                if timestamp_split_column_name:
-                    timestamp_split = gca_training_pipeline.TimestampSplit(
-                        training_fraction=training_fraction_split,
-                        validation_fraction=validation_fraction_split,
-                        test_fraction=test_fraction_split,
-                        key=timestamp_split_column_name,
-                    )
-                else:
-                    fraction_split = gca_training_pipeline.FractionSplit(
-                        training_fraction=training_fraction_split,
-                        validation_fraction=validation_fraction_split,
-                        test_fraction=test_fraction_split,
-                    )
+                fraction_split = gca_training_pipeline.FractionSplit(
+                    training_fraction=training_fraction_split,
+                    validation_fraction=validation_fraction_split,
+                    test_fraction=test_fraction_split,
+                )
 
             splits = [
                 split
@@ -5669,9 +5666,9 @@ class AutoMLVideoTrainingJob(_TrainingJob):
             training_task_inputs=training_task_inputs_dict,
             dataset=dataset,
             training_fraction_split=training_fraction_split,
-            validation_fraction_split=0,
             test_fraction_split=test_fraction_split,
             training_filter_split=training_filter_split,
+            # AutoMLVideo does not support validation, so pass in '-'
             validation_filter_split="-",
             test_filter_split=test_filter_split,
             model=model_tbt,

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -1764,6 +1764,17 @@ class CustomTrainingJob(_CustomTrainingJob):
         they can be set as '-' (the minus sign).
         Supported only for unstructured Datasets.
 
+        Predefined splits:
+        Assigns input data to training, validation, and test sets based on the value of a provided key.
+        Supported only for tabular Datasets.
+
+        Timestamp splits:
+        Assigns input data to training, validation, and test sets
+        based on a provided timestamps. The youngest data pieces are
+        assigned to training set, next to validation set, and the oldest
+        to the test set.
+        Supported only for tabular Datasets.        
+
         Args:
             dataset (
                 Union[
@@ -2510,7 +2521,18 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
         If any of the filters in this message are to match nothing, then
         they can be set as '-' (the minus sign).
         Supported only for unstructured Datasets.
-        
+
+        Predefined splits:
+        Assigns input data to training, validation, and test sets based on the value of a provided key.
+        Supported only for tabular Datasets.
+
+        Timestamp splits:
+        Assigns input data to training, validation, and test sets
+        based on a provided timestamps. The youngest data pieces are
+        assigned to training set, next to validation set, and the oldest
+        to the test set.
+        Supported only for tabular Datasets.        
+
         Args:
             dataset (Union[datasets.ImageDataset,datasets.TabularDataset,datasets.TextDataset,datasets.VideoDataset]):
                 Vertex AI to fit this training against. Custom training script should
@@ -4874,6 +4896,17 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
         If any of the filters in this message are to match nothing, then
         they can be set as '-' (the minus sign).
         Supported only for unstructured Datasets.
+
+        Predefined splits:
+        Assigns input data to training, validation, and test sets based on the value of a provided key.
+        Supported only for tabular Datasets.
+
+        Timestamp splits:
+        Assigns input data to training, validation, and test sets
+        based on a provided timestamps. The youngest data pieces are
+        assigned to training set, next to validation set, and the oldest
+        to the test set.
+        Supported only for tabular Datasets.        
 
         Args:
             dataset (Union[datasets.ImageDataset,datasets.TabularDataset,datasets.TextDataset,datasets.VideoDataset,]):

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -500,7 +500,7 @@ class _TrainingJob(base.VertexAiResourceNounWithFutureManager):
             # Fallback to fraction split if nothing else is specified
             if len(splits) == 0:
                 logging.info(
-                    f"No dataset split provided. The service will use a default split."
+                    "No dataset split provided. The service will use a default split."
                 )
             elif len(splits) > 1:
                 raise ValueError(
@@ -1773,7 +1773,7 @@ class CustomTrainingJob(_CustomTrainingJob):
         based on a provided timestamps. The youngest data pieces are
         assigned to training set, next to validation set, and the oldest
         to the test set.
-        Supported only for tabular Datasets.        
+        Supported only for tabular Datasets.
 
         Args:
             dataset (
@@ -2531,7 +2531,7 @@ class CustomContainerTrainingJob(_CustomTrainingJob):
         based on a provided timestamps. The youngest data pieces are
         assigned to training set, next to validation set, and the oldest
         to the test set.
-        Supported only for tabular Datasets.        
+        Supported only for tabular Datasets.
 
         Args:
             dataset (Union[datasets.ImageDataset,datasets.TabularDataset,datasets.TextDataset,datasets.VideoDataset]):
@@ -4906,7 +4906,7 @@ class CustomPythonPackageTrainingJob(_CustomTrainingJob):
         based on a provided timestamps. The youngest data pieces are
         assigned to training set, next to validation set, and the oldest
         to the test set.
-        Supported only for tabular Datasets.        
+        Supported only for tabular Datasets.
 
         Args:
             dataset (Union[datasets.ImageDataset,datasets.TabularDataset,datasets.TextDataset,datasets.VideoDataset,]):

--- a/tests/unit/aiplatform/test_automl_forecasting_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_forecasting_training_jobs.py
@@ -103,14 +103,11 @@ _TEST_TRAINING_TASK_INPUTS_WITH_ADDITIONAL_EXPERIMENTS = json_format.ParseDict(
 _TEST_DATASET_NAME = "test-dataset-name"
 
 _TEST_MODEL_DISPLAY_NAME = "model-display-name"
+
 _TEST_LABELS = {"key": "value"}
 _TEST_MODEL_LABELS = {"model_key": "model_value"}
-_TEST_TRAINING_FRACTION_SPLIT = 0.8
-_TEST_VALIDATION_FRACTION_SPLIT = 0.1
-_TEST_TEST_FRACTION_SPLIT = 0.1
-_TEST_PREDEFINED_SPLIT_COLUMN_NAME = "split"
 
-_TEST_OUTPUT_PYTHON_PACKAGE_PATH = "gs://test/ouput/python/trainer.tar.gz"
+_TEST_PREDEFINED_SPLIT_COLUMN_NAME = "split"
 
 _TEST_MODEL_NAME = "projects/my-project/locations/us-central1/models/12345"
 
@@ -261,18 +258,11 @@ class TestAutoMLForecastingTrainingJob:
         if not sync:
             model_from_job.wait()
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_TEST_FRACTION_SPLIT,
-        )
-
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME, labels=_TEST_MODEL_LABELS
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
             predefined_split=gca_training_pipeline.PredefinedSplit(
                 key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
             ),
@@ -348,19 +338,12 @@ class TestAutoMLForecastingTrainingJob:
         if not sync:
             model_from_job.wait()
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_TEST_FRACTION_SPLIT,
-        )
-
         # Test that if defaults to the job display name
         true_managed_model = gca_model.Model(
             display_name=_TEST_DISPLAY_NAME, labels=_TEST_LABELS,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
             dataset_id=mock_dataset_time_series.name,
         )
 
@@ -422,17 +405,10 @@ class TestAutoMLForecastingTrainingJob:
         if not sync:
             model_from_job.wait()
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_TEST_FRACTION_SPLIT,
-        )
-
         # Test that if defaults to the job display name
         true_managed_model = gca_model.Model(display_name=_TEST_DISPLAY_NAME)
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
             dataset_id=mock_dataset_time_series.name,
         )
 

--- a/tests/unit/aiplatform/test_automl_image_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_image_training_jobs.py
@@ -74,6 +74,10 @@ _TEST_FRACTION_SPLIT_TRAINING = 0.6
 _TEST_FRACTION_SPLIT_VALIDATION = 0.2
 _TEST_FRACTION_SPLIT_TEST = 0.2
 
+_TEST_FILTER_SPLIT_TRAINING = "train"
+_TEST_FILTER_SPLIT_VALIDATION = "validate"
+_TEST_FILTER_SPLIT_TEST = "test"
+
 _TEST_MODEL_NAME = (
     f"projects/{_TEST_PROJECT}/locations/{_TEST_LOCATION}/models/{_TEST_MODEL_ID}"
 )
@@ -159,6 +163,7 @@ def mock_model_service_get():
 def mock_dataset_image():
     ds = mock.MagicMock(datasets.ImageDataset)
     ds.name = _TEST_DATASET_NAME
+    ds.metadata_schema_uri = _TEST_METADATA_SCHEMA_URI_IMAGE
     ds._latest_future = None
     ds._exception = None
     ds._gca_resource = gca_dataset.Dataset(
@@ -172,7 +177,7 @@ def mock_dataset_image():
 
 
 @pytest.fixture
-def mock_model_image():
+def mock_model():
     model = mock.MagicMock(models.Model)
     model.name = _TEST_MODEL_ID
     model._latest_future = None
@@ -193,8 +198,8 @@ class TestAutoMLImageTrainingJob:
     def teardown_method(self):
         initializer.global_pool.shutdown(wait=True)
 
-    def test_init_all_parameters(self, mock_model_image):
-        """Ensure all private members are set correctly at initialization"""
+    def test_init_all_parameters(self, mock_model):
+        """Ensure all private members are set correctly at initalization"""
 
         aiplatform.init(project=_TEST_PROJECT)
 
@@ -202,7 +207,7 @@ class TestAutoMLImageTrainingJob:
             display_name=_TEST_DISPLAY_NAME,
             prediction_type=_TEST_PREDICTION_TYPE_ICN,
             model_type=_TEST_MODEL_TYPE_MOBILE,
-            base_model=mock_model_image,
+            base_model=mock_model,
             multi_label=True,
         )
 
@@ -210,9 +215,9 @@ class TestAutoMLImageTrainingJob:
         assert job._model_type == _TEST_MODEL_TYPE_MOBILE
         assert job._prediction_type == _TEST_PREDICTION_TYPE_ICN
         assert job._multi_label is True
-        assert job._base_model == mock_model_image
+        assert job._base_model == mock_model
 
-    def test_init_wrong_parameters(self, mock_model_image):
+    def test_init_wrong_parameters(self, mock_model):
         """Ensure correct exceptions are raised when initializing with invalid args"""
 
         aiplatform.init(project=_TEST_PROJECT)
@@ -233,7 +238,7 @@ class TestAutoMLImageTrainingJob:
             training_jobs.AutoMLImageTrainingJob(
                 display_name=_TEST_DISPLAY_NAME,
                 prediction_type=_TEST_PREDICTION_TYPE_IOD,
-                base_model=mock_model_image,
+                base_model=mock_model,
             )
 
     @pytest.mark.parametrize("sync", [True, False])
@@ -243,7 +248,7 @@ class TestAutoMLImageTrainingJob:
         mock_pipeline_service_get,
         mock_dataset_image,
         mock_model_service_get,
-        mock_model_image,
+        mock_model,
         sync,
     ):
         """Create and run an AutoML ICN training job, verify calls and return value"""
@@ -254,18 +259,16 @@ class TestAutoMLImageTrainingJob:
         )
 
         job = training_jobs.AutoMLImageTrainingJob(
-            display_name=_TEST_DISPLAY_NAME,
-            base_model=mock_model_image,
-            labels=_TEST_LABELS,
+            display_name=_TEST_DISPLAY_NAME, base_model=mock_model, labels=_TEST_LABELS,
         )
 
         model_from_job = job.run(
             dataset=mock_dataset_image,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
             model_labels=_TEST_MODEL_LABELS,
-            training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
-            validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
-            test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
+            training_filter_split=_TEST_FILTER_SPLIT_TRAINING,
+            validation_filter_split=_TEST_FILTER_SPLIT_VALIDATION,
+            test_filter_split=_TEST_FILTER_SPLIT_TEST,
             budget_milli_node_hours=_TEST_TRAINING_BUDGET_MILLI_NODE_HOURS,
             disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
             sync=sync,
@@ -274,21 +277,21 @@ class TestAutoMLImageTrainingJob:
         if not sync:
             model_from_job.wait()
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_FRACTION_SPLIT_TRAINING,
-            validation_fraction=_TEST_FRACTION_SPLIT_VALIDATION,
-            test_fraction=_TEST_FRACTION_SPLIT_TEST,
+        true_filter_split = gca_training_pipeline.FilterSplit(
+            training_filter=_TEST_FILTER_SPLIT_TRAINING,
+            validation_filter=_TEST_FILTER_SPLIT_VALIDATION,
+            test_filter=_TEST_FILTER_SPLIT_TEST,
         )
 
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
-            labels=mock_model_image._gca_resource.labels,
-            description=mock_model_image._gca_resource.description,
+            labels=mock_model._gca_resource.labels,
+            description=mock_model._gca_resource.description,
             encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split, dataset_id=mock_dataset_image.name,
+            filter_split=true_filter_split, dataset_id=mock_dataset_image.name,
         )
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
@@ -333,21 +336,12 @@ class TestAutoMLImageTrainingJob:
 
         model_from_job = job.run(
             dataset=mock_dataset_image,
-            training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
-            validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
-            test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
             budget_milli_node_hours=_TEST_TRAINING_BUDGET_MILLI_NODE_HOURS,
             disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
         )
 
         if not sync:
             model_from_job.wait()
-
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_FRACTION_SPLIT_TRAINING,
-            validation_fraction=_TEST_FRACTION_SPLIT_VALIDATION,
-            test_fraction=_TEST_FRACTION_SPLIT_TEST,
-        )
 
         # Test that if defaults to the job display name
         true_managed_model = gca_model.Model(
@@ -357,7 +351,7 @@ class TestAutoMLImageTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split, dataset_id=mock_dataset_image.name,
+            dataset_id=mock_dataset_image.name
         )
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
@@ -400,11 +394,36 @@ class TestAutoMLImageTrainingJob:
             job.run(
                 dataset=mock_dataset_image,
                 model_display_name=_TEST_MODEL_DISPLAY_NAME,
+                sync=sync,
+            )
+
+    @pytest.mark.usefixtures(
+        "mock_pipeline_service_create",
+        "mock_pipeline_service_get",
+        "mock_model_service_get",
+    )
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_run_with_two_split_raises(
+        self, mock_dataset_image, sync,
+    ):
+        aiplatform.init(project=_TEST_PROJECT)
+
+        job = training_jobs.AutoMLImageTrainingJob(display_name=_TEST_DISPLAY_NAME,)
+
+        with pytest.raises(ValueError):
+            model_from_job = job.run(
+                dataset=mock_dataset_image,
+                model_display_name=_TEST_MODEL_DISPLAY_NAME,
                 training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
                 validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
                 test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
+                training_filter_split=_TEST_FILTER_SPLIT_TRAINING,
+                validation_filter_split=_TEST_FILTER_SPLIT_VALIDATION,
+                test_filter_split=_TEST_FILTER_SPLIT_TEST,
                 sync=sync,
             )
+            if not sync:
+                model_from_job.wait()
 
     @pytest.mark.parametrize("sync", [True, False])
     def test_run_raises_if_pipeline_fails(
@@ -444,3 +463,194 @@ class TestAutoMLImageTrainingJob:
 
         with pytest.raises(RuntimeError):
             job.state
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_splits_fraction(
+        self,
+        mock_pipeline_service_create,
+        mock_pipeline_service_get,
+        mock_dataset_image,
+        mock_model_service_get,
+        mock_model,
+        sync,
+    ):
+        """
+        Initiate aiplatform with encryption key name.
+        Create and run an AutoML Video Classification training job, verify calls and return value
+        """
+
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
+        )
+        job = training_jobs.AutoMLImageTrainingJob(
+            display_name=_TEST_DISPLAY_NAME, base_model=mock_model
+        )
+
+        model_from_job = job.run(
+            dataset=mock_dataset_image,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
+            validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
+            test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
+            disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
+            sync=sync,
+        )
+
+        if not sync:
+            model_from_job.wait()
+
+        true_fraction_split = gca_training_pipeline.FractionSplit(
+            training_fraction=_TEST_FRACTION_SPLIT_TRAINING,
+            validation_fraction=_TEST_FRACTION_SPLIT_VALIDATION,
+            test_fraction=_TEST_FRACTION_SPLIT_TEST,
+        )
+
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            description=mock_model._gca_resource.description,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        true_input_data_config = gca_training_pipeline.InputDataConfig(
+            fraction_split=true_fraction_split, dataset_id=mock_dataset_image.name,
+        )
+
+        true_training_pipeline = gca_training_pipeline.TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.automl_image_classification,
+            training_task_inputs=_TEST_TRAINING_TASK_INPUTS_WITH_BASE_MODEL,
+            model_to_upload=true_managed_model,
+            input_data_config=true_input_data_config,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_splits_filter(
+        self,
+        mock_pipeline_service_create,
+        mock_pipeline_service_get,
+        mock_dataset_image,
+        mock_model_service_get,
+        mock_model,
+        sync,
+    ):
+        """
+        Initiate aiplatform with encryption key name.
+        Create and run an AutoML Video Classification training job, verify calls and return value
+        """
+
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
+        )
+
+        job = training_jobs.AutoMLImageTrainingJob(
+            display_name=_TEST_DISPLAY_NAME, base_model=mock_model
+        )
+
+        model_from_job = job.run(
+            dataset=mock_dataset_image,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            training_filter_split=_TEST_FILTER_SPLIT_TRAINING,
+            validation_filter_split=_TEST_FILTER_SPLIT_VALIDATION,
+            test_filter_split=_TEST_FILTER_SPLIT_TEST,
+            disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
+            sync=sync,
+        )
+
+        if not sync:
+            model_from_job.wait()
+
+        true_filter_split = gca_training_pipeline.FilterSplit(
+            training_filter=_TEST_FILTER_SPLIT_TRAINING,
+            validation_filter=_TEST_FILTER_SPLIT_VALIDATION,
+            test_filter=_TEST_FILTER_SPLIT_TEST,
+        )
+
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            description=mock_model._gca_resource.description,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        true_input_data_config = gca_training_pipeline.InputDataConfig(
+            filter_split=true_filter_split, dataset_id=mock_dataset_image.name,
+        )
+
+        true_training_pipeline = gca_training_pipeline.TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.automl_image_classification,
+            training_task_inputs=_TEST_TRAINING_TASK_INPUTS_WITH_BASE_MODEL,
+            model_to_upload=true_managed_model,
+            input_data_config=true_input_data_config,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_splits_default(
+        self,
+        mock_pipeline_service_create,
+        mock_pipeline_service_get,
+        mock_dataset_image,
+        mock_model_service_get,
+        mock_model,
+        sync,
+    ):
+        """
+        Initiate aiplatform with encryption key name.
+        Create and run an AutoML Video Classification training job, verify calls and return value
+        """
+
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
+        )
+
+        job = training_jobs.AutoMLImageTrainingJob(
+            display_name=_TEST_DISPLAY_NAME, base_model=mock_model
+        )
+
+        model_from_job = job.run(
+            dataset=mock_dataset_image,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
+            sync=sync,
+        )
+
+        if not sync:
+            model_from_job.wait()
+
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            description=mock_model._gca_resource.description,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        true_input_data_config = gca_training_pipeline.InputDataConfig(
+            dataset_id=mock_dataset_image.name,
+        )
+
+        true_training_pipeline = gca_training_pipeline.TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.automl_image_classification,
+            training_task_inputs=_TEST_TRAINING_TASK_INPUTS_WITH_BASE_MODEL,
+            model_to_upload=true_managed_model,
+            input_data_config=true_input_data_config,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )

--- a/tests/unit/aiplatform/test_automl_image_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_image_training_jobs.py
@@ -199,7 +199,7 @@ class TestAutoMLImageTrainingJob:
         initializer.global_pool.shutdown(wait=True)
 
     def test_init_all_parameters(self, mock_model):
-        """Ensure all private members are set correctly at initalization"""
+        """Ensure all private members are set correctly at initialization"""
 
         aiplatform.init(project=_TEST_PROJECT)
 

--- a/tests/unit/aiplatform/test_automl_image_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_image_training_jobs.py
@@ -654,3 +654,35 @@ class TestAutoMLImageTrainingJob:
             parent=initializer.global_config.common_location_path(),
             training_pipeline=true_training_pipeline,
         )
+
+    def test_splits_filter_incomplete(
+        self,
+        mock_pipeline_service_create,
+        mock_pipeline_service_get,
+        mock_dataset_image,
+        mock_model_service_get,
+        mock_model,
+    ):
+        """
+        Initiate aiplatform with encryption key name.
+        Create and run an AutoML Video Classification training job, verify calls and return value
+        """
+
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
+        )
+
+        job = training_jobs.AutoMLImageTrainingJob(
+            display_name=_TEST_DISPLAY_NAME, base_model=mock_model
+        )
+
+        with pytest.raises(ValueError):
+            job.run(
+                dataset=mock_dataset_image,
+                model_display_name=_TEST_MODEL_DISPLAY_NAME,
+                training_filter_split=_TEST_FILTER_SPLIT_TRAINING,
+                validation_fraction_split=None,
+                test_filter_split=_TEST_FILTER_SPLIT_TEST,
+                disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
+            )

--- a/tests/unit/aiplatform/test_automl_tabular_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_tabular_training_jobs.py
@@ -140,10 +140,12 @@ _TEST_MODEL_DISPLAY_NAME = "model-display-name"
 _TEST_LABELS = {"key": "value"}
 _TEST_MODEL_LABELS = {"model_key": "model_value"}
 
-_TEST_TRAINING_FRACTION_SPLIT = 0.6
-_TEST_VALIDATION_FRACTION_SPLIT = 0.2
-_TEST_TEST_FRACTION_SPLIT = 0.2
-_TEST_PREDEFINED_SPLIT_COLUMN_NAME = "split"
+_TEST_FRACTION_SPLIT_TRAINING = 0.6
+_TEST_FRACTION_SPLIT_VALIDATION = 0.2
+_TEST_FRACTION_SPLIT_TEST = 0.2
+
+_TEST_SPLIT_PREDEFINED_COLUMN_NAME = "split"
+_TEST_SPLIT_TIMESTAMP_COLUMN_NAME = "timestamp"
 
 _TEST_OUTPUT_PYTHON_PACKAGE_PATH = "gs://test/ouput/python/trainer.tar.gz"
 
@@ -325,10 +327,6 @@ class TestAutoMLTabularTrainingJob:
             target_column=_TEST_TRAINING_TARGET_COLUMN,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
             model_labels=_TEST_MODEL_LABELS,
-            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
-            predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
             weight_column=_TEST_TRAINING_WEIGHT_COLUMN,
             budget_milli_node_hours=_TEST_TRAINING_BUDGET_MILLI_NODE_HOURS,
             disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
@@ -342,12 +340,6 @@ class TestAutoMLTabularTrainingJob:
         if not sync:
             model_from_job.wait()
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_TEST_FRACTION_SPLIT,
-        )
-
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
             labels=_TEST_MODEL_LABELS,
@@ -355,10 +347,6 @@ class TestAutoMLTabularTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
-            predefined_split=gca_training_pipeline.PredefinedSplit(
-                key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
-            ),
             dataset_id=mock_dataset_tabular.name,
         )
 
@@ -417,10 +405,6 @@ class TestAutoMLTabularTrainingJob:
             dataset=mock_dataset_tabular,
             target_column=_TEST_TRAINING_TARGET_COLUMN,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
-            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
-            predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
             weight_column=_TEST_TRAINING_WEIGHT_COLUMN,
             budget_milli_node_hours=_TEST_TRAINING_BUDGET_MILLI_NODE_HOURS,
             disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
@@ -437,22 +421,12 @@ class TestAutoMLTabularTrainingJob:
         if not sync:
             model_from_job.wait()
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_TEST_FRACTION_SPLIT,
-        )
-
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
             encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
-            predefined_split=gca_training_pipeline.PredefinedSplit(
-                key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
-            ),
             dataset_id=mock_dataset_tabular.name,
         )
 
@@ -508,9 +482,6 @@ class TestAutoMLTabularTrainingJob:
         model_from_job = job.run(
             dataset=mock_dataset_tabular,
             target_column=_TEST_TRAINING_TARGET_COLUMN,
-            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
             weight_column=_TEST_TRAINING_WEIGHT_COLUMN,
             budget_milli_node_hours=_TEST_TRAINING_BUDGET_MILLI_NODE_HOURS,
             disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
@@ -523,12 +494,6 @@ class TestAutoMLTabularTrainingJob:
         if not sync:
             model_from_job.wait()
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_TEST_FRACTION_SPLIT,
-        )
-
         # Test that if defaults to the job display name
         true_managed_model = gca_model.Model(
             display_name=_TEST_DISPLAY_NAME,
@@ -537,7 +502,7 @@ class TestAutoMLTabularTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split, dataset_id=mock_dataset_tabular.name,
+            dataset_id=mock_dataset_tabular.name,
         )
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
@@ -584,10 +549,6 @@ class TestAutoMLTabularTrainingJob:
             dataset=mock_dataset_tabular,
             target_column=_TEST_TRAINING_TARGET_COLUMN,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
-            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
-            predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
             weight_column=_TEST_TRAINING_WEIGHT_COLUMN,
             budget_milli_node_hours=_TEST_TRAINING_BUDGET_MILLI_NODE_HOURS,
             disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
@@ -601,22 +562,12 @@ class TestAutoMLTabularTrainingJob:
         if not sync:
             model_from_job.wait()
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_TEST_FRACTION_SPLIT,
-        )
-
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
             encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
-            predefined_split=gca_training_pipeline.PredefinedSplit(
-                key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
-            ),
             dataset_id=mock_dataset_tabular.name,
         )
 
@@ -665,10 +616,6 @@ class TestAutoMLTabularTrainingJob:
             dataset=mock_dataset_tabular,
             target_column=_TEST_TRAINING_TARGET_COLUMN,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
-            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
-            predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
             weight_column=_TEST_TRAINING_WEIGHT_COLUMN,
             budget_milli_node_hours=_TEST_TRAINING_BUDGET_MILLI_NODE_HOURS,
             disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
@@ -682,22 +629,12 @@ class TestAutoMLTabularTrainingJob:
         if not sync:
             model_from_job.wait()
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_TEST_FRACTION_SPLIT,
-        )
-
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
             encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
-            predefined_split=gca_training_pipeline.PredefinedSplit(
-                key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
-            ),
             dataset_id=mock_dataset_tabular.name,
         )
 
@@ -746,10 +683,6 @@ class TestAutoMLTabularTrainingJob:
             dataset=mock_dataset_tabular_alternative,
             target_column=_TEST_TRAINING_TARGET_COLUMN,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
-            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
-            predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
             weight_column=_TEST_TRAINING_WEIGHT_COLUMN,
             budget_milli_node_hours=_TEST_TRAINING_BUDGET_MILLI_NODE_HOURS,
             disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
@@ -759,19 +692,9 @@ class TestAutoMLTabularTrainingJob:
         if not sync:
             model_from_job.wait()
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_TEST_FRACTION_SPLIT,
-        )
-
         true_managed_model = gca_model.Model(display_name=_TEST_MODEL_DISPLAY_NAME)
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
-            predefined_split=gca_training_pipeline.PredefinedSplit(
-                key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
-            ),
             dataset_id=mock_dataset_tabular_alternative.name,
         )
 
@@ -858,10 +781,6 @@ class TestAutoMLTabularTrainingJob:
             dataset=mock_dataset_tabular_alternative,
             target_column=_TEST_TRAINING_TARGET_COLUMN,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
-            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
-            predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
             weight_column=_TEST_TRAINING_WEIGHT_COLUMN,
             budget_milli_node_hours=_TEST_TRAINING_BUDGET_MILLI_NODE_HOURS,
             disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
@@ -871,19 +790,9 @@ class TestAutoMLTabularTrainingJob:
         if not sync:
             model_from_job.wait()
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_TEST_FRACTION_SPLIT,
-        )
-
         true_managed_model = gca_model.Model(display_name=_TEST_MODEL_DISPLAY_NAME)
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
-            predefined_split=gca_training_pipeline.PredefinedSplit(
-                key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
-            ),
             dataset_id=mock_dataset_tabular_alternative.name,
         )
 
@@ -923,9 +832,6 @@ class TestAutoMLTabularTrainingJob:
             dataset=mock_dataset_tabular,
             target_column=_TEST_TRAINING_TARGET_COLUMN,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
-            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
             sync=sync,
         )
 
@@ -938,9 +844,6 @@ class TestAutoMLTabularTrainingJob:
                 dataset=mock_dataset_tabular,
                 target_column=_TEST_TRAINING_TARGET_COLUMN,
                 model_display_name=_TEST_MODEL_DISPLAY_NAME,
-                training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-                validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-                test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
                 sync=sync,
             )
 
@@ -965,9 +868,6 @@ class TestAutoMLTabularTrainingJob:
                 model_display_name=_TEST_MODEL_DISPLAY_NAME,
                 dataset=mock_dataset_tabular,
                 target_column=_TEST_TRAINING_TARGET_COLUMN,
-                training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-                validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-                test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
                 sync=sync,
             )
 
@@ -996,9 +896,6 @@ class TestAutoMLTabularTrainingJob:
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
             dataset=mock_dataset_tabular,
             target_column=_TEST_TRAINING_TARGET_COLUMN,
-            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
             sync=False,
         )
 
@@ -1033,9 +930,6 @@ class TestAutoMLTabularTrainingJob:
                     model_display_name=_TEST_MODEL_DISPLAY_NAME,
                     dataset=mock_dataset_tabular,
                     target_column=_TEST_TRAINING_TARGET_COLUMN,
-                    training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-                    validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-                    test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
                     sync=sync,
                 )
             assert e.match("Mock fail")
@@ -1065,9 +959,6 @@ class TestAutoMLTabularTrainingJob:
                 model_display_name=_TEST_MODEL_DISPLAY_NAME,
                 dataset=mock_dataset_tabular,
                 target_column=_TEST_TRAINING_TARGET_COLUMN,
-                training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-                validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-                test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
                 sync=sync,
             )
 
@@ -1163,3 +1054,280 @@ class TestAutoMLTabularTrainingJob:
             assert e.match(
                 regexp=r"AutoMLTabularTrainingJob resource has not been created"
             )
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_splits_fraction(
+        self,
+        mock_pipeline_service_create,
+        mock_pipeline_service_get,
+        mock_dataset_tabular,
+        mock_model_service_get,
+        sync,
+    ):
+        """
+        Initiate aiplatform with encryption key name.
+        Create and run an AutoML Video Classification training job, verify calls and return value
+        """
+
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
+        )
+
+        job = training_jobs.AutoMLTabularTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            optimization_prediction_type=_TEST_TRAINING_OPTIMIZATION_PREDICTION_TYPE,
+            optimization_objective=_TEST_TRAINING_OPTIMIZATION_OBJECTIVE_NAME,
+            column_transformations=_TEST_TRAINING_COLUMN_TRANSFORMATIONS,
+            optimization_objective_recall_value=None,
+            optimization_objective_precision_value=None,
+        )
+
+        model_from_job = job.run(
+            dataset=mock_dataset_tabular,
+            target_column=_TEST_TRAINING_TARGET_COLUMN,
+            weight_column=_TEST_TRAINING_WEIGHT_COLUMN,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
+            validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
+            test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
+            disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
+            sync=sync,
+        )
+
+        if not sync:
+            model_from_job.wait()
+
+        true_fraction_split = gca_training_pipeline.FractionSplit(
+            training_fraction=_TEST_FRACTION_SPLIT_TRAINING,
+            validation_fraction=_TEST_FRACTION_SPLIT_VALIDATION,
+            test_fraction=_TEST_FRACTION_SPLIT_TEST,
+        )
+
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        true_input_data_config = gca_training_pipeline.InputDataConfig(
+            fraction_split=true_fraction_split, dataset_id=mock_dataset_tabular.name,
+        )
+
+        true_training_pipeline = gca_training_pipeline.TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.automl_tabular,
+            training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
+            model_to_upload=true_managed_model,
+            input_data_config=true_input_data_config,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_splits_timestamp(
+        self,
+        mock_pipeline_service_create,
+        mock_pipeline_service_get,
+        mock_dataset_tabular,
+        mock_model_service_get,
+        sync,
+    ):
+        """
+        Initiate aiplatform with encryption key name.
+        Create and run an AutoML Video Classification training job, verify calls and return value
+        """
+
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
+        )
+
+        job = training_jobs.AutoMLTabularTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            optimization_prediction_type=_TEST_TRAINING_OPTIMIZATION_PREDICTION_TYPE,
+            optimization_objective=_TEST_TRAINING_OPTIMIZATION_OBJECTIVE_NAME,
+            column_transformations=_TEST_TRAINING_COLUMN_TRANSFORMATIONS,
+            optimization_objective_recall_value=None,
+            optimization_objective_precision_value=None,
+        )
+
+        model_from_job = job.run(
+            dataset=mock_dataset_tabular,
+            target_column=_TEST_TRAINING_TARGET_COLUMN,
+            weight_column=_TEST_TRAINING_WEIGHT_COLUMN,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
+            validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
+            test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
+            timestamp_split_column_name=_TEST_SPLIT_TIMESTAMP_COLUMN_NAME,
+            disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
+            sync=sync,
+        )
+
+        if not sync:
+            model_from_job.wait()
+
+        true_split = gca_training_pipeline.TimestampSplit(
+            training_fraction=_TEST_FRACTION_SPLIT_TRAINING,
+            validation_fraction=_TEST_FRACTION_SPLIT_VALIDATION,
+            test_fraction=_TEST_FRACTION_SPLIT_TEST,
+            key=_TEST_SPLIT_TIMESTAMP_COLUMN_NAME,
+        )
+
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        true_input_data_config = gca_training_pipeline.InputDataConfig(
+            timestamp_split=true_split, dataset_id=mock_dataset_tabular.name,
+        )
+
+        true_training_pipeline = gca_training_pipeline.TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.automl_tabular,
+            training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
+            model_to_upload=true_managed_model,
+            input_data_config=true_input_data_config,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_splits_predefined(
+        self,
+        mock_pipeline_service_create,
+        mock_pipeline_service_get,
+        mock_dataset_tabular,
+        mock_model_service_get,
+        sync,
+    ):
+        """
+        Initiate aiplatform with encryption key name.
+        Create and run an AutoML Video Classification training job, verify calls and return value
+        """
+
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
+        )
+
+        job = training_jobs.AutoMLTabularTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            optimization_prediction_type=_TEST_TRAINING_OPTIMIZATION_PREDICTION_TYPE,
+            optimization_objective=_TEST_TRAINING_OPTIMIZATION_OBJECTIVE_NAME,
+            column_transformations=_TEST_TRAINING_COLUMN_TRANSFORMATIONS,
+            optimization_objective_recall_value=None,
+            optimization_objective_precision_value=None,
+        )
+
+        model_from_job = job.run(
+            dataset=mock_dataset_tabular,
+            target_column=_TEST_TRAINING_TARGET_COLUMN,
+            weight_column=_TEST_TRAINING_WEIGHT_COLUMN,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            predefined_split_column_name=_TEST_SPLIT_PREDEFINED_COLUMN_NAME,
+            disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
+            sync=sync,
+        )
+
+        if not sync:
+            model_from_job.wait()
+
+        true_split = gca_training_pipeline.PredefinedSplit(
+            key=_TEST_SPLIT_PREDEFINED_COLUMN_NAME
+        )
+
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        true_input_data_config = gca_training_pipeline.InputDataConfig(
+            predefined_split=true_split, dataset_id=mock_dataset_tabular.name,
+        )
+
+        true_training_pipeline = gca_training_pipeline.TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.automl_tabular,
+            training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
+            model_to_upload=true_managed_model,
+            input_data_config=true_input_data_config,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_splits_default(
+        self,
+        mock_pipeline_service_create,
+        mock_pipeline_service_get,
+        mock_dataset_tabular,
+        mock_model_service_get,
+        sync,
+    ):
+        """
+        Initiate aiplatform with encryption key name.
+        Create and run an AutoML Video Classification training job, verify calls and return value
+        """
+
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
+        )
+
+        job = training_jobs.AutoMLTabularTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            optimization_prediction_type=_TEST_TRAINING_OPTIMIZATION_PREDICTION_TYPE,
+            optimization_objective=_TEST_TRAINING_OPTIMIZATION_OBJECTIVE_NAME,
+            column_transformations=_TEST_TRAINING_COLUMN_TRANSFORMATIONS,
+            optimization_objective_recall_value=None,
+            optimization_objective_precision_value=None,
+        )
+
+        model_from_job = job.run(
+            dataset=mock_dataset_tabular,
+            target_column=_TEST_TRAINING_TARGET_COLUMN,
+            weight_column=_TEST_TRAINING_WEIGHT_COLUMN,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            disable_early_stopping=_TEST_TRAINING_DISABLE_EARLY_STOPPING,
+            sync=sync,
+        )
+
+        if not sync:
+            model_from_job.wait()
+
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        true_input_data_config = gca_training_pipeline.InputDataConfig(
+            dataset_id=mock_dataset_tabular.name,
+        )
+
+        true_training_pipeline = gca_training_pipeline.TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.automl_tabular,
+            training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
+            model_to_upload=true_managed_model,
+            input_data_config=true_input_data_config,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )

--- a/tests/unit/aiplatform/test_automl_text_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_text_training_jobs.py
@@ -59,6 +59,10 @@ _TEST_TRAINING_TASK_INPUTS_SENTIMENT = training_job_inputs.AutoMlTextSentimentIn
 _TEST_FRACTION_SPLIT_TRAINING = 0.6
 _TEST_FRACTION_SPLIT_VALIDATION = 0.2
 _TEST_FRACTION_SPLIT_TEST = 0.2
+_TEST_FILTER_SPLIT_TRAINING = "train"
+_TEST_FILTER_SPLIT_VALIDATION = "validate"
+_TEST_FILTER_SPLIT_TEST = "test"
+_TEST_PREDEFINED_SPLIT_COLUMN_NAME = "predefined_column"
 
 _TEST_MODEL_NAME = (
     f"projects/{_TEST_PROJECT}/locations/{_TEST_LOCATION}/models/{_TEST_MODEL_ID}"
@@ -145,6 +149,7 @@ def mock_model_service_get():
 def mock_dataset_text():
     ds = mock.MagicMock(datasets.TextDataset)
     ds.name = _TEST_DATASET_NAME
+    ds.metadata_schema_uri = _TEST_METADATA_SCHEMA_URI_TEXT
     ds._latest_future = None
     ds._exception = None
     ds._gca_resource = gca_dataset.Dataset(
@@ -270,20 +275,11 @@ class TestAutoMLTextTrainingJob:
         model_from_job = job.run(
             dataset=mock_dataset_text,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
-            training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
-            validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
-            test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
             sync=sync,
         )
 
         if not sync:
             model_from_job.wait()
-
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_FRACTION_SPLIT_TRAINING,
-            validation_fraction=_TEST_FRACTION_SPLIT_VALIDATION,
-            test_fraction=_TEST_FRACTION_SPLIT_TEST,
-        )
 
         true_managed_model = gca_model.Model(
             display_name=_TEST_MODEL_DISPLAY_NAME,
@@ -291,7 +287,7 @@ class TestAutoMLTextTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split, dataset_id=mock_dataset_text.name,
+            dataset_id=mock_dataset_text.name,
         )
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
@@ -334,19 +330,19 @@ class TestAutoMLTextTrainingJob:
             dataset=mock_dataset_text,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
             model_labels=_TEST_MODEL_LABELS,
-            training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
-            validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
-            test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
+            training_filter_split=_TEST_FILTER_SPLIT_TRAINING,
+            validation_filter_split=_TEST_FILTER_SPLIT_VALIDATION,
+            test_filter_split=_TEST_FILTER_SPLIT_TEST,
             sync=sync,
         )
 
         if not sync:
             model_from_job.wait()
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_FRACTION_SPLIT_TRAINING,
-            validation_fraction=_TEST_FRACTION_SPLIT_VALIDATION,
-            test_fraction=_TEST_FRACTION_SPLIT_TEST,
+        true_filter_split = gca_training_pipeline.FilterSplit(
+            training_filter=_TEST_FILTER_SPLIT_TRAINING,
+            validation_filter=_TEST_FILTER_SPLIT_VALIDATION,
+            test_filter=_TEST_FILTER_SPLIT_TEST,
         )
 
         true_managed_model = gca_model.Model(
@@ -356,7 +352,7 @@ class TestAutoMLTextTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split, dataset_id=mock_dataset_text.name,
+            filter_split=true_filter_split, dataset_id=mock_dataset_text.name,
         )
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
@@ -472,19 +468,19 @@ class TestAutoMLTextTrainingJob:
             dataset=mock_dataset_text,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
             model_labels=_TEST_MODEL_LABELS,
-            training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
-            validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
-            test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
+            training_filter_split=_TEST_FILTER_SPLIT_TRAINING,
+            validation_filter_split=_TEST_FILTER_SPLIT_VALIDATION,
+            test_filter_split=_TEST_FILTER_SPLIT_TEST,
             sync=sync,
         )
 
         if not sync:
             model_from_job.wait()
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_FRACTION_SPLIT_TRAINING,
-            validation_fraction=_TEST_FRACTION_SPLIT_VALIDATION,
-            test_fraction=_TEST_FRACTION_SPLIT_TEST,
+        true_filter_split = gca_training_pipeline.FilterSplit(
+            training_filter=_TEST_FILTER_SPLIT_TRAINING,
+            validation_filter=_TEST_FILTER_SPLIT_VALIDATION,
+            test_filter=_TEST_FILTER_SPLIT_TEST,
         )
 
         true_managed_model = gca_model.Model(
@@ -492,7 +488,7 @@ class TestAutoMLTextTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split, dataset_id=mock_dataset_text.name,
+            filter_split=true_filter_split, dataset_id=mock_dataset_text.name,
         )
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
@@ -537,9 +533,6 @@ class TestAutoMLTextTrainingJob:
 
         model_from_job = job.run(
             dataset=mock_dataset_text,
-            training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
-            validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
-            test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
             model_display_name=None,  # Omit model_display_name
             sync=sync,
         )
@@ -547,19 +540,13 @@ class TestAutoMLTextTrainingJob:
         if not sync:
             model_from_job.wait()
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_FRACTION_SPLIT_TRAINING,
-            validation_fraction=_TEST_FRACTION_SPLIT_VALIDATION,
-            test_fraction=_TEST_FRACTION_SPLIT_TEST,
-        )
-
         # Test that if defaults to the job display name
         true_managed_model = gca_model.Model(
             display_name=_TEST_DISPLAY_NAME, labels=_TEST_LABELS,
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split, dataset_id=mock_dataset_text.name,
+            dataset_id=mock_dataset_text.name,
         )
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
@@ -604,11 +591,40 @@ class TestAutoMLTextTrainingJob:
             job.run(
                 dataset=mock_dataset_text,
                 model_display_name=_TEST_MODEL_DISPLAY_NAME,
+                sync=sync,
+            )
+
+    @pytest.mark.usefixtures(
+        "mock_pipeline_service_create",
+        "mock_pipeline_service_get",
+        "mock_model_service_get",
+    )
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_run_with_two_split_raises(
+        self, mock_dataset_text, sync,
+    ):
+        aiplatform.init(project=_TEST_PROJECT)
+
+        job = training_jobs.AutoMLTextTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            prediction_type="classification",
+            multi_label=True,
+        )
+
+        with pytest.raises(ValueError):
+            model_from_job = job.run(
+                dataset=mock_dataset_text,
+                model_display_name=_TEST_MODEL_DISPLAY_NAME,
                 training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
                 validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
                 test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
+                training_filter_split=_TEST_FILTER_SPLIT_TRAINING,
+                validation_filter_split=_TEST_FILTER_SPLIT_VALIDATION,
+                test_filter_split=_TEST_FILTER_SPLIT_TEST,
                 sync=sync,
             )
+            if not sync:
+                model_from_job.wait()
 
     @pytest.mark.parametrize("sync", [True, False])
     def test_run_raises_if_pipeline_fails(
@@ -638,3 +654,198 @@ class TestAutoMLTextTrainingJob:
 
         with pytest.raises(RuntimeError):
             job.get_model()
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_splits_fraction(
+        self,
+        mock_pipeline_service_create,
+        mock_pipeline_service_get,
+        mock_dataset_text,
+        mock_model_service_get,
+        mock_model,
+        sync,
+    ):
+        """
+        Initiate aiplatform with encryption key name.
+        Create and run an AutoML Video Classification training job, verify calls and return value
+        """
+
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
+        )
+
+        job = training_jobs.AutoMLTextTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            prediction_type=_TEST_PREDICTION_TYPE_CLASSIFICATION,
+            multi_label=_TEST_CLASSIFICATION_MULTILABEL,
+        )
+
+        model_from_job = job.run(
+            dataset=mock_dataset_text,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
+            validation_fraction_split=_TEST_FRACTION_SPLIT_VALIDATION,
+            test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
+            sync=sync,
+        )
+
+        if not sync:
+            model_from_job.wait()
+
+        true_fraction_split = gca_training_pipeline.FractionSplit(
+            training_fraction=_TEST_FRACTION_SPLIT_TRAINING,
+            validation_fraction=_TEST_FRACTION_SPLIT_VALIDATION,
+            test_fraction=_TEST_FRACTION_SPLIT_TEST,
+        )
+
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            description=mock_model._gca_resource.description,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        true_input_data_config = gca_training_pipeline.InputDataConfig(
+            fraction_split=true_fraction_split, dataset_id=mock_dataset_text.name,
+        )
+
+        true_training_pipeline = gca_training_pipeline.TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.automl_text_classification,
+            training_task_inputs=_TEST_TRAINING_TASK_INPUTS_CLASSIFICATION,
+            model_to_upload=true_managed_model,
+            input_data_config=true_input_data_config,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_splits_filter(
+        self,
+        mock_pipeline_service_create,
+        mock_pipeline_service_get,
+        mock_dataset_text,
+        mock_model_service_get,
+        mock_model,
+        sync,
+    ):
+        """
+        Initiate aiplatform with encryption key name.
+        Create and run an AutoML Video Classification training job, verify calls and return value
+        """
+
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
+        )
+
+        job = training_jobs.AutoMLTextTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            prediction_type=_TEST_PREDICTION_TYPE_CLASSIFICATION,
+            multi_label=_TEST_CLASSIFICATION_MULTILABEL,
+        )
+
+        model_from_job = job.run(
+            dataset=mock_dataset_text,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            training_filter_split=_TEST_FILTER_SPLIT_TRAINING,
+            validation_filter_split=_TEST_FILTER_SPLIT_VALIDATION,
+            test_filter_split=_TEST_FILTER_SPLIT_TEST,
+            sync=sync,
+        )
+
+        if not sync:
+            model_from_job.wait()
+
+        true_filter_split = gca_training_pipeline.FilterSplit(
+            training_filter=_TEST_FILTER_SPLIT_TRAINING,
+            validation_filter=_TEST_FILTER_SPLIT_VALIDATION,
+            test_filter=_TEST_FILTER_SPLIT_TEST,
+        )
+
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            description=mock_model._gca_resource.description,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        true_input_data_config = gca_training_pipeline.InputDataConfig(
+            filter_split=true_filter_split, dataset_id=mock_dataset_text.name,
+        )
+
+        true_training_pipeline = gca_training_pipeline.TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.automl_text_classification,
+            training_task_inputs=_TEST_TRAINING_TASK_INPUTS_CLASSIFICATION,
+            model_to_upload=true_managed_model,
+            input_data_config=true_input_data_config,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_splits_default(
+        self,
+        mock_pipeline_service_create,
+        mock_pipeline_service_get,
+        mock_dataset_text,
+        mock_model_service_get,
+        mock_model,
+        sync,
+    ):
+        """
+        Initiate aiplatform with encryption key name.
+        Create and run an AutoML Video Classification training job, verify calls and return value
+        """
+
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
+        )
+
+        job = training_jobs.AutoMLTextTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            prediction_type=_TEST_PREDICTION_TYPE_CLASSIFICATION,
+            multi_label=_TEST_CLASSIFICATION_MULTILABEL,
+        )
+
+        model_from_job = job.run(
+            dataset=mock_dataset_text,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            sync=sync,
+        )
+
+        if not sync:
+            model_from_job.wait()
+
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            description=mock_model._gca_resource.description,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        true_input_data_config = gca_training_pipeline.InputDataConfig(
+            dataset_id=mock_dataset_text.name,
+        )
+
+        true_training_pipeline = gca_training_pipeline.TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.automl_text_classification,
+            training_task_inputs=_TEST_TRAINING_TASK_INPUTS_CLASSIFICATION,
+            model_to_upload=true_managed_model,
+            input_data_config=true_input_data_config,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )

--- a/tests/unit/aiplatform/test_automl_video_training_jobs.py
+++ b/tests/unit/aiplatform/test_automl_video_training_jobs.py
@@ -54,7 +54,13 @@ _TEST_TRAINING_TASK_INPUTS = json_format.ParseDict(
 )
 
 _TEST_FRACTION_SPLIT_TRAINING = 0.8
+_TEST_FRACTION_SPLIT_VALIDATION = 0.0
 _TEST_FRACTION_SPLIT_TEST = 0.2
+_TEST_ALTERNATE_FRACTION_SPLIT_TRAINING = 0.7
+_TEST_ALTERNATE_FRACTION_SPLIT_TEST = 0.3
+_TEST_FILTER_SPLIT_TRAINING = "train"
+_TEST_FILTER_SPLIT_VALIDATION = "-"
+_TEST_FILTER_SPLIT_TEST = "test"
 
 _TEST_MODEL_NAME = (
     f"projects/{_TEST_PROJECT}/locations/{_TEST_LOCATION}/models/{_TEST_MODEL_ID}"
@@ -141,6 +147,7 @@ def mock_model_service_get():
 def mock_dataset_video():
     ds = mock.MagicMock(datasets.VideoDataset)
     ds.name = _TEST_DATASET_NAME
+    ds.metadata_schema_uri = _TEST_METADATA_SCHEMA_URI_VIDEO
     ds._latest_future = None
     ds._exception = None
     ds._gca_resource = gca_dataset.Dataset(
@@ -234,6 +241,72 @@ class TestAutoMLVideoTrainingJob:
         model_from_job = job.run(
             dataset=mock_dataset_video,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            sync=sync,
+        )
+
+        if not sync:
+            model_from_job.wait()
+
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            description=mock_model._gca_resource.description,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        true_input_data_config = gca_training_pipeline.InputDataConfig(
+            dataset_id=mock_dataset_video.name,
+        )
+
+        true_training_pipeline = gca_training_pipeline.TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.automl_video_classification,
+            training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
+            model_to_upload=true_managed_model,
+            input_data_config=true_input_data_config,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )
+
+        mock_model_service_get.assert_called_once_with(name=_TEST_MODEL_NAME)
+        assert job._gca_resource is mock_pipeline_service_get.return_value
+        assert model_from_job._gca_resource is mock_model_service_get.return_value
+        assert job.get_model()._gca_resource is mock_model_service_get.return_value
+        assert not job.has_failed
+        assert job.state == gca_pipeline_state.PipelineState.PIPELINE_STATE_SUCCEEDED
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_splits_fraction(
+        self,
+        mock_pipeline_service_create,
+        mock_pipeline_service_get,
+        mock_dataset_video,
+        mock_model_service_get,
+        mock_model,
+        sync,
+    ):
+        """
+        Initiate aiplatform with encryption key name.
+        Create and run an AutoML Video Classification training job, verify calls and return value
+        """
+
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
+        )
+
+        job = training_jobs.AutoMLVideoTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            prediction_type=_TEST_PREDICTION_TYPE_VCN,
+            model_type=_TEST_MODEL_TYPE_CLOUD,
+        )
+
+        model_from_job = job.run(
+            dataset=mock_dataset_video,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
             training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
             test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
             sync=sync,
@@ -244,6 +317,7 @@ class TestAutoMLVideoTrainingJob:
 
         true_fraction_split = gca_training_pipeline.FractionSplit(
             training_fraction=_TEST_FRACTION_SPLIT_TRAINING,
+            validation_fraction=_TEST_FRACTION_SPLIT_VALIDATION,
             test_fraction=_TEST_FRACTION_SPLIT_TEST,
         )
 
@@ -271,12 +345,131 @@ class TestAutoMLVideoTrainingJob:
             training_pipeline=true_training_pipeline,
         )
 
-        mock_model_service_get.assert_called_once_with(name=_TEST_MODEL_NAME)
-        assert job._gca_resource is mock_pipeline_service_get.return_value
-        assert model_from_job._gca_resource is mock_model_service_get.return_value
-        assert job.get_model()._gca_resource is mock_model_service_get.return_value
-        assert not job.has_failed
-        assert job.state == gca_pipeline_state.PipelineState.PIPELINE_STATE_SUCCEEDED
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_splits_filter(
+        self,
+        mock_pipeline_service_create,
+        mock_pipeline_service_get,
+        mock_dataset_video,
+        mock_model_service_get,
+        mock_model,
+        sync,
+    ):
+        """
+        Initiate aiplatform with encryption key name.
+        Create and run an AutoML Video Classification training job, verify calls and return value
+        """
+
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
+        )
+
+        job = training_jobs.AutoMLVideoTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            prediction_type=_TEST_PREDICTION_TYPE_VCN,
+            model_type=_TEST_MODEL_TYPE_CLOUD,
+        )
+
+        model_from_job = job.run(
+            dataset=mock_dataset_video,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            training_filter_split=_TEST_FILTER_SPLIT_TRAINING,
+            test_filter_split=_TEST_FILTER_SPLIT_TEST,
+            sync=sync,
+        )
+
+        if not sync:
+            model_from_job.wait()
+
+        true_filter_split = gca_training_pipeline.FilterSplit(
+            training_filter=_TEST_FILTER_SPLIT_TRAINING,
+            validation_filter=_TEST_FILTER_SPLIT_VALIDATION,
+            test_filter=_TEST_FILTER_SPLIT_TEST,
+        )
+
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            description=mock_model._gca_resource.description,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        true_input_data_config = gca_training_pipeline.InputDataConfig(
+            filter_split=true_filter_split, dataset_id=mock_dataset_video.name,
+        )
+
+        true_training_pipeline = gca_training_pipeline.TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.automl_video_classification,
+            training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
+            model_to_upload=true_managed_model,
+            input_data_config=true_input_data_config,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_splits_default(
+        self,
+        mock_pipeline_service_create,
+        mock_pipeline_service_get,
+        mock_dataset_video,
+        mock_model_service_get,
+        mock_model,
+        sync,
+    ):
+        """
+        Initiate aiplatform with encryption key name.
+        Create and run an AutoML Video Classification training job, verify calls and return value
+        """
+
+        aiplatform.init(
+            project=_TEST_PROJECT,
+            encryption_spec_key_name=_TEST_DEFAULT_ENCRYPTION_KEY_NAME,
+        )
+
+        job = training_jobs.AutoMLVideoTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            prediction_type=_TEST_PREDICTION_TYPE_VCN,
+            model_type=_TEST_MODEL_TYPE_CLOUD,
+        )
+
+        model_from_job = job.run(
+            dataset=mock_dataset_video,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            sync=sync,
+        )
+
+        if not sync:
+            model_from_job.wait()
+
+        true_managed_model = gca_model.Model(
+            display_name=_TEST_MODEL_DISPLAY_NAME,
+            description=mock_model._gca_resource.description,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        true_input_data_config = gca_training_pipeline.InputDataConfig(
+            dataset_id=mock_dataset_video.name,
+        )
+
+        true_training_pipeline = gca_training_pipeline.TrainingPipeline(
+            display_name=_TEST_DISPLAY_NAME,
+            training_task_definition=schema.training_job.definition.automl_video_classification,
+            training_task_inputs=_TEST_TRAINING_TASK_INPUTS,
+            model_to_upload=true_managed_model,
+            input_data_config=true_input_data_config,
+            encryption_spec=_TEST_DEFAULT_ENCRYPTION_SPEC,
+        )
+
+        mock_pipeline_service_create.assert_called_once_with(
+            parent=initializer.global_config.common_location_path(),
+            training_pipeline=true_training_pipeline,
+        )
 
     @pytest.mark.parametrize("sync", [True, False])
     def test_run_call_pipeline_service_create(
@@ -305,17 +498,18 @@ class TestAutoMLVideoTrainingJob:
             dataset=mock_dataset_video,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
             model_labels=_TEST_MODEL_LABELS,
-            training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
-            test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
+            training_filter_split=_TEST_FILTER_SPLIT_TRAINING,
+            test_filter_split=_TEST_FILTER_SPLIT_TEST,
             sync=sync,
         )
 
         if not sync:
             model_from_job.wait()
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_FRACTION_SPLIT_TRAINING,
-            test_fraction=_TEST_FRACTION_SPLIT_TEST,
+        true_filter_split = gca_training_pipeline.FilterSplit(
+            training_filter=_TEST_FILTER_SPLIT_TRAINING,
+            validation_filter=_TEST_FILTER_SPLIT_VALIDATION,
+            test_filter=_TEST_FILTER_SPLIT_TEST,
         )
 
         true_managed_model = gca_model.Model(
@@ -326,7 +520,7 @@ class TestAutoMLVideoTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split, dataset_id=mock_dataset_video.name,
+            filter_split=true_filter_split, dataset_id=mock_dataset_video.name,
         )
 
         true_training_pipeline = gca_training_pipeline.TrainingPipeline(
@@ -371,16 +565,17 @@ class TestAutoMLVideoTrainingJob:
 
         model_from_job = job.run(
             dataset=mock_dataset_video,
-            training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
-            test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
+            training_fraction_split=_TEST_ALTERNATE_FRACTION_SPLIT_TRAINING,
+            test_fraction_split=_TEST_ALTERNATE_FRACTION_SPLIT_TEST,
         )
 
         if not sync:
             model_from_job.wait()
 
         true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_FRACTION_SPLIT_TRAINING,
-            test_fraction=_TEST_FRACTION_SPLIT_TEST,
+            training_fraction=_TEST_ALTERNATE_FRACTION_SPLIT_TRAINING,
+            validation_fraction=_TEST_FRACTION_SPLIT_VALIDATION,
+            test_fraction=_TEST_ALTERNATE_FRACTION_SPLIT_TEST,
         )
 
         # Test that if defaults to the job display name
@@ -422,8 +617,6 @@ class TestAutoMLVideoTrainingJob:
         job.run(
             dataset=mock_dataset_video,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
-            training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
-            test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
             sync=sync,
         )
 
@@ -431,10 +624,34 @@ class TestAutoMLVideoTrainingJob:
             job.run(
                 dataset=mock_dataset_video,
                 model_display_name=_TEST_MODEL_DISPLAY_NAME,
-                training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
-                test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
                 sync=sync,
             )
+
+    @pytest.mark.usefixtures(
+        "mock_pipeline_service_create",
+        "mock_pipeline_service_get",
+        "mock_model_service_get",
+    )
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_run_with_two_split_raises(
+        self, mock_dataset_video, sync,
+    ):
+        aiplatform.init(project=_TEST_PROJECT)
+
+        job = training_jobs.AutoMLVideoTrainingJob(display_name=_TEST_DISPLAY_NAME,)
+
+        with pytest.raises(ValueError):
+            model_from_job = job.run(
+                dataset=mock_dataset_video,
+                model_display_name=_TEST_MODEL_DISPLAY_NAME,
+                training_fraction_split=_TEST_FRACTION_SPLIT_TRAINING,
+                test_fraction_split=_TEST_FRACTION_SPLIT_TEST,
+                training_filter_split=_TEST_FILTER_SPLIT_TEST,
+                test_filter_split=_TEST_FILTER_SPLIT_TEST,
+                sync=sync,
+            )
+            if not sync:
+                model_from_job.wait()
 
     @pytest.mark.parametrize("sync", [True, False])
     def test_run_raises_if_pipeline_fails(

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -1672,7 +1672,6 @@ class TestCustomTrainingJob:
             machine_type=_TEST_MACHINE_TYPE,
             accelerator_type=_TEST_ACCELERATOR_TYPE,
             accelerator_count=_TEST_ACCELERATOR_COUNT,
-            model_display_name=_TEST_MODEL_DISPLAY_NAME,
             training_filter_split=_TEST_TRAINING_FILTER_SPLIT,
             validation_filter_split=_TEST_VALIDATION_FILTER_SPLIT,
             test_filter_split=_TEST_TEST_FILTER_SPLIT,

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -103,13 +103,14 @@ _TEST_MODEL_DISPLAY_NAME = "model-display-name"
 _TEST_LABELS = {"key": "value"}
 _TEST_MODEL_LABELS = {"model_key": "model_value"}
 
-_TEST_DEFAULT_TRAINING_FRACTION_SPLIT = 0.8
-_TEST_DEFAULT_VALIDATION_FRACTION_SPLIT = 0.1
-_TEST_DEFAULT_TEST_FRACTION_SPLIT = 0.1
 _TEST_TRAINING_FRACTION_SPLIT = 0.6
 _TEST_VALIDATION_FRACTION_SPLIT = 0.2
 _TEST_TEST_FRACTION_SPLIT = 0.2
+_TEST_TRAINING_FILTER_SPLIT = "train"
+_TEST_VALIDATION_FILTER_SPLIT = "validate"
+_TEST_TEST_FILTER_SPLIT = "test"
 _TEST_PREDEFINED_SPLIT_COLUMN_NAME = "split"
+_TEST_TIMESTAMP_SPLIT_COLUMN_NAME = "timestamp"
 
 _TEST_PROJECT = "test-project"
 _TEST_LOCATION = "us-central1"
@@ -579,6 +580,7 @@ def mock_python_package_to_gcs():
 def mock_tabular_dataset():
     ds = mock.MagicMock(datasets.TabularDataset)
     ds.name = _TEST_DATASET_NAME
+    ds.metadata_schema_uri = _TEST_METADATA_SCHEMA_URI_TABULAR
     ds._latest_future = None
     ds._exception = None
     ds._gca_resource = gca_dataset.Dataset(
@@ -595,6 +597,7 @@ def mock_tabular_dataset():
 def mock_nontabular_dataset():
     ds = mock.MagicMock(datasets.ImageDataset)
     ds.name = _TEST_DATASET_NAME
+    ds.metadata_schema_uri = _TEST_METADATA_SCHEMA_URI_NONTABULAR
     ds._latest_future = None
     ds._exception = None
     ds._gca_resource = gca_dataset.Dataset(
@@ -668,7 +671,7 @@ class TestCustomTrainingJob:
             training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
             validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
             test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
-            predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
+            timestamp_split_column_name=_TEST_TIMESTAMP_SPLIT_COLUMN_NAME,
             tensorboard=_TEST_TENSORBOARD_RESOURCE_NAME,
             sync=sync,
         )
@@ -708,10 +711,11 @@ class TestCustomTrainingJob:
             },
         }
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
+        true_timestamp_split = gca_training_pipeline.TimestampSplit(
             training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
             validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
             test_fraction=_TEST_TEST_FRACTION_SPLIT,
+            key=_TEST_TIMESTAMP_SPLIT_COLUMN_NAME,
         )
 
         env = [
@@ -748,10 +752,7 @@ class TestCustomTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
-            predefined_split=gca_training_pipeline.PredefinedSplit(
-                key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
-            ),
+            timestamp_split=true_timestamp_split,
             dataset_id=mock_tabular_dataset.name,
             gcs_destination=gca_io.GcsDestination(
                 output_uri_prefix=_TEST_BASE_OUTPUT_DIR
@@ -843,9 +844,6 @@ class TestCustomTrainingJob:
             accelerator_type=_TEST_ACCELERATOR_TYPE,
             accelerator_count=_TEST_ACCELERATOR_COUNT,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
-            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
             predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
             sync=sync,
         )
@@ -878,12 +876,6 @@ class TestCustomTrainingJob:
                 "env": true_env,
             },
         }
-
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_TEST_FRACTION_SPLIT,
-        )
 
         env = [
             gca_env_var.EnvVar(name=str(key), value=str(value))
@@ -918,7 +910,6 @@ class TestCustomTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
             predefined_split=gca_training_pipeline.PredefinedSplit(
                 key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
             ),
@@ -1049,6 +1040,34 @@ class TestCustomTrainingJob:
                 accelerator_type=_TEST_INVALID_ACCELERATOR_TYPE,
                 accelerator_count=_TEST_ACCELERATOR_COUNT,
                 model_display_name=_TEST_MODEL_DISPLAY_NAME,
+                sync=sync,
+            )
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_run_with_two_splits_raises(
+        self,
+        mock_pipeline_service_create,
+        mock_python_package_to_gcs,
+        mock_tabular_dataset,
+        mock_model_service_get,
+        sync,
+    ):
+        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+
+        job = training_jobs.CustomTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            script_path=_TEST_LOCAL_SCRIPT_FILE_NAME,
+            container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
+        )
+
+        with pytest.raises(ValueError):
+            job.run(
+                dataset=mock_tabular_dataset,
+                replica_count=1,
+                machine_type=_TEST_MACHINE_TYPE,
+                accelerator_type=_TEST_INVALID_ACCELERATOR_TYPE,
+                accelerator_count=_TEST_ACCELERATOR_COUNT,
+                predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
                 training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
                 validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
                 test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
@@ -1123,6 +1142,9 @@ class TestCustomTrainingJob:
             training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
             validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
             test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
+            training_filter_split=_TEST_TRAINING_FILTER_SPLIT,
+            validation_filter_split=_TEST_VALIDATION_FILTER_SPLIT,
+            test_filter_split=_TEST_TEST_FILTER_SPLIT,
             sync=sync,
         )
 
@@ -1379,9 +1401,6 @@ class TestCustomTrainingJob:
             accelerator_type=_TEST_ACCELERATOR_TYPE,
             accelerator_count=_TEST_ACCELERATOR_COUNT,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
-            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
             sync=sync,
         )
 
@@ -1441,12 +1460,6 @@ class TestCustomTrainingJob:
             },
         ]
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_TEST_FRACTION_SPLIT,
-        )
-
         true_container_spec = gca_model.ModelContainerSpec(
             image_uri=_TEST_SERVING_CONTAINER_IMAGE,
             predict_route=_TEST_SERVING_CONTAINER_PREDICTION_ROUTE,
@@ -1464,7 +1477,6 @@ class TestCustomTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
             dataset_id=mock_tabular_dataset.name,
             gcs_destination=gca_io.GcsDestination(
                 output_uri_prefix=_TEST_BASE_OUTPUT_DIR
@@ -1660,6 +1672,10 @@ class TestCustomTrainingJob:
             machine_type=_TEST_MACHINE_TYPE,
             accelerator_type=_TEST_ACCELERATOR_TYPE,
             accelerator_count=_TEST_ACCELERATOR_COUNT,
+            model_display_name=_TEST_MODEL_DISPLAY_NAME,
+            training_filter_split=_TEST_TRAINING_FILTER_SPLIT,
+            validation_filter_split=_TEST_VALIDATION_FILTER_SPLIT,
+            test_filter_split=_TEST_TEST_FILTER_SPLIT,
             sync=sync,
         )
 
@@ -1693,10 +1709,10 @@ class TestCustomTrainingJob:
             },
         }
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_DEFAULT_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_DEFAULT_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_DEFAULT_TEST_FRACTION_SPLIT,
+        true_filter_split = gca_training_pipeline.FilterSplit(
+            training_filter=_TEST_TRAINING_FILTER_SPLIT,
+            validation_filter=_TEST_VALIDATION_FILTER_SPLIT,
+            test_filter=_TEST_TEST_FILTER_SPLIT,
         )
 
         env = [
@@ -1732,7 +1748,7 @@ class TestCustomTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
+            filter_split=true_filter_split,
             dataset_id=mock_nontabular_dataset.name,
             annotation_schema_uri=_TEST_ANNOTATION_SCHEMA_URI,
             gcs_destination=gca_io.GcsDestination(
@@ -1909,9 +1925,6 @@ class TestCustomContainerTrainingJob:
             accelerator_count=_TEST_ACCELERATOR_COUNT,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
             model_labels=_TEST_MODEL_LABELS,
-            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
             predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
             service_account=_TEST_SERVICE_ACCOUNT,
             tensorboard=_TEST_TENSORBOARD_RESOURCE_NAME,
@@ -1945,12 +1958,6 @@ class TestCustomContainerTrainingJob:
                 "env": true_env,
             },
         }
-
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_TEST_FRACTION_SPLIT,
-        )
 
         env = [
             gca_env_var.EnvVar(name=str(key), value=str(value))
@@ -1986,7 +1993,6 @@ class TestCustomContainerTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
             predefined_split=gca_training_pipeline.PredefinedSplit(
                 key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
             ),
@@ -2079,7 +2085,7 @@ class TestCustomContainerTrainingJob:
             training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
             validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
             test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
-            predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
+            timestamp_split_column_name=_TEST_TIMESTAMP_SPLIT_COLUMN_NAME,
             sync=sync,
         )
 
@@ -2106,10 +2112,11 @@ class TestCustomContainerTrainingJob:
             },
         }
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
+        true_timestamp_split = gca_training_pipeline.TimestampSplit(
             training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
             validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
             test_fraction=_TEST_TEST_FRACTION_SPLIT,
+            key=_TEST_TIMESTAMP_SPLIT_COLUMN_NAME,
         )
 
         env = [
@@ -2145,10 +2152,7 @@ class TestCustomContainerTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
-            predefined_split=gca_training_pipeline.PredefinedSplit(
-                key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
-            ),
+            timestamp_split=true_timestamp_split,
             dataset_id=mock_tabular_dataset.name,
             bigquery_destination=gca_io.BigQueryDestination(
                 output_uri=_TEST_BIGQUERY_DESTINATION
@@ -2276,6 +2280,33 @@ class TestCustomContainerTrainingJob:
                 accelerator_type=_TEST_INVALID_ACCELERATOR_TYPE,
                 accelerator_count=_TEST_ACCELERATOR_COUNT,
                 model_display_name=_TEST_MODEL_DISPLAY_NAME,
+                sync=sync,
+            )
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_run_with_two_split_raises(
+        self,
+        mock_pipeline_service_create,
+        mock_python_package_to_gcs,
+        mock_tabular_dataset,
+        mock_model_service_get,
+        sync,
+    ):
+        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+
+        job = training_jobs.CustomContainerTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
+        )
+
+        with pytest.raises(ValueError):
+            job.run(
+                dataset=mock_tabular_dataset,
+                replica_count=1,
+                machine_type=_TEST_MACHINE_TYPE,
+                accelerator_type=_TEST_INVALID_ACCELERATOR_TYPE,
+                accelerator_count=_TEST_ACCELERATOR_COUNT,
+                predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
                 training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
                 validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
                 test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
@@ -2432,9 +2463,6 @@ class TestCustomContainerTrainingJob:
             machine_type=_TEST_MACHINE_TYPE,
             accelerator_type=_TEST_ACCELERATOR_TYPE,
             accelerator_count=_TEST_ACCELERATOR_COUNT,
-            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
             sync=sync,
         )
 
@@ -2734,6 +2762,9 @@ class TestCustomContainerTrainingJob:
             accelerator_count=_TEST_ACCELERATOR_COUNT,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
             model_labels=_TEST_MODEL_LABELS,
+            training_filter_split=_TEST_TRAINING_FILTER_SPLIT,
+            validation_filter_split=_TEST_VALIDATION_FILTER_SPLIT,
+            test_filter_split=_TEST_TEST_FILTER_SPLIT,
             sync=sync,
         )
 
@@ -2760,10 +2791,10 @@ class TestCustomContainerTrainingJob:
             },
         }
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_DEFAULT_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_DEFAULT_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_DEFAULT_TEST_FRACTION_SPLIT,
+        true_filter_split = gca_training_pipeline.FilterSplit(
+            training_filter=_TEST_TRAINING_FILTER_SPLIT,
+            validation_filter=_TEST_VALIDATION_FILTER_SPLIT,
+            test_filter=_TEST_TEST_FILTER_SPLIT,
         )
 
         env = [
@@ -2799,7 +2830,7 @@ class TestCustomContainerTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
+            filter_split=true_filter_split,
             dataset_id=mock_nontabular_dataset.name,
             annotation_schema_uri=_TEST_ANNOTATION_SCHEMA_URI,
             gcs_destination=gca_io.GcsDestination(
@@ -3257,7 +3288,6 @@ class TestCustomPythonPackageTrainingJob:
             training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
             validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
             test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
-            predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
             sync=sync,
         )
 
@@ -3331,9 +3361,6 @@ class TestCustomPythonPackageTrainingJob:
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
             fraction_split=true_fraction_split,
-            predefined_split=gca_training_pipeline.PredefinedSplit(
-                key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
-            ),
             dataset_id=mock_tabular_dataset.name,
             gcs_destination=gca_io.GcsDestination(
                 output_uri_prefix=_TEST_BASE_OUTPUT_DIR
@@ -3421,9 +3448,6 @@ class TestCustomPythonPackageTrainingJob:
             machine_type=_TEST_MACHINE_TYPE,
             accelerator_type=_TEST_ACCELERATOR_TYPE,
             accelerator_count=_TEST_ACCELERATOR_COUNT,
-            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
             predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
             sync=sync,
         )
@@ -3451,12 +3475,6 @@ class TestCustomPythonPackageTrainingJob:
                 "args": true_args,
             },
         }
-
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_TEST_FRACTION_SPLIT,
-        )
 
         env = [
             gca_env_var.EnvVar(name=str(key), value=str(value))
@@ -3492,7 +3510,6 @@ class TestCustomPythonPackageTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
             predefined_split=gca_training_pipeline.PredefinedSplit(
                 key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
             ),
@@ -3582,7 +3599,7 @@ class TestCustomPythonPackageTrainingJob:
             training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
             validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
             test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
-            predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
+            timestamp_split_column_name=_TEST_TIMESTAMP_SPLIT_COLUMN_NAME,
             sync=sync,
         )
 
@@ -3610,10 +3627,11 @@ class TestCustomPythonPackageTrainingJob:
             },
         }
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
+        true_timestamp_split = gca_training_pipeline.TimestampSplit(
             training_fraction=_TEST_TRAINING_FRACTION_SPLIT,
             validation_fraction=_TEST_VALIDATION_FRACTION_SPLIT,
             test_fraction=_TEST_TEST_FRACTION_SPLIT,
+            key=_TEST_TIMESTAMP_SPLIT_COLUMN_NAME,
         )
 
         env = [
@@ -3649,10 +3667,7 @@ class TestCustomPythonPackageTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
-            predefined_split=gca_training_pipeline.PredefinedSplit(
-                key=_TEST_PREDEFINED_SPLIT_COLUMN_NAME
-            ),
+            timestamp_split=true_timestamp_split,
             dataset_id=mock_tabular_dataset.name,
             bigquery_destination=gca_io.BigQueryDestination(
                 output_uri=_TEST_BIGQUERY_DESTINATION
@@ -3726,9 +3741,6 @@ class TestCustomPythonPackageTrainingJob:
             accelerator_type=_TEST_ACCELERATOR_TYPE,
             accelerator_count=_TEST_ACCELERATOR_COUNT,
             model_display_name=_TEST_MODEL_DISPLAY_NAME,
-            training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-            validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-            test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
             sync=sync,
         )
 
@@ -3742,9 +3754,6 @@ class TestCustomPythonPackageTrainingJob:
                 accelerator_type=_TEST_ACCELERATOR_TYPE,
                 accelerator_count=_TEST_ACCELERATOR_COUNT,
                 model_display_name=_TEST_MODEL_DISPLAY_NAME,
-                training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-                validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-                test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
                 sync=sync,
             )
 
@@ -3782,6 +3791,38 @@ class TestCustomPythonPackageTrainingJob:
                 accelerator_type=_TEST_INVALID_ACCELERATOR_TYPE,
                 accelerator_count=_TEST_ACCELERATOR_COUNT,
                 model_display_name=_TEST_MODEL_DISPLAY_NAME,
+                training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
+                validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
+                test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
+                sync=sync,
+            )
+
+    @pytest.mark.parametrize("sync", [True, False])
+    def test_run_with_two_split_raises(
+        self,
+        mock_pipeline_service_create,
+        mock_python_package_to_gcs,
+        mock_tabular_dataset,
+        mock_model_service_get,
+        sync,
+    ):
+        aiplatform.init(project=_TEST_PROJECT, staging_bucket=_TEST_BUCKET_NAME)
+
+        job = training_jobs.CustomPythonPackageTrainingJob(
+            display_name=_TEST_DISPLAY_NAME,
+            python_package_gcs_uri=_TEST_OUTPUT_PYTHON_PACKAGE_PATH,
+            python_module_name=_TEST_PYTHON_MODULE_NAME,
+            container_uri=_TEST_TRAINING_CONTAINER_IMAGE,
+        )
+
+        with pytest.raises(ValueError):
+            job.run(
+                dataset=mock_tabular_dataset,
+                replica_count=1,
+                machine_type=_TEST_MACHINE_TYPE,
+                accelerator_type=_TEST_INVALID_ACCELERATOR_TYPE,
+                accelerator_count=_TEST_ACCELERATOR_COUNT,
+                predefined_split_column_name=_TEST_PREDEFINED_SPLIT_COLUMN_NAME,
                 training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
                 validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
                 test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
@@ -4013,9 +4054,6 @@ class TestCustomPythonPackageTrainingJob:
                 machine_type=_TEST_MACHINE_TYPE,
                 accelerator_type=_TEST_ACCELERATOR_TYPE,
                 accelerator_count=_TEST_ACCELERATOR_COUNT,
-                training_fraction_split=_TEST_TRAINING_FRACTION_SPLIT,
-                validation_fraction_split=_TEST_VALIDATION_FRACTION_SPLIT,
-                test_fraction_split=_TEST_TEST_FRACTION_SPLIT,
                 sync=sync,
             )
 
@@ -4250,6 +4288,9 @@ class TestCustomPythonPackageTrainingJob:
             accelerator_count=_TEST_ACCELERATOR_COUNT,
             service_account=_TEST_SERVICE_ACCOUNT,
             tensorboard=_TEST_TENSORBOARD_RESOURCE_NAME,
+            training_filter_split=_TEST_TRAINING_FILTER_SPLIT,
+            validation_filter_split=_TEST_VALIDATION_FILTER_SPLIT,
+            test_filter_split=_TEST_TEST_FILTER_SPLIT,
             sync=sync,
         )
 
@@ -4277,10 +4318,10 @@ class TestCustomPythonPackageTrainingJob:
             },
         }
 
-        true_fraction_split = gca_training_pipeline.FractionSplit(
-            training_fraction=_TEST_DEFAULT_TRAINING_FRACTION_SPLIT,
-            validation_fraction=_TEST_DEFAULT_VALIDATION_FRACTION_SPLIT,
-            test_fraction=_TEST_DEFAULT_TEST_FRACTION_SPLIT,
+        true_filter_split = gca_training_pipeline.FilterSplit(
+            training_filter=_TEST_TRAINING_FILTER_SPLIT,
+            validation_filter=_TEST_VALIDATION_FILTER_SPLIT,
+            test_filter=_TEST_TEST_FILTER_SPLIT,
         )
 
         env = [
@@ -4316,7 +4357,7 @@ class TestCustomPythonPackageTrainingJob:
         )
 
         true_input_data_config = gca_training_pipeline.InputDataConfig(
-            fraction_split=true_fraction_split,
+            filter_split=true_filter_split,
             dataset_id=mock_nontabular_dataset.name,
             annotation_schema_uri=_TEST_ANNOTATION_SCHEMA_URI,
             gcs_destination=gca_io.GcsDestination(


### PR DESCRIPTION
Changes to training splits:

- Defers default splits to the server instead of setting in client
- Raises error when multiple split types passed
- Adds filter splits (b/172365904) to image, text and video
- Adds timestamp split (b/172368070) to tabular
- Added tests for all split types

Future:
- next PR will change forecasting training jobs to extend tabular; therefore, adding timestamp and predefined split to forecasting

Continued from: https://github.com/googleapis/python-aiplatform/pull/549