### PR TITLE
feat: Add support for Vertex Tables Q2 regions

### DIFF
--- a/google/cloud/aiplatform/constants/base.py
+++ b/google/cloud/aiplatform/constants/base.py
@@ -29,6 +29,7 @@ SUPPORTED_REGIONS = {
     "europe-west3",
     "europe-west4",
     "europe-west6",
+    "europe-west9",
     "northamerica-northeast1",
     "northamerica-northeast2",
     "us-central1",


### PR DESCRIPTION
Add Vertex Tables Q2 region in the SUPPORTED_REGIONS set to enable the SDK. The implementation of this region is complete and the change is required for E2E tests.