### PR TITLE
feat: Add support for Vertex Tables Q1 regions

### DIFF
--- a/google/cloud/aiplatform/constants/base.py
+++ b/google/cloud/aiplatform/constants/base.py
@@ -36,6 +36,8 @@ SUPPORTED_REGIONS = {
     "us-east4",
     "us-west1",
     "us-west2",
+    "us-west4",
+    "southamerica-east1",
 }
 
 API_BASE_PATH = "aiplatform.googleapis.com"

--- a/tests/unit/aiplatform/test_utils.py
+++ b/tests/unit/aiplatform/test_utils.py
@@ -42,7 +42,7 @@ model_service_client_default = model_service_client_v1
 
 def test_invalid_region_raises_with_invalid_region():
     with pytest.raises(ValueError):
-        aiplatform.utils.validate_region(region="us-west4")
+        aiplatform.utils.validate_region(region="us-west3")
 
 
 def test_invalid_region_does_not_raise_with_valid_region():


### PR DESCRIPTION
Add Vertex Tables Q1 regions in the SUPPORTED_REGIONS set to enable the SDK. The implementation of these regions is complete and the change is required for E2E tests.