### PR TITLE
chore: add aiplatform.init back to model monitoring system tests

### DIFF
--- a/tests/system/aiplatform/test_model_monitoring.py
+++ b/tests/system/aiplatform/test_model_monitoring.py
@@ -99,6 +99,10 @@ objective_config2 = model_monitoring.ObjectiveConfig(skew_config, drift_config2)
 
 class TestModelDeploymentMonitoring(e2e_base.TestEndToEnd):
     _temp_prefix = "temp_e2e_model_monitoring_test_"
+    aiplatform.init(
+        project = e2e_base._PROJECT,
+        location = e2e_base._LOCATION
+    )
     endpoint = aiplatform.Endpoint(PERMANENT_CHURN_ENDPOINT_ID)
 
     def test_mdm_two_models_one_valid_config(self):

--- a/tests/system/aiplatform/test_model_monitoring.py
+++ b/tests/system/aiplatform/test_model_monitoring.py
@@ -99,10 +99,7 @@ objective_config2 = model_monitoring.ObjectiveConfig(skew_config, drift_config2)
 
 class TestModelDeploymentMonitoring(e2e_base.TestEndToEnd):
     _temp_prefix = "temp_e2e_model_monitoring_test_"
-    aiplatform.init(
-        project = e2e_base._PROJECT,
-        location = e2e_base._LOCATION
-    )
+    aiplatform.init(project=e2e_base._PROJECT, location=e2e_base._LOCATION)
     endpoint = aiplatform.Endpoint(PERMANENT_CHURN_ENDPOINT_ID)
 
     def test_mdm_two_models_one_valid_config(self):


### PR DESCRIPTION
System test was erroring out due to missing `aiplatform.init` in refactored model monitoring system test. As a result, kokoro picked a random test project for this script to run in. 
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-aiplatform/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
