### PR TITLE
fix: remove empty scripts kwarg in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,6 @@ setuptools.setup(
         "cloud_profiler": profiler_extra_require,
     },
     python_requires=">=3.6",
-    scripts=[],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
The empty kwarg `scripts` was introduced in https://github.com/googleapis/python-aiplatform/pull/96.

Towards #1003 🦕
