### PR TITLE
chore: add aiplatform.init to test_model_interactions.py

### DIFF
--- a/tests/system/aiplatform/test_model_interactions.py
+++ b/tests/system/aiplatform/test_model_interactions.py
@@ -32,6 +32,7 @@ _PREDICTION_INSTANCE = {
 
 class TestModelInteractions(e2e_base.TestEndToEnd):
     _temp_prefix = ""
+    aiplatform.init(project=e2e_base._PROJECT, location=e2e_base._LOCATION)
     endpoint = aiplatform.Endpoint(_PERMANENT_IRIS_ENDPOINT_ID)
 
     def test_prediction(self):


### PR DESCRIPTION
This fixes the test failures in `test_model_interactions.py`. Note to self: `aiplatform.init` needs to be called at the beginning of every system test, otherwise kokoro randomly assigns a project number to the test suite. 

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-aiplatform/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
