### PR TITLE
chore: add tear_down_resources fixture to individual system test classes

### DIFF
--- a/tests/system/aiplatform/test_e2e_tabular.py
+++ b/tests/system/aiplatform/test_e2e_tabular.py
@@ -46,7 +46,9 @@ _INSTANCE = {
 }
 
 
-@pytest.mark.usefixtures("prepare_staging_bucket", "delete_staging_bucket")
+@pytest.mark.usefixtures(
+    "prepare_staging_bucket", "delete_staging_bucket", "tear_down_resources"
+)
 class TestEndToEndTabular(e2e_base.TestEndToEnd):
     """End to end system test of the Vertex SDK with tabular data adapted from
     reference notebook http://shortn/_eyoNx3SN0X"""

--- a/tests/system/aiplatform/test_metadata.py
+++ b/tests/system/aiplatform/test_metadata.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+import pytest
+
 from google.cloud import aiplatform
 from tests.system.aiplatform import e2e_base
 
@@ -24,6 +26,7 @@ PARAMS = {"sdk-param-test-1": 0.1, "sdk-param-test-2": 0.2}
 METRICS = {"sdk-metric-test-1": 0.8, "sdk-metric-test-2": 100}
 
 
+@pytest.mark.usefixtures("tear_down_resources")
 class TestMetadata(e2e_base.TestEndToEnd):
 
     _temp_prefix = "temp-vertex-sdk-e2e-test"

--- a/tests/system/aiplatform/test_model_upload.py
+++ b/tests/system/aiplatform/test_model_upload.py
@@ -28,7 +28,7 @@ from tests.system.aiplatform import e2e_base
 _XGBOOST_MODEL_URI = "gs://cloud-samples-data-us-central1/vertex-ai/google-cloud-aiplatform-ci-artifacts/models/iris_xgboost/model.bst"
 
 
-@pytest.mark.usefixtures("delete_staging_bucket")
+@pytest.mark.usefixtures("delete_staging_bucket", "tear_down_resources")
 class TestModel(e2e_base.TestEndToEnd):
 
     _temp_prefix = "temp_vertex_sdk_e2e_model_upload_test"

--- a/tests/system/aiplatform/test_tensorboard.py
+++ b/tests/system/aiplatform/test_tensorboard.py
@@ -15,10 +15,13 @@
 # limitations under the License.
 #
 
+import pytest
+
 from google.cloud import aiplatform
 from tests.system.aiplatform import e2e_base
 
 
+@pytest.mark.usefixtures("tear_down_resources")
 class TestTensorboard(e2e_base.TestEndToEnd):
 
     _temp_prefix = "temp-vertex-sdk-e2e-test"


### PR DESCRIPTION
Added the `tear_down_resources` fixture to system test classes: e2e_tabular, metadata, model_upload, and tensorboard.