### PR TITLE
chore: Use `True` for PipelineJob for clearer documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -386,7 +386,7 @@ To create a Vertex Pipeline run:
 
     # Whether this function call should be synchronous (wait for pipeline run to finish before terminating)
     # or asynchronous (return immediately)
-    sync=sync
+    sync=True
   )
 
 


### PR DESCRIPTION
Currently `sync=sync` is confusing for users for the type of sync to pass in. 