### PR TITLE
chore: increase kokoro VM timeout for system tests

### DIFF
--- a/.kokoro/continuous/system.cfg
+++ b/.kokoro/continuous/system.cfg
@@ -11,5 +11,5 @@ env_vars: {
     value: "-n=auto --dist=loadscope"
 }
 
-# Kokoro VM timeout of 6 hours for system tests
-timeout_mins: 360
+# Kokoro VM timeout of 8 hours for system tests
+timeout_mins: 480


### PR DESCRIPTION
Temporary fix for https://github.com/googleapis/python-aiplatform/issues/1551 while we try to decrease total execution time for Model Monitoring system tests.
