### PR TITLE
chore: updates so tests can run in different environments

### DIFF
--- a/tests/unit/aiplatform/test_explain_saved_model_metadata_builder_tf1_test.py
+++ b/tests/unit/aiplatform/test_explain_saved_model_metadata_builder_tf1_test.py
@@ -26,6 +26,7 @@ import test_models
 from test_models import upload_model_mock, get_model_mock  # noqa: F401
 
 
+@pytest.mark.usefixtures("google_auth_mock")
 class SavedModelMetadataBuilderTF1Test(tf.test.TestCase):
     def _set_up(self):
         self.sess = tf.Session(graph=tf.Graph())

--- a/tests/unit/aiplatform/test_explain_saved_model_metadata_builder_tf2_test.py
+++ b/tests/unit/aiplatform/test_explain_saved_model_metadata_builder_tf2_test.py
@@ -27,6 +27,7 @@ import test_models
 from test_models import upload_model_mock, get_model_mock  # noqa: F401
 
 
+@pytest.mark.usefixtures("google_auth_mock")
 class SavedModelMetadataBuilderTF2Test(tf.test.TestCase):
     def _set_up_sequential(self):
         # Set up for the sequential.

--- a/tests/unit/aiplatform/test_training_jobs.py
+++ b/tests/unit/aiplatform/test_training_jobs.py
@@ -330,6 +330,9 @@ def mock_get_backing_custom_job_with_enable_web_access():
         yield get_custom_job_mock
 
 
+@pytest.mark.skipif(
+    sys.executable is None, reason="requires python path to invoke subprocess"
+)
 @pytest.mark.usefixtures("google_auth_mock")
 class TestTrainingScriptPythonPackagerHelpers:
     def setup_method(self):
@@ -446,6 +449,9 @@ class TestTrainingScriptPythonPackagerHelpers:
         assert "python" in source_utils._get_python_executable().lower()
 
 
+@pytest.mark.skipif(
+    sys.executable is None, reason="requires python path to invoke subprocess"
+)
 @pytest.mark.usefixtures("google_auth_mock")
 class TestTrainingScriptPythonPackager:
     def setup_method(self):


### PR DESCRIPTION
Updated two tests:
* Added `google_auth_mock` to `test_explain_saved_model*` so those tests can run when `GOOGLE_APPLICATION_CREDENTIALS` is not set
* Added `skipif` to `test_training_jobs` to skip tests when `sys.executable` is not set
