### PR TITLE
chore: Made it easier to use the latest framework version when calling Model.upload_*

### DIFF
--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -2534,7 +2534,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
     def upload_xgboost_model_file(
         cls,
         model_file_path: str,
-        xgboost_version: str = "1.4",
+        xgboost_version: Optional[str] = None,
         display_name: str = "XGBoost model",
         description: Optional[str] = None,
         instance_schema_uri: Optional[str] = None,
@@ -2674,7 +2674,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         container_image_uri = aiplatform.helpers.get_prebuilt_prediction_container_uri(
             region=location,
             framework="xgboost",
-            framework_version=xgboost_version,
+            framework_version=xgboost_version or "1.4",
             accelerator="cpu",
         )
 
@@ -2729,7 +2729,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
     def upload_scikit_learn_model_file(
         cls,
         model_file_path: str,
-        sklearn_version: str = "1.0",
+        sklearn_version: Optional[str] = None,
         display_name: str = "Scikit-learn model",
         description: Optional[str] = None,
         instance_schema_uri: Optional[str] = None,
@@ -2869,7 +2869,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         container_image_uri = aiplatform.helpers.get_prebuilt_prediction_container_uri(
             region=location,
             framework="sklearn",
-            framework_version=sklearn_version,
+            framework_version=sklearn_version or "1.0",
             accelerator="cpu",
         )
 
@@ -2923,7 +2923,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
     def upload_tensorflow_saved_model(
         cls,
         saved_model_dir: str,
-        tensorflow_version: str = "2.7",
+        tensorflow_version: Optional[str] = None,
         use_gpu: bool = False,
         display_name: str = "Tensorflow model",
         description: Optional[str] = None,
@@ -3061,7 +3061,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         container_image_uri = aiplatform.helpers.get_prebuilt_prediction_container_uri(
             region=location,
             framework="tensorflow",
-            framework_version=tensorflow_version,
+            framework_version=tensorflow_version or "2.7",
             accelerator="gpu" if use_gpu else "cpu",
         )
 


### PR DESCRIPTION
Goal: make it easier for the calling functions to ask for the latest framework version.
It turns out that the current approach complicates calling the upload_* functions, because there is no values of the *_version parameter that mean "latest version". This leads to the need to have different code paths depending on whether the user has given an explicit version value.
Example of the problem:

```python
def my_import_xgboost_model(
    model_path: str,
    xgboost_version: Optional[str] = None,
):
    if xgboost_version:
            # Case for when the user has provided explicit version
            aiplatfor.Model.upload_xgboost_model(model_path=model_path, xgboost_version=xgboost_version)
    else:
            # Case for when the user has not provided explicit version
            aiplatfor.Model.upload_xgboost_model(model_path=model_path)
```

With this small change, the call is simplified:

```python
def my_import_xgboost_model(
    model_path: str,
    xgboost_version: Optional[str] = None,
):
    aiplatfor.Model.upload_xgboost_model(model_path=model_path, xgboost_version=xgboost_version)
```

P.S. It would be great if the `get_prebuilt_prediction_container_uri` supported the "latest version" feature.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-aiplatform/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
