### PR TITLE
docs: Include time dependency in documentation for weight, time, and target columns.

### DIFF
--- a/google/cloud/aiplatform/training_jobs.py
+++ b/google/cloud/aiplatform/training_jobs.py
@@ -4005,9 +4005,11 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
                 For time series Datasets, all their data is exported to
                 training, to pick and choose from.
             target_column (str):
-                Required. Name of the column that the Model is to predict values for.
+                Required. Name of the column that the Model is to predict values for. This
+                column must be unavailable at forecast.
             time_column (str):
                 Required. Name of the column that identifies time order in the time series.
+                This column must be available at forecast.
             time_series_identifier_column (str):
                 Required. Name of the column that identifies the time series.
             unavailable_at_forecast_columns (List[str]):
@@ -4046,7 +4048,7 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
                 during Model training. The column must have numeric values between 0 and
                 10000 inclusively, and 0 value means that the row is ignored.
                 If the weight column field is not set, then all rows are assumed to have
-                equal weight of 1.
+                equal weight of 1. This column must be available at forecast.
             time_series_attribute_columns (List[str]):
                 Optional. Column names that should be used as attribute columns.
                 Each column is constant within a time series.
@@ -4078,7 +4080,7 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
                 Applies only if [export_evaluated_data_items] is True and
                 [export_evaluated_data_items_bigquery_destination_uri] is specified.
             quantiles (List[float]):
-                Quantiles to use for the `minizmize-quantile-loss`
+                Quantiles to use for the `minimize-quantile-loss`
                 [AutoMLForecastingTrainingJob.optimization_objective]. This argument is required in
                 this case.
 
@@ -4236,9 +4238,11 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
                 For time series Datasets, all their data is exported to
                 training, to pick and choose from.
             target_column (str):
-                Required. Name of the column that the Model is to predict values for.
+                Required. Name of the column that the Model is to predict values for. This
+                column must be unavailable at forecast.
             time_column (str):
                 Required. Name of the column that identifies time order in the time series.
+                This column must be available at forecast.
             time_series_identifier_column (str):
                 Required. Name of the column that identifies the time series.
             unavailable_at_forecast_columns (List[str]):
@@ -4286,7 +4290,7 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
                 during Model training. The column must have numeric values between 0 and
                 10000 inclusively, and 0 value means that the row is ignored.
                 If the weight column field is not set, then all rows are assumed to have
-                equal weight of 1.
+                equal weight of 1. This column must be available at forecast.
             time_series_attribute_columns (List[str]):
                 Optional. Column names that should be used as attribute columns.
                 Each column is constant within a time series.
@@ -4317,7 +4321,7 @@ class AutoMLForecastingTrainingJob(_TrainingJob):
                 Applies only if [export_evaluated_data_items] is True and
                 [export_evaluated_data_items_bigquery_destination_uri] is specified.
             quantiles (List[float]):
-                Quantiles to use for the `minizmize-quantile-loss`
+                Quantiles to use for the `minimize-quantile-loss`
                 [AutoMLForecastingTrainingJob.optimization_objective]. This argument is required in
                 this case.
 


### PR DESCRIPTION
Updates documentation for Vertex Forecasting run function to specify column types for columns with time dependency properties.