### PR TITLE
chore: update bigquery_destination_prefix docstring for bp job

### DIFF
--- a/google/cloud/aiplatform/jobs.py
+++ b/google/cloud/aiplatform/jobs.py
@@ -438,27 +438,27 @@ class BatchPredictionJob(_Job):
                 which as value has ```google.rpc.Status`` <Status>`__
                 containing only ``code`` and ``message`` fields.
             bigquery_destination_prefix (Optional[str]):
-                The BigQuery URI to a project or table, up to 2000 characters long.
-                When only the project is specified, the Dataset and Table is created.
-                When the full table reference is specified, the Dataset must exist and
-                table must not exist. Accepted forms: ``bq://projectId`` or
-                ``bq://projectId.bqDatasetId`` or
-                ``bq://projectId.bqDatasetId.bqTableId``. If no Dataset is specified,
-                a new one is created with the name
-                ``prediction_<model-display-name>_<job-create-time>``
-                where the table name is made BigQuery-dataset-name compatible
-                (for example, most special characters become underscores), and
-                timestamp is in YYYY_MM_DDThh_mm_ss_sssZ "based on ISO-8601"
-                format. In the dataset two tables will be created, ``predictions``,
-                and ``errors``. If the Model has both ``instance`` and
-                ``prediction`` schemata defined then the tables have columns as
-                follows: The ``predictions`` table contains instances for which
-                the prediction succeeded, it has columns as per a concatenation
-                of the Model's instance and prediction schemata. The ``errors``
-                table contains rows for which the prediction has failed, it has
-                instance columns, as per the instance schema, followed by a single
-                "errors" column, which as values has ```google.rpc.Status`` <Status>`__
-                represented as a STRUCT, and containing only ``code`` and ``message``.
+                The BigQuery project or dataset location where the output is
+                to be written to. If project is provided, a new dataset is
+                created with name
+                ``prediction_<model-display-name>_<job-create-time>`` where
+                is made BigQuery-dataset-name compatible (for example, most
+                special characters become underscores), and timestamp is in
+                YYYY_MM_DDThh_mm_ss_sssZ "based on ISO-8601" format. In the
+                dataset two tables will be created, ``predictions``, and
+                ``errors``. If the Model has both
+                [instance][google.cloud.aiplatform.v1.PredictSchemata.instance_schema_uri]
+                and
+                [prediction][google.cloud.aiplatform.v1.PredictSchemata.parameters_schema_uri]
+                schemata defined then the tables have columns as follows:
+                The ``predictions`` table contains instances for which the
+                prediction succeeded, it has columns as per a concatenation
+                of the Model's instance and prediction schemata. The
+                ``errors`` table contains rows for which the prediction has
+                failed, it has instance columns, as per the instance schema,
+                followed by a single "errors" column, which as values has
+                [google.rpc.Status][google.rpc.Status] represented as a
+                STRUCT, and containing only ``code`` and ``message``.
             model_parameters (Optional[Dict]):
                 The parameters that govern the predictions. The schema of
                 the parameters may be specified via the Model's `parameters_schema_uri`.


### PR DESCRIPTION
Updated the `bigquery_destination_prefix` to indicate that only BQ projects and datasets are supported in this uri, not a table name prefix. 

Fixes b/238520266 🦕