### PR TITLE
chore: update mock to use tf.__version__ directly

### DIFF
--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1386,6 +1386,8 @@ class Endpoint(base.VertexAiResourceNounWithFutureManager):
 
         _LOGGER.log_action_completed_against_resource("endpoint", "updated", self)
 
+        self._sync_gca_resource()
+
         return self
 
     def predict(

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1386,8 +1386,6 @@ class Endpoint(base.VertexAiResourceNounWithFutureManager):
 
         _LOGGER.log_action_completed_against_resource("endpoint", "updated", self)
 
-        self._sync_gca_resource()
-
         return self
 
     def predict(

--- a/tests/unit/aiplatform/test_cloud_profiler.py
+++ b/tests/unit/aiplatform/test_cloud_profiler.py
@@ -175,13 +175,13 @@ class TestProfilerPlugin(unittest.TestCase):
     def testCanInitializeTFVersion(self):
         import tensorflow
 
-        with mock.patch.dict(tensorflow.__dict__, {"__version__": "1.2.3.4"}):
+        with mock.patch.object(tensorflow, "__version__", return_value="1.2.3.4"):
             assert not TFProfiler.can_initialize()
 
     def testCanInitializeOldTFVersion(self):
         import tensorflow
 
-        with mock.patch.dict(tensorflow.__dict__, {"__version__": "2.3.0"}):
+        with mock.patch.object(tensorflow, "__version__", return_value="2.3.0"):
             assert not TFProfiler.can_initialize()
 
     def testCanInitializeNoProfilePlugin(self):


### PR DESCRIPTION
Changed the way we're mocking `tf.__version__` in `test_cloud_profiler` so it runs on multiple environments.
