### PR TITLE
feat: Added `cloud_console_url` property to Vertex resources

### DIFF
--- a/google/cloud/aiplatform/base.py
+++ b/google/cloud/aiplatform/base.py
@@ -736,6 +736,23 @@ class VertexAiResourceNoun(metaclass=abc.ABCMeta):
             prefix = cls.__name__
         return prefix + " " + datetime.datetime.now().isoformat(sep=" ")
 
+    @property
+    def cloud_console_url(self) -> str:
+        """Returns the Google Cloud console URL where the resource can be viewed."""
+        (
+            literal_projects,
+            project_id,
+            resource_name_without_project,
+        ) = self.resource_name.split("/", 2)
+
+        if literal_projects != "projects":
+            # Should not happen
+            _LOGGER.warn(f"Unexpected resource name format: {self.resource_name}")
+            return None
+
+        url = f"https://console.cloud.google.com/vertex-ai/{resource_name_without_project}?project={project_id}"
+        return url
+
 
 def optional_sync(
     construct_object_on_arg: Optional[str] = None,

--- a/google/cloud/aiplatform/pipeline_jobs.py
+++ b/google/cloud/aiplatform/pipeline_jobs.py
@@ -380,7 +380,7 @@ class PipelineJob(
             self.__class__, self._gca_resource, "pipeline_job"
         )
 
-        _LOGGER.info("View Pipeline Job:\n%s" % self._dashboard_uri())
+        _LOGGER.info("View Pipeline Job:\n%s" % self.cloud_console_url)
 
         if experiment:
             self._associate_to_experiment(experiment)
@@ -415,7 +415,8 @@ class PipelineJob(
         """
         return self.state == gca_pipeline_state.PipelineState.PIPELINE_STATE_FAILED
 
-    def _dashboard_uri(self) -> str:
+    @property
+    def cloud_console_url(self) -> str:
         """Helper method to compose the dashboard uri where pipeline can be
         viewed."""
         fields = self._parse_resource_name(self.resource_name)


### PR DESCRIPTION
The property returns a URL that leads to Google Cloud console page showing the resource.

The URL works for most resources, but not for all.
For example the correct URL for PipelineJob is
https://console.cloud.google.com/vertex-ai/locations/us-central1/pipelines/runs/<id>?project=<project>
instead of
https://console.cloud.google.com/vertex-ai/locations/us-central1/pipelineJobs/<id>?project=<project>

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-aiplatform/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
