### PR TITLE
feat: Added `aiplatform.Model.update`  method

### DIFF
--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1562,9 +1562,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
 
         update_mask = field_mask_pb2.FieldMask(paths=update_mask)
 
-        self.api_client.update_model(
-            model=copied_model_proto, update_mask=update_mask
-        )
+        self.api_client.update_model(model=copied_model_proto, update_mask=update_mask)
 
         self._sync_gca_resource()
 

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1539,13 +1539,12 @@ class Model(base.VertexAiResourceNounWithFutureManager):
             ValueError: If `labels` is not the correct format.
         """
 
-        if labels:
-            utils.validate_labels(labels)
-
         current_model_proto = self.gca_resource
         update_mask: List[str] = []
 
         if display_name:
+            utils.validate_display_name(display_name)
+
             current_model_proto.display_name = display_name
             update_mask.append("display_name")
 

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1501,7 +1501,6 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         )
         self._gca_resource = self._get_gca_resource(resource_name=model_name)
 
-    @base.optional_sync()
     def update(
         self,
         display_name: Optional[str] = None,

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1562,7 +1562,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
 
         update_mask = field_mask_pb2.FieldMask(paths=update_mask)
 
-        _ = self.api_client.update_model(
+        self.api_client.update_model(
             model=copied_model_proto, update_mask=update_mask
         )
 

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1519,7 +1519,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
 
         Args:
             display_name (str):
-                Required. The display name of the Model. The name can be up to 128
+                The display name of the Model. The name can be up to 128
                 characters long and can be consist of any UTF-8 characters.
             description (str):
                 The description of the model.

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1540,31 +1540,33 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         """
 
         current_model_proto = self.gca_resource
+        copied_model_proto = current_model_proto.__class__(current_model_proto)
+
         update_mask: List[str] = []
 
         if display_name:
             utils.validate_display_name(display_name)
 
-            current_model_proto.display_name = display_name
+            copied_model_proto.display_name = display_name
             update_mask.append("display_name")
 
         if description:
-            current_model_proto.description = description
+            copied_model_proto.description = description
             update_mask.append("description")
 
         if labels:
             utils.validate_labels(labels)
 
-            current_model_proto.labels = labels
+            copied_model_proto.labels = labels
             update_mask.append("labels")
 
         update_mask = field_mask_pb2.FieldMask(paths=update_mask)
 
