### PR TITLE
feat: adding BigQuery location of exported evaluated examples from AutoML Forecasting training job in training output

### DIFF
--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -3420,21 +3420,18 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
     def evaluated_data_items_bigquery_uri(self) -> Optional[str]:
         """BigQuery location of exported evaluated examples from the Training Job"""
 
-        if self._gca_resource is None:
-          _LOGGER.warning("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
-          return
+        self._assert_gca_resource_is_available()
         
         try:
             meta = getattr((self._gca_resource), "training_task_metadata")
         except ValueError:
-            _LOGGER.warning("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
-            return
+            raise ValueError("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
 
-        if meta is not None and "evaluatedDataItemsBigqueryUri" in meta._pb:
-          return meta._pb["evaluatedDataItemsBigqueryUri"].string_value
-        else:
-          _LOGGER.warning("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
-          return
+        try: 
+            metadata = self._gca_resource.training_task_metadata 
+            return metadata["evaluatedDataItemsBigqueryUri"] 
+        except (AttributeError, KeyError): 
+            raise ValueError("BigQuery URI for evaluated data items does not exist. Must export evaluated data items during training.")
 
 
 class AutoMLImageTrainingJob(_TrainingJob):

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -3420,7 +3420,8 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
     def evaluated_data_items_bigquery_uri(self) -> Optional[str]:
         """BigQuery location of exported evaluated examples from the Training Job"""
 
-        self._assert_gca_resource_is_available()
+        if self._gca_resource is None:
+          raise ValueError("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
         
         try:
             meta = getattr((self._gca_resource), "training_task_metadata")

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -3422,8 +3422,11 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
 
         if self._gca_resource is None:
           raise Exception("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
-
-        meta = getattr((self._gca_resource), "training_task_metadata")
+        
+        try:
+            meta = getattr((self._gca_resource), "training_task_metadata")
+        except ValueError:
+            print("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
 
         if meta is not None and "evaluatedDataItemsBigqueryUri" in meta._pb:
           return meta._pb["evaluatedDataItemsBigqueryUri"].string_value

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -3421,18 +3421,20 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
         """BigQuery location of exported evaluated examples from the Training Job"""
 
         if self._gca_resource is None:
-          raise Exception("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
+          _LOGGER.warning("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
+          return
         
         try:
             meta = getattr((self._gca_resource), "training_task_metadata")
         except ValueError:
-            print("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
-            sys.exit(1)
+            _LOGGER.warning("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
+            return
 
         if meta is not None and "evaluatedDataItemsBigqueryUri" in meta._pb:
           return meta._pb["evaluatedDataItemsBigqueryUri"].string_value
         else:
-          raise Exception("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
+          _LOGGER.warning("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
+          return
 
 
 class AutoMLImageTrainingJob(_TrainingJob):

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -3403,8 +3403,8 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
             model=model
         )
 
-        if self.bq_uri is not None:
-            _LOGGER.info("Exported examples available at:\n%s" % self.bq_uri)
+        if export_evaluated_data_items:
+            _LOGGER.info("Exported examples available at:\n%s" % self.evaluated_data_items_bigquery_uri)
 
         return new_model
 
@@ -3417,7 +3417,7 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
         )
     
     @property
-    def bq_uri(self) -> Optional[str]:
+    def evaluated_data_items_bigquery_uri(self) -> Optional[str]:
         """BigQuery location of exported evaluated examples from the Training Job"""
 
         if self._gca_resource is None:

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -3427,6 +3427,7 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
             meta = getattr((self._gca_resource), "training_task_metadata")
         except ValueError:
             print("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
+            sys.exit(1)
 
         if meta is not None and "evaluatedDataItemsBigqueryUri" in meta._pb:
           return meta._pb["evaluatedDataItemsBigqueryUri"].string_value

--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -3421,14 +3421,14 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
         """BigQuery location of exported evaluated examples from the Training Job"""
 
         if self._gca_resource is None:
-          return None
+          raise Exception("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
 
         meta = getattr((self._gca_resource), "training_task_metadata")
 
         if meta is not None and "evaluatedDataItemsBigqueryUri" in meta._pb:
           return meta._pb["evaluatedDataItemsBigqueryUri"].string_value
         else:
-          return None
+          raise Exception("BigQuery uri for evaluated data items does not exist. Must export evaluated data items during training.")
 
 
 class AutoMLImageTrainingJob(_TrainingJob):


### PR DESCRIPTION
We currently do not support the output of a BigQuery destination uri for the exported evaluated examples from our training step when creating an AutoML Forecast model. Adding this feature would allow users to easily access the evaluated examples and use them for data visualization. 
