### PR TITLE
chore: Revert "chore: Support bigquery 3.x"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setuptools.setup(
         "protobuf >= 3.19.0, <4.0.0dev",
         "packaging >= 14.3, <22.0.0dev",
         "google-cloud-storage >= 1.32.0, < 3.0.0dev",
-        "google-cloud-bigquery >= 1.15.0, < 4.0.0dev",
+        "google-cloud-bigquery >= 1.15.0, < 3.0.0dev",
         "google-cloud-resource-manager >= 1.3.3, < 3.0.0dev",
     ),
     extras_require={


### PR DESCRIPTION
Reverting googleapis/python-aiplatform#1444 since it caused system tests to fail