### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "aiplatform",
     "name_pretty": "AI Platform",
     "product_documentation": "https://cloud.google.com/ai-platform",
-    "client_documentation": "https://googleapis.dev/python/aiplatform/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/aiplatform/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559744",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Vertex SDK for Python
 .. |sample-tests| image:: https://storage.googleapis.com/cloud-devrel-public/python-aiplatform/badges/sdk-sample-tests.svg
    :target: https://storage.googleapis.com/cloud-devrel-public/python-aiplatform/badges/sdk-sample-tests.html
 .. _Vertex AI: https://cloud.google.com/vertex-ai/docs
-.. _Client Library Documentation: https://googleapis.dev/python/aiplatform/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/aiplatform/latest
 .. _Product Documentation:  https://cloud.google.com/vertex-ai/docs
 
 Quick Start

--- a/change-metadata.py
+++ b/change-metadata.py
@@ -1,0 +1,30 @@
+import json
+
+fname = ".repo-metadata.json"
+rname = "README.rst"
+ky = "client_documentation"
+doc_link = ""
+new_link = ""
+
+new_data = {}
+
+with open (fname) as jsonfile:
+    data = json.load(jsonfile)
+    doc_link = data[ky]
+    product = doc_link.split("/")[4]
+    data[ky] = new_link = f"https://cloud.google.com/python/docs/reference/{product}/latest"
+    new_data = data
+
+with open (fname, "w") as outfile:
+    json.dump(new_data, outfile, indent=4)
+
+with open (fname, "a") as outfile:
+    outfile.write("\n")
+
+content = ""
+with open (rname, "r") as outfile:
+    content = outfile.read().replace(doc_link, new_link)
+
+with open (rname, "w") as outfile:
+    outfile.write(content)
+


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.