### PR TITLE
chore: pin `proto-plus<1.19.7`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setuptools.setup(
         # Until this issue is closed
         # https://github.com/googleapis/google-cloud-python/issues/10566
         "google-api-core[grpc] >= 1.26.0, <3.0.0dev",
-        "proto-plus >= 1.10.1",
+        "proto-plus >= 1.10.1, <1.19.7",
         "packaging >= 14.3",
         "google-cloud-storage >= 1.32.0, < 2.0.0dev",
         "google-cloud-bigquery >= 1.15.0, < 3.0.0dev",


### PR DESCRIPTION
`proto-plus>=1.19.7` breaks `google-api-core<2.x.x` compatibility by
requiring `protobuf>=1.19.0`. The compatibility break is detailed here:
https://github.com/googleapis/python-api-core/issues/276

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-aiplatform/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #830 🦕
