### PR TITLE
fix: show logs when TFX pipelines are submitted

### DIFF
--- a/google/cloud/aiplatform/pipeline_jobs.py
+++ b/google/cloud/aiplatform/pipeline_jobs.py
@@ -16,6 +16,7 @@
 #
 
 import datetime
+import logging
 import time
 import re
 from typing import Any, Dict, List, Optional
@@ -272,6 +273,10 @@ class PipelineJob(base.VertexAiResourceNounWithFutureManager):
 
         if network:
             self._gca_resource.network = network
+
+        # Prevents logs from being supressed on TFX pipelines
+        if self._gca_resource.pipeline_spec["sdkVersion"].startswith("tfx"):
+            _LOGGER.setLevel(logging.INFO)
 
         _LOGGER.log_create_with_lro(self.__class__)
 


### PR DESCRIPTION
Fixes an issue where calling `PipelineJob.submit()` with TFX pipelines didn't show any logs. This was happening because when `tfx.v1` is imported, the log level gets set to `WARNING`. I added a check for TFX pipelines and reset the log level to `INFO`.

Fixes b/209602615.