-        model = self.api_client.update_model(
-            model=current_model_proto, update_mask=update_mask
+        _ = self.api_client.update_model(
+            model=copied_model_proto, update_mask=update_mask
         )
 
-        self._gca_resource = model
+        self._sync_gca_resource()
 
         return self
 

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1534,7 +1534,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
                 See https://goo.gl/xmQnxf for more information
                 and examples of labels.
         Returns:
-            model: Updated model resource.                
+            model: Updated model resource.
         Raises:
             ValueError: If `labels` is not the correct format.
         """

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1506,7 +1506,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         display_name: Optional[str] = None,
         description: Optional[str] = None,
         labels: Optional[Dict[str, str]] = None,
-    ):
+    ) -> "Model":
         """Updates a model.
 
         Example usage:

--- a/tests/system/aiplatform/test_model_upload.py
+++ b/tests/system/aiplatform/test_model_upload.py
@@ -37,7 +37,7 @@ class TestModel(e2e_base.TestEndToEnd):
     _temp_prefix = f"{_TEST_PROJECT}-vertex-staging-{_TEST_LOCATION}"
 
     def test_upload_and_deploy_xgboost_model(self, shared_state):
-        """Upload XGBoost model from local file and deploy it for prediction."""
+        """Upload XGBoost model from local file and deploy it for prediction. Additionally, update model name, description and labels"""
 
         aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
 
@@ -65,3 +65,12 @@ class TestModel(e2e_base.TestEndToEnd):
         shared_state["resources"].append(endpoint)
         predict_response = endpoint.predict(instances=[[0, 0, 0]])
         assert len(predict_response.predictions) == 1
+
+        model = model.update(
+            display_name="new_name",
+            description="new_description",
+            labels={"my_label": "updated"},
+        )
+        assert model.display_name == "new_name"
+        assert model.display_name == "new_description"
+        assert model.labels == {"my_label": "updated"}

--- a/tests/unit/aiplatform/test_models.py
+++ b/tests/unit/aiplatform/test_models.py
@@ -1709,4 +1709,3 @@ class TestModel:
         update_model_mock.assert_called_once_with(
             model=current_model_proto, update_mask=update_mask
         )
-

--- a/tests/unit/aiplatform/test_models.py
+++ b/tests/unit/aiplatform/test_models.py
@@ -54,6 +54,7 @@ from google.cloud.aiplatform.compat.types import (
     encryption_spec as gca_encryption_spec,
 )
 
+from google.protobuf import field_mask_pb2
 
 from test_endpoints import create_endpoint_mock  # noqa: F401
 
@@ -178,6 +179,27 @@ _TEST_CONTAINER_REGISTRY_DESTINATION
 
 
 @pytest.fixture
+def mock_model():
+    model = mock.MagicMock(models.Model)
+    model.name = _TEST_ID
+    model._latest_future = None
+    model._exception = None
+    model._gca_resource = gca_model.Model(
+        display_name=_TEST_MODEL_NAME,
+        description=_TEST_DESCRIPTION,
+        labels=_TEST_LABEL,
+    )
+    yield model
+
+
+@pytest.fixture
+def update_model_mock(mock_model):
+    with patch.object(model_service_client.ModelServiceClient, "update_model") as mock:
+        mock.return_value = mock_model
+        yield mock
+
+
+@pytest.fixture
 def get_endpoint_mock():
     with mock.patch.object(
         endpoint_service_client.EndpointServiceClient, "get_endpoint"
@@ -199,6 +221,7 @@ def get_model_mock():
         get_model_mock.return_value = gca_model.Model(
             display_name=_TEST_MODEL_NAME, name=_TEST_MODEL_RESOURCE_NAME,
         )
+
         yield get_model_mock
 
 
@@ -1660,3 +1683,30 @@ class TestModel:
         ]
         staged_model_file_name = staged_model_file_path.split("/")[-1]
         assert staged_model_file_name in ["saved_model.pb", "saved_model.pbtxt"]
+
+    @pytest.mark.usefixtures("get_model_mock")
+    def test_update(self, update_model_mock, get_model_mock):
+
+        test_model = models.Model(_TEST_ID)
+
+        test_model.update(
+            display_name=_TEST_MODEL_NAME,
+            description=_TEST_DESCRIPTION,
+            labels=_TEST_LABEL,
+        )
+
+        current_model_proto = gca_model.Model(
+            display_name=_TEST_MODEL_NAME,
+            description=_TEST_DESCRIPTION,
+            labels=_TEST_LABEL,
+            name=_TEST_MODEL_RESOURCE_NAME,
+        )
+
+        update_mask = field_mask_pb2.FieldMask(
+            paths=["display_name", "description", "labels"]
+        )
+
+        update_model_mock.assert_called_once_with(
+            model=current_model_proto, update_mask=update_mask
+        )
+


### PR DESCRIPTION
Added ability to update `display_name`, `description` and `labels`.

Fixes https://b.corp.google.com/issues/213921337

# TODO
- [x] Manual test
- [x] Automated unit test
- [x] Automated integration test

# Test code
```

models = Model.list()

my_model = models[0]

print(f"eTag: {my_model._gca_resource.etag}")
print(f"Current display_name: {my_model.display_name}")
my_model = my_model.update(display_name=my_model.display_name + "_new")
print(f"Current display_name: {my_model.display_name}")

print(f"eTag: {my_model._gca_resource.etag}")
my_model = Model(my_model.resource_name)  # Fetch model from server
print(f"eTag after fetch: {my_model._gca_resource.etag}")
print(f"Current description: {my_model.description}")
my_model = my_model.update(description=my_model.description + "_new")
print(f"Current description: {my_model.description}")

print(f"eTag: {my_model._gca_resource.etag}")
my_model = Model(my_model.resource_name)  # Fetch model from server
print(f"eTag after fetch: {my_model._gca_resource.etag}")
print(f"Current labels: {my_model.labels}")
my_model = my_model.update(labels={"my_label": "updated"})
print(f"Current labels: {my_model.labels}")
```

# Bug?
There's some weirdness going on with the eTags though. If I don't "refetch" the model from the server, I get an "etag mismatch" exception on the subsequent update.

Tracked at b/214432914