### PR TITLE
chore: fix param names in experiments samples

### DIFF
--- a/samples/model-builder/experiment_tracking/log_metrics_sample.py
+++ b/samples/model-builder/experiment_tracking/log_metrics_sample.py
@@ -25,9 +25,9 @@ def log_metrics_sample(
     project: str,
     location: str,
 ):
-    aiplatform.init(experiment_name=experiment_name, project=project, location=location)
+    aiplatform.init(experiment=experiment_name, project=project, location=location)
 
-    aiplatform.start_run(run_name=run_name, resume=True)
+    aiplatform.start_run(run=run_name, resume=True)
 
     aiplatform.log_metrics(metrics)
 

--- a/samples/model-builder/experiment_tracking/log_params_sample.py
+++ b/samples/model-builder/experiment_tracking/log_params_sample.py
@@ -25,9 +25,9 @@ def log_params_sample(
     project: str,
     location: str,
 ):
-    aiplatform.init(experiment_name=experiment_name, project=project, location=location)
+    aiplatform.init(experiment=experiment_name, project=project, location=location)
 
-    aiplatform.start_run(run_name=run_name, resume=True)
+    aiplatform.start_run(run=run_name, resume=True)
 
     aiplatform.log_params(params)
 


### PR DESCRIPTION
Use correct param names (`experiment` and `run`) in experiments samples. See [here](https://github.com/googleapis/python-aiplatform/blob/34bbd0abbaf29e644ed7703b3251f1de65bf5a86/google/cloud/aiplatform/initializer.py#L60) and [here](https://github.com/googleapis/python-aiplatform/blob/34bbd0abbaf29e644ed7703b3251f1de65bf5a86/google/cloud/aiplatform/metadata/metadata.py#L245).

Fixes #1605 🦕
