### PR TITLE
fix(PipelineJob): use name as output only field

### DIFF
--- a/tests/unit/aiplatform/test_pipeline_jobs.py
+++ b/tests/unit/aiplatform/test_pipeline_jobs.py
@@ -236,7 +236,6 @@ class TestPipelineJob:
         # Construct expected request
         expected_gapic_pipeline_job = gca_pipeline_job_v1beta1.PipelineJob(
             display_name=_TEST_PIPELINE_JOB_DISPLAY_NAME,
-            name=_TEST_PIPELINE_JOB_NAME,
             pipeline_spec={
                 "components": {},
                 "pipelineInfo": _TEST_PIPELINE_JOB_SPEC["pipelineSpec"]["pipelineInfo"],


### PR DESCRIPTION
Previously, `create_time` is used to identify whether a job has been created. Now since we have `job_id` fixed, we could leave `name` out for output only and identify whether a job has been created using `name`. 