### PR TITLE
feat: adding Python 3.10 support + updating google-vizier version

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ In order to add a feature:
   documentation.
 
 - The feature must work fully on the following CPython versions:
-  3.7, 3.8 and 3.9 on both UNIX and Windows.
+  3.7, 3.8, 3.9, and 3.10 on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should
@@ -72,7 +72,7 @@ We use `nox <https://nox.readthedocs.io/en/latest/>`__ to instrument our tests.
 
 - To run a single unit test::
 
-    $ nox -s unit-3.9 -- -k <name of test>
+    $ nox -s unit-3.10 -- -k <name of test>
 
 
   .. note::
@@ -224,10 +224,12 @@ We support:
 -  `Python 3.7`_
 -  `Python 3.8`_
 -  `Python 3.9`_
+-  `Python 3.10`_
 
 .. _Python 3.7: https://docs.python.org/3.7/
 .. _Python 3.8: https://docs.python.org/3.8/
 .. _Python 3.9: https://docs.python.org/3.9/
+.. _Python 3.9: https://docs.python.org/3.10/
 
 
 Supported versions can be found in our ``noxfile.py`` `config`_.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -229,7 +229,7 @@ We support:
 .. _Python 3.7: https://docs.python.org/3.7/
 .. _Python 3.8: https://docs.python.org/3.8/
 .. _Python 3.9: https://docs.python.org/3.9/
-.. _Python 3.9: https://docs.python.org/3.10/
+.. _Python 3.10: https://docs.python.org/3.10/
 
 
 Supported versions can be found in our ``noxfile.py`` `config`_.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ In order to add a feature:
   documentation.
 
 - The feature must work fully on the following CPython versions:
-  3.7, 3.8, 3.9, and 3.10 on both UNIX and Windows.
+  3.7, 3.8, 3.9 and 3.10 on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should

--- a/google/cloud/aiplatform/vizier/pyvizier/__init__.py
+++ b/google/cloud/aiplatform/vizier/pyvizier/__init__.py
@@ -33,7 +33,7 @@ try:
 except ImportError:
     raise ImportError(
         "Google-vizier is not installed, and is required to use Vizier client."
-        'Please install the SDK using "pip install google-vizier==0.0.3a"'
+        'Please install the SDK using "pip install google-vizier==0.0.4"'
     )
 
 from google.cloud.aiplatform.vizier.pyvizier.proto_converters import TrialConverter

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,7 +31,7 @@ LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 DEFAULT_PYTHON_VERSION = "3.8"
 
-UNIT_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9"]
+UNIT_TEST_PYTHON_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     "asyncmock",

--- a/owlbot.py
+++ b/owlbot.py
@@ -88,7 +88,7 @@ s.remove_staging_dirs()
 templated_files = common.py_library(
     cov_level=98,
     system_test_python_versions=["3.8"],
-    unit_test_python_versions=["3.7", "3.8", "3.9"],
+    unit_test_python_versions=["3.7", "3.8", "3.9", "3.10"],
     unit_test_extras=["testing"],
     system_test_extras=["testing"],
     microgenerator=True,

--- a/setup.py
+++ b/setup.py
@@ -161,6 +161,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Internet",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,7 @@ vizier_extra_require = [
     "portpicker==1.3.1",
     "googleapis-common-protos==1.56.0",
     "google-api-python-client==1.12.8",
-    "google-vizier==0.0.3a",
-    "pytype"
+    "google-vizier==0.0.4",
 ]
 
 prediction_extra_require = [

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ vizier_extra_require = [
     "googleapis-common-protos==1.56.0",
     "google-api-python-client==1.12.8",
     "google-vizier==0.0.3a",
+    "pytype"
 ]
 
 prediction_extra_require = [


### PR DESCRIPTION
Hey @parthea, I think we're ready to support Python version 3.10 (TensorFlow now supports Python 3.10). Is there more to do for 3.10 support other than adding the extra line to `setup.py` (I'm assuming this change will automatically update the related files) or will I need to manually add to `CONTRIBUTING.rst`, `noxfile.py`, and `owlbot.py` (according to https://github.com/googleapis/python-aiplatform/pull/831)?

Thanks,
Nishant
