### PR TITLE
chore: increase system test timeout to 6 hours

### DIFF
--- a/.kokoro/continuous/system.cfg
+++ b/.kokoro/continuous/system.cfg
@@ -11,5 +11,5 @@ env_vars: {
     value: "-n=auto --dist=loadscope"
 }
 
-# Kokoro VM timeout of 5 hours for system tests
-timeout_mins: 300
+# Kokoro VM timeout of 6 hours for system tests
+timeout_mins: 360


### PR DESCRIPTION
Our last 2 system test runs timed out because they went over the 5 hour timeout we had. Increasing to 6 hours.
