### PR TITLE
chore: upgrading tb uploader tf dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open(os.path.join(package_root, "google/cloud/aiplatform/version.py")) as f
     exec(fp.read(), version)
 version = version["__version__"]
 
-tensorboard_extra_require = ["tensorflow >=2.3.0, <=2.5.0"]
+tensorboard_extra_require = ["tensorflow >=2.3.0, <=2.7.0"]
 metadata_extra_require = ["pandas >= 1.0.0"]
 xai_extra_require = ["tensorflow >=2.3.0, <=2.5.0"]
 lit_extra_require = ["tensorflow >= 2.3.0", "pandas >= 1.0.0", "lit-nlp >= 0.4.0"]


### PR DESCRIPTION
for b/210986314, where users of the latest TF will get downgraded one because of the lower version upper bound of the tb uploader.

OSS TensorBoard team discourages eliminating the upper bound. I.e., >= 2.5.0 was frowned upon.

Tried installing the uploader and uploading. Worked fine.