### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "aiplatform",
     "name_pretty": "AI Platform",
     "product_documentation": "https://cloud.google.com/ai-platform",
-    "client_documentation": "https://googleapis.dev/python/aiplatform/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/aiplatform/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559744",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.