### PR TITLE
fix: rename teardown fixture

### DIFF
--- a/tests/system/aiplatform/e2e_base.py
+++ b/tests/system/aiplatform/e2e_base.py
@@ -124,10 +124,12 @@ class TestEndToEnd(metaclass=abc.ABCMeta):
         )  # Make an API request.
 
     @pytest.fixture(scope="class", autouse=True)
-    def teardown(self, shared_state: Dict[str, Any]):
+    def tear_down_resources(self, shared_state: Dict[str, Any]):
         """Delete every Vertex AI resource created during test"""
 
         yield
+
+        # TODO(b/218310362): Add resource deletion system tests
 
         # Bring all Endpoints to the front of the list
         # Ensures Models are undeployed first before we attempt deletion

--- a/tests/system/aiplatform/test_e2e_tabular.py
+++ b/tests/system/aiplatform/test_e2e_tabular.py
@@ -46,7 +46,7 @@ _INSTANCE = {
 }
 
 
-@pytest.mark.usefixtures("prepare_staging_bucket", "delete_staging_bucket", "teardown")
+@pytest.mark.usefixtures("prepare_staging_bucket", "delete_staging_bucket")
 class TestEndToEndTabular(e2e_base.TestEndToEnd):
     """End to end system test of the Vertex SDK with tabular data adapted from
     reference notebook http://shortn/_eyoNx3SN0X"""

--- a/tests/system/aiplatform/test_model_upload.py
+++ b/tests/system/aiplatform/test_model_upload.py
@@ -32,7 +32,7 @@ _TEST_LOCATION = "us-central1"
 _XGBOOST_MODEL_URI = "gs://cloud-samples-data-us-central1/vertex-ai/google-cloud-aiplatform-ci-artifacts/models/iris_xgboost/model.bst"
 
 
-@pytest.mark.usefixtures("delete_staging_bucket", "teardown")
+@pytest.mark.usefixtures("delete_staging_bucket")
 class TestModel(e2e_base.TestEndToEnd):
     _temp_prefix = f"{_TEST_PROJECT}-vertex-staging-{_TEST_LOCATION}"
 


### PR DESCRIPTION
PyTest version 7.0 was released on Feb 4. 
```
Calling a fixture function directly, as opposed to request them in a test function, is deprecated.
```
This deprecation is affecting the system tests. 