### PR TITLE
tests: Added VPC network constants to common file instead of continuous

### DIFF
--- a/.kokoro/continuous/common.cfg
+++ b/.kokoro/continuous/common.cfg
@@ -29,3 +29,7 @@ env_vars: {
     key: "BUILD_SPECIFIC_GCLOUD_PROJECT"
     value: "ucaip-sample-tests"
 }
+env_vars {
+  key: "_VPC_NETWORK_URI"
+  value: "projects/580378083368/global/networks/system-tests"
+}

--- a/.kokoro/continuous/continuous.cfg
+++ b/.kokoro/continuous/continuous.cfg
@@ -1,6 +1,1 @@
 # Format: //devtools/kokoro/config/proto/build.proto
-
-env_vars {
-  key: "_VPC_NETWORK_URI"
-  value: "projects/580378083368/global/networks/system-tests"
-}

--- a/owlbot.py
+++ b/owlbot.py
@@ -97,7 +97,6 @@ s.move(
     excludes=[
         ".coveragerc",
         ".kokoro/continuous/common.cfg",
-        ".kokoro/continuous/continuous.cfg",
         ".kokoro/presubmit/presubmit.cfg",
         ".github/CODEOWNERS",
         ".github/workflows",  # exclude gh actions as credentials are needed for tests


### PR DESCRIPTION
After testing, it seems that common.cfg should work better.