### PR TITLE
chore: e2e tabular system test improvement

### DIFF
--- a/tests/system/aiplatform/e2e_base.py
+++ b/tests/system/aiplatform/e2e_base.py
@@ -35,6 +35,12 @@ _PROJECT = os.getenv("BUILD_SPECIFIC_GCLOUD_PROJECT")
 _VPC_NETWORK_URI = os.getenv("_VPC_NETWORK_URI")
 _LOCATION = "us-central1"
 
+_PROJECT_NUMBER = (
+    resourcemanager.ProjectsClient()
+    .get_project(name=f"projects/{_PROJECT}")
+    .name.split("/", 1)[1]
+)
+
 
 class TestEndToEnd(metaclass=abc.ABCMeta):
     @property
@@ -86,13 +92,7 @@ class TestEndToEnd(metaclass=abc.ABCMeta):
 
         # TODO(#1415) Once PR Is merged, use the added utilities to
         # provide create/view access to Pipeline's default service account (compute)
-        project_number = (
-            resourcemanager.ProjectsClient()
-            .get_project(name=f"projects/{_PROJECT}")
-            .name.split("/", 1)[1]
-        )
-
-        service_account = f"{project_number}-compute@developer.gserviceaccount.com"
+        service_account = f"{_PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
         bucket_iam_policy = bucket.get_iam_policy()
         bucket_iam_policy.setdefault("roles/storage.objectCreator", set()).add(
             f"serviceAccount:{service_account}"

--- a/tests/system/aiplatform/test_e2e_tabular.py
+++ b/tests/system/aiplatform/test_e2e_tabular.py
@@ -81,7 +81,6 @@ class TestEndToEndTabular(e2e_base.TestEndToEnd):
         )
 
         # Create and import to single managed dataset for both training jobs
-
         dataset_gcs_source = f'gs://{shared_state["staging_bucket_name"]}/{_BLOB_PATH}'
 
         ds = aiplatform.TabularDataset.create(
@@ -94,7 +93,6 @@ class TestEndToEndTabular(e2e_base.TestEndToEnd):
         shared_state["resources"].extend([ds])
 
         # Define both training jobs
-
         custom_job = aiplatform.CustomTrainingJob(
             display_name=self._make_display_name("train-housing-custom"),
             script_path=_LOCAL_TRAINING_SCRIPT_PATH,
@@ -110,7 +108,6 @@ class TestEndToEndTabular(e2e_base.TestEndToEnd):
         )
 
         # Kick off both training jobs to check they are started correctly, then cancel the AutoML job
-
         custom_model = custom_job.run(
             ds,
             replica_count=1,

--- a/tests/system/aiplatform/test_e2e_tabular.py
+++ b/tests/system/aiplatform/test_e2e_tabular.py
@@ -46,7 +46,7 @@ _INSTANCE = {
     "median_income": 3.014700,
 }
 
-_AUTOML_MODEL_PERMANENT_ENDPOINT_RESOURCE_NAME = f"projects/{e2e_base._PROJECT_NUMBER}/locations/us-central1/endpoints/4728348600180932608"
+_PERMANENT_AUTOML_MODEL_RESOURCE_NAME = f"projects/{e2e_base._PROJECT_NUMBER}/locations/us-central1/models/6591277539400876032"
 
 
 @pytest.mark.usefixtures(
@@ -137,16 +137,17 @@ class TestEndToEndTabular(e2e_base.TestEndToEnd):
         # Cancel the AutoML job once it's successfully been created, this is async
         automl_job.cancel()
 
-        shared_state["resources"].extend([automl_job, custom_job, custom_model])
+        shared_state["resources"].extend([custom_job, custom_model])
 
         # Deploy the custom model after training completes
         custom_endpoint = custom_model.deploy(machine_type="n1-standard-4", sync=False)
-        shared_state["resources"].extend([custom_endpoint])
 
-        # Create a reference to the permanent AutoML endpoint
-        automl_endpoint = aiplatform.Endpoint(
-            endpoint_name=_AUTOML_MODEL_PERMANENT_ENDPOINT_RESOURCE_NAME
+        # Create a reference to the permanent AutoML model and deloy it to a temporary endpoint
+        automl_model = aiplatform.Model(
+            model_name=_PERMANENT_AUTOML_MODEL_RESOURCE_NAME
         )
+        automl_endpoint = automl_model.deploy(machine_type="n1-standard-4", sync=False)
+        shared_state["resources"].extend([custom_endpoint, automl_endpoint])
 
         custom_batch_prediction_job = custom_model.batch_predict(
             job_display_name=self._make_display_name("automl-housing-model"),

--- a/tests/system/aiplatform/test_e2e_tabular.py
+++ b/tests/system/aiplatform/test_e2e_tabular.py
@@ -46,7 +46,7 @@ _INSTANCE = {
     "median_income": 3.014700,
 }
 
-_AUTOML_MODEL_PERMANENT_ENDPOINT_RESOURCE_NAME = f"projects/{e2e_base._PROJECT_NUMBER}/locations/us-central1/endpoints/TODO"
+_AUTOML_MODEL_PERMANENT_ENDPOINT_RESOURCE_NAME = f"projects/{e2e_base._PROJECT_NUMBER}/locations/us-central1/endpoints/4728348600180932608"
 
 
 @pytest.mark.usefixtures(
@@ -122,7 +122,7 @@ class TestEndToEndTabular(e2e_base.TestEndToEnd):
             create_request_timeout=None,
         )
 
-        automl_model = automl_job.run(
+        automl_job.run(
             dataset=ds,
             target_column="median_house_value",
             model_display_name=self._make_display_name("automl-housing-model"),
@@ -134,17 +134,10 @@ class TestEndToEndTabular(e2e_base.TestEndToEnd):
         ):
             time.sleep(5)
 
-        # Cancel the job once it's successfully been created
+        # Cancel the AutoML job once it's successfully been created, this is async
         automl_job.cancel()
 
-        assert (
-            automl_job.state
-            == gca_pipeline_state.PipelineState.PIPELINE_STATE_CANCELLED
-        )
-
-        shared_state["resources"].extend(
-            [automl_job, automl_model, custom_job, custom_model]
-        )
+        shared_state["resources"].extend([automl_job, custom_job, custom_model])
 
         # Deploy the custom model after training completes
         custom_endpoint = custom_model.deploy(machine_type="n1-standard-4", sync=False)
@@ -210,6 +203,10 @@ class TestEndToEndTabular(e2e_base.TestEndToEnd):
         assert (
             custom_batch_prediction_job.state
             == gca_job_state.JobState.JOB_STATE_SUCCEEDED
+        )
+        assert (
+            automl_job.state
+            == gca_pipeline_state.PipelineState.PIPELINE_STATE_CANCELLED
         )
 
         # Ensure a single prediction was returned


### PR DESCRIPTION
Removed AutoML model training from `tests/system/aiplatform/test_e2e_tabular`. This update creates the training job, checks the state is `RUNNING`, and then cancels it. 

The prediction test references a permanent tabular endpoint resource I set up. Based on the time improvements we get from this, we can consider doing the same for other tests that train AutoML models.

Fixes b/244325057 🦕
