### PR TITLE
feat: add eval metrics types to get_experiment_df

### DIFF
--- a/google/cloud/aiplatform/metadata/constants.py
+++ b/google/cloud/aiplatform/metadata/constants.py
@@ -22,6 +22,9 @@ SYSTEM_EXPERIMENT_RUN = "system.ExperimentRun"
 SYSTEM_PIPELINE = "system.Pipeline"
 SYSTEM_PIPELINE_RUN = "system.PipelineRun"
 SYSTEM_METRICS = "system.Metrics"
+GOOGLE_CLASSIFICATION_METRICS = "google.ClassificationMetrics"
+GOOGLE_REGRESSION_METRICS = "google.RegressionMetrics"
+GOOGLE_FORECASTING_METRICS = "google.ForecastingMetrics"
 
 _EXPERIMENTS_V2_TENSORBOARD_RUN = "google.VertexTensorboardRun"
 

--- a/google/cloud/aiplatform/pipeline_jobs.py
+++ b/google/cloud/aiplatform/pipeline_jobs.py
@@ -633,10 +633,14 @@ class PipelineJob(
             credentials=node.credentials,
             filter=metadata_utils._make_filter_string(
                 in_context=[node.resource_name],
-                schema_title=metadata_constants.SYSTEM_METRICS,
+                schema_title=[
+                    metadata_constants.SYSTEM_METRICS,
+                    metadata_constants.GOOGLE_CLASSIFICATION_METRICS,
+                    metadata_constants.GOOGLE_REGRESSION_METRICS,
+                    metadata_constants.GOOGLE_FORECASTING_METRICS,
+                ],
             ),
         )
-
         row = experiment_resources._ExperimentRow(
             experiment_run_type=node.schema_title, name=node.display_name
         )

--- a/tests/unit/aiplatform/test_metadata.py
+++ b/tests/unit/aiplatform/test_metadata.py
@@ -1352,7 +1352,12 @@ class TestExperiments:
 
         expected_filter = metadata_utils._make_filter_string(
             in_context=[_TEST_PIPELINE_CONTEXT.name],
-            schema_title=constants.SYSTEM_METRICS,
+            schema_title=[
+                constants.SYSTEM_METRICS,
+                constants.GOOGLE_CLASSIFICATION_METRICS,
+                constants.GOOGLE_REGRESSION_METRICS,
+                constants.GOOGLE_FORECASTING_METRICS,
+            ],
         )
 
         list_artifact_mock_for_experiment_dataframe.assert_has_calls(


### PR DESCRIPTION
Add new Model Evaluation metric schema types to `get_experiment_df`. With this addition, calling `get_experiment_df` will return metrics produced by Model Evaluation pipelines.
