### PR TITLE
fix: project/location parsing for nested resources

### DIFF
--- a/google/cloud/aiplatform/base.py
+++ b/google/cloud/aiplatform/base.py
@@ -1078,7 +1078,9 @@ class VertexAiResourceNounWithFutureManager(VertexAiResourceNoun, FutureManager)
             List[VertexAiResourceNoun] - A list of SDK resource objects
         """
         if parent:
-            project, location = utils.extract_project_and_location_from_parent(parent)
+            parent_resources  = utils.extract_project_and_location_from_parent(parent)
+            if parent_resources:
+                project, location = parent_resources["project"], parent_resources["location"]
 
         resource = cls._empty_constructor(
             project=project, location=location, credentials=credentials

--- a/google/cloud/aiplatform/base.py
+++ b/google/cloud/aiplatform/base.py
@@ -1079,8 +1079,6 @@ class VertexAiResourceNounWithFutureManager(VertexAiResourceNoun, FutureManager)
         """
         if parent:
             project, location = utils.extract_project_and_location_from_parent(parent)
-        print(project)
-        print(location)
 
         resource = cls._empty_constructor(
             project=project, location=location, credentials=credentials

--- a/google/cloud/aiplatform/base.py
+++ b/google/cloud/aiplatform/base.py
@@ -1078,10 +1078,9 @@ class VertexAiResourceNounWithFutureManager(VertexAiResourceNoun, FutureManager)
             List[VertexAiResourceNoun] - A list of SDK resource objects
         """
         if parent:
-            project, location = cls._parse_resource_name(parent)
+            project, location = utils.extract_project_and_location_from_parent(parent)
         print(project)
         print(location)
-
 
         resource = cls._empty_constructor(
             project=project, location=location, credentials=credentials

--- a/google/cloud/aiplatform/base.py
+++ b/google/cloud/aiplatform/base.py
@@ -1078,9 +1078,12 @@ class VertexAiResourceNounWithFutureManager(VertexAiResourceNoun, FutureManager)
             List[VertexAiResourceNoun] - A list of SDK resource objects
         """
         if parent:
-            parent_resources  = utils.extract_project_and_location_from_parent(parent)
+            parent_resources = utils.extract_project_and_location_from_parent(parent)
             if parent_resources:
-                project, location = parent_resources["project"], parent_resources["location"]
+                project, location = (
+                    parent_resources["project"],
+                    parent_resources["location"],
+                )
 
         resource = cls._empty_constructor(
             project=project, location=location, credentials=credentials

--- a/google/cloud/aiplatform/base.py
+++ b/google/cloud/aiplatform/base.py
@@ -1077,6 +1077,11 @@ class VertexAiResourceNounWithFutureManager(VertexAiResourceNoun, FutureManager)
         Returns:
             List[VertexAiResourceNoun] - A list of SDK resource objects
         """
+        if parent:
+            project, location = cls._parse_resource_name(parent)
+        print(project)
+        print(location)
+
 
         resource = cls._empty_constructor(
             project=project, location=location, credentials=credentials

--- a/google/cloud/aiplatform/utils/__init__.py
+++ b/google/cloud/aiplatform/utils/__init__.py
@@ -324,6 +324,32 @@ def extract_bucket_and_prefix_from_gcs_path(gcs_path: str) -> Tuple[str, Optiona
 
     return (gcs_bucket, gcs_blob_prefix)
 
+def extract_project_and_location_from_parent(parent: str) -> Tuple[str, str]:
+    """Given a complete parent resource name, return the project and location as a tuple.
+
+    Example Usage:
+
+        project, location = extract_project_and_location_from_parent(
+            "projects/123/locations/us-central1/datasets/456"
+        )
+
+        project = "123"
+        location = "us-central1"
+
+    Args:
+        parent (str):
+            Required. A complete parent resource name.
+
+    Returns:
+        Tuple[str, str]
+            A (project, location) pair from provided parent resource name.
+    """
+    parent_parts = parent.split("/", 4)
+    parent_project =  None if len(parent_parts) == 1 else parent_parts[1]
+    parent_location = None if len(parent_parts) < 4 else parent_parts[3]
+
+    return (parent_project, parent_location)
+
 
 class ClientWithOverride:
     class WrappedClient:

--- a/google/cloud/aiplatform/utils/__init__.py
+++ b/google/cloud/aiplatform/utils/__init__.py
@@ -327,7 +327,7 @@ def extract_bucket_and_prefix_from_gcs_path(gcs_path: str) -> Tuple[str, Optiona
 
 def extract_project_and_location_from_parent(
     parent: str,
-) -> Dict[Optional[str], Optional[str]]:
+) -> Dict[str, str]:
     """Given a complete parent resource name, return the project and location as a dict.
 
     Example Usage:
@@ -344,7 +344,7 @@ def extract_project_and_location_from_parent(
             Required. A complete parent resource name.
 
     Returns:
-        Dict[Optional[str], Optional[str]
+        Dict[str, str]
             A project, location dict from provided parent resource name.
     """
     parent_resources = re.match(

--- a/google/cloud/aiplatform/utils/__init__.py
+++ b/google/cloud/aiplatform/utils/__init__.py
@@ -324,7 +324,10 @@ def extract_bucket_and_prefix_from_gcs_path(gcs_path: str) -> Tuple[str, Optiona
 
     return (gcs_bucket, gcs_blob_prefix)
 
-def extract_project_and_location_from_parent(parent: str) -> Dict[Optional[str], Optional[str]]:
+
+def extract_project_and_location_from_parent(
+    parent: str,
+) -> Dict[Optional[str], Optional[str]]:
     """Given a complete parent resource name, return the project and location as a dict.
 
     Example Usage:
@@ -344,7 +347,9 @@ def extract_project_and_location_from_parent(parent: str) -> Dict[Optional[str],
         Dict[Optional[str], Optional[str]
             A project, location dict from provided parent resource name.
     """
-    parent_resources = re.match(r"^projects/(?P<project>.+?)/locations/(?P<location>.+?)(/|$)", parent)
+    parent_resources = re.match(
+        r"^projects/(?P<project>.+?)/locations/(?P<location>.+?)(/|$)", parent
+    )
     return parent_resources.groupdict() if parent_resources else {}
 
 

--- a/google/cloud/aiplatform/utils/__init__.py
+++ b/google/cloud/aiplatform/utils/__init__.py
@@ -324,8 +324,8 @@ def extract_bucket_and_prefix_from_gcs_path(gcs_path: str) -> Tuple[str, Optiona
 
     return (gcs_bucket, gcs_blob_prefix)
 
-def extract_project_and_location_from_parent(parent: str) -> Tuple[str, str]:
-    """Given a complete parent resource name, return the project and location as a tuple.
+def extract_project_and_location_from_parent(parent: str) -> Dict[Optional[str], Optional[str]]:
+    """Given a complete parent resource name, return the project and location as a dict.
 
     Example Usage:
 
@@ -344,11 +344,8 @@ def extract_project_and_location_from_parent(parent: str) -> Tuple[str, str]:
         Tuple[str, str]
             A (project, location) pair from provided parent resource name.
     """
-    parent_parts = parent.split("/", 4)
-    parent_project =  None if len(parent_parts) == 1 else parent_parts[1]
-    parent_location = None if len(parent_parts) < 4 else parent_parts[3]
-
-    return (parent_project, parent_location)
+    parent_resources = re.match(r"^projects/(?P<project>.+?)/locations/(?P<location>.+?)$", parent)
+    return parent_resources.groupdict() if parent_resources else {}
 
 
 class ClientWithOverride:

--- a/google/cloud/aiplatform/utils/__init__.py
+++ b/google/cloud/aiplatform/utils/__init__.py
@@ -329,22 +329,22 @@ def extract_project_and_location_from_parent(parent: str) -> Dict[Optional[str],
 
     Example Usage:
 
-        project, location = extract_project_and_location_from_parent(
+        parent_resources = extract_project_and_location_from_parent(
             "projects/123/locations/us-central1/datasets/456"
         )
 
-        project = "123"
-        location = "us-central1"
+        parent_resources["project"] = "123"
+        parent_resources["location"] = "us-central1"
 
     Args:
         parent (str):
             Required. A complete parent resource name.
 
     Returns:
-        Tuple[str, str]
-            A (project, location) pair from provided parent resource name.
+        Dict[Optional[str], Optional[str]
+            A project, location dict from provided parent resource name.
     """
-    parent_resources = re.match(r"^projects/(?P<project>.+?)/locations/(?P<location>.+?)$", parent)
+    parent_resources = re.match(r"^projects/(?P<project>.+?)/locations/(?P<location>.+?)(/|$)", parent)
     return parent_resources.groupdict() if parent_resources else {}
 
 

--- a/tests/unit/aiplatform/test_featurestores.py
+++ b/tests/unit/aiplatform/test_featurestores.py
@@ -1812,7 +1812,7 @@ class TestEntityType:
             entity_type_name=_TEST_ENTITY_TYPE_ID,
             featurestore_id=_TEST_FEATURESTORE_ID,
             project=_TEST_PROJECT,
-            location=_TEST_LOCATION
+            location=_TEST_LOCATION,
         )
         my_feature_list = my_entity_type.list_features()
 

--- a/tests/unit/aiplatform/test_featurestores.py
+++ b/tests/unit/aiplatform/test_featurestores.py
@@ -1035,9 +1035,7 @@ class TestFeaturestore:
             assert type(my_entity_type) == aiplatform.EntityType
 
     @pytest.mark.usefixtures("get_featurestore_mock")
-    def test_list_entity_types_with_project_and_location(self, list_entity_types_mock):
-        aiplatform.init(project=_TEST_PROJECT)
-
+    def test_list_entity_types_with_no_init(self, list_entity_types_mock):
         my_featurestore = aiplatform.Featurestore(
             featurestore_name=_TEST_FEATURESTORE_ID,
             project=_TEST_PROJECT,
@@ -1799,6 +1797,23 @@ class TestEntityType:
         aiplatform.init(project=_TEST_PROJECT)
 
         my_entity_type = aiplatform.EntityType(entity_type_name=_TEST_ENTITY_TYPE_NAME)
+        my_feature_list = my_entity_type.list_features()
+
+        list_features_mock.assert_called_once_with(
+            request={"parent": _TEST_ENTITY_TYPE_NAME}
+        )
+        assert len(my_feature_list) == len(_TEST_FEATURE_LIST)
+        for my_feature in my_feature_list:
+            assert type(my_feature) == aiplatform.Feature
+
+    @pytest.mark.usefixtures("get_entity_type_mock")
+    def test_list_features_with_no_init(self, list_features_mock):
+        my_entity_type = aiplatform.EntityType(
+            entity_type_name=_TEST_ENTITY_TYPE_ID,
+            featurestore_id=_TEST_FEATURESTORE_ID,
+            project=_TEST_PROJECT,
+            location=_TEST_LOCATION
+        )
         my_feature_list = my_entity_type.list_features()
 
         list_features_mock.assert_called_once_with(

--- a/tests/unit/aiplatform/test_featurestores.py
+++ b/tests/unit/aiplatform/test_featurestores.py
@@ -1023,7 +1023,25 @@ class TestFeaturestore:
         aiplatform.init(project=_TEST_PROJECT)
 
         my_featurestore = aiplatform.Featurestore(
-            featurestore_name=_TEST_FEATURESTORE_ID
+            featurestore_name=_TEST_FEATURESTORE_ID,
+        )
+        my_entity_type_list = my_featurestore.list_entity_types()
+
+        list_entity_types_mock.assert_called_once_with(
+            request={"parent": _TEST_FEATURESTORE_NAME}
+        )
+        assert len(my_entity_type_list) == len(_TEST_ENTITY_TYPE_LIST)
+        for my_entity_type in my_entity_type_list:
+            assert type(my_entity_type) == aiplatform.EntityType
+
+    @pytest.mark.usefixtures("get_featurestore_mock")
+    def test_list_entity_types_with_project_and_location(self, list_entity_types_mock):
+        aiplatform.init(project=_TEST_PROJECT)
+
+        my_featurestore = aiplatform.Featurestore(
+            featurestore_name=_TEST_FEATURESTORE_ID,
+            project=_TEST_PROJECT,
+            location=_TEST_LOCATION,
         )
         my_entity_type_list = my_featurestore.list_entity_types()
 
@@ -1762,7 +1780,7 @@ class TestEntityType:
     @pytest.mark.parametrize(
         "featurestore_name", [_TEST_FEATURESTORE_NAME, _TEST_FEATURESTORE_ID]
     )
-    def test_list_entity_types(self, featurestore_name, list_entity_types_mock):
+    def test_list_entity_type(self, featurestore_name, list_entity_types_mock):
         aiplatform.init(project=_TEST_PROJECT)
 
         my_entity_type_list = aiplatform.EntityType.list(

--- a/tests/unit/aiplatform/test_utils.py
+++ b/tests/unit/aiplatform/test_utils.py
@@ -322,11 +322,11 @@ def test_extract_bucket_and_prefix_from_gcs_path(gcs_path: str, expected: tuple)
 @pytest.mark.parametrize(
     "parent, expected",
     [
-        ("projects/123/locations/us-central1/datasets/456", {}),
-        ("example-bucket/path/to/folder/", ("example-bucket", "path/to/folder")),
-        ("gs://example-bucket", ("example-bucket", None)),
-        ("gs://example-bucket/", ("example-bucket", None)),
-        ("gs://example-bucket/path", ("example-bucket", "path")),
+        ("projects/123/locations/us-central1/datasets/456", {'project': '123', 'location': 'us-central1'}),
+        ("projects/123/locations/us-central1/", {'project': '123', 'location': 'us-central1'}),
+        ("projects/123/locations/us-central1", {'project': '123', 'location': 'us-central1'}),
+        ("projects/123/locations/", {}),
+        ("projects/123", {}),
     ],
 )
 def test_extract_project_and_location_from_parent(parent: str, expected: tuple):

--- a/tests/unit/aiplatform/test_utils.py
+++ b/tests/unit/aiplatform/test_utils.py
@@ -319,12 +319,22 @@ def test_extract_bucket_and_prefix_from_gcs_path(gcs_path: str, expected: tuple)
     # Given a GCS path, ensure correct bucket and prefix are extracted
     assert expected == utils.extract_bucket_and_prefix_from_gcs_path(gcs_path)
 
+
 @pytest.mark.parametrize(
     "parent, expected",
     [
-        ("projects/123/locations/us-central1/datasets/456", {'project': '123', 'location': 'us-central1'}),
-        ("projects/123/locations/us-central1/", {'project': '123', 'location': 'us-central1'}),
-        ("projects/123/locations/us-central1", {'project': '123', 'location': 'us-central1'}),
+        (
+            "projects/123/locations/us-central1/datasets/456",
+            {"project": "123", "location": "us-central1"},
+        ),
+        (
+            "projects/123/locations/us-central1/",
+            {"project": "123", "location": "us-central1"},
+        ),
+        (
+            "projects/123/locations/us-central1",
+            {"project": "123", "location": "us-central1"},
+        ),
         ("projects/123/locations/", {}),
         ("projects/123", {}),
     ],

--- a/tests/unit/aiplatform/test_utils.py
+++ b/tests/unit/aiplatform/test_utils.py
@@ -319,6 +319,20 @@ def test_extract_bucket_and_prefix_from_gcs_path(gcs_path: str, expected: tuple)
     # Given a GCS path, ensure correct bucket and prefix are extracted
     assert expected == utils.extract_bucket_and_prefix_from_gcs_path(gcs_path)
 
+@pytest.mark.parametrize(
+    "parent, expected",
+    [
+        ("projects/123/locations/us-central1/datasets/456", {}),
+        ("example-bucket/path/to/folder/", ("example-bucket", "path/to/folder")),
+        ("gs://example-bucket", ("example-bucket", None)),
+        ("gs://example-bucket/", ("example-bucket", None)),
+        ("gs://example-bucket/path", ("example-bucket", "path")),
+    ],
+)
+def test_extract_project_and_location_from_parent(parent: str, expected: tuple):
+    # Given a GCS path, ensure correct bucket and prefix are extracted
+    assert expected == utils.extract_project_and_location_from_parent(parent)
+
 
 @pytest.mark.usefixtures("google_auth_mock")
 def test_wrapped_client():

--- a/tests/unit/aiplatform/test_utils.py
+++ b/tests/unit/aiplatform/test_utils.py
@@ -340,7 +340,7 @@ def test_extract_bucket_and_prefix_from_gcs_path(gcs_path: str, expected: tuple)
     ],
 )
 def test_extract_project_and_location_from_parent(parent: str, expected: tuple):
-    # Given a GCS path, ensure correct bucket and prefix are extracted
+    # Given a parent resource name, ensure correct project and location are extracted
     assert expected == utils.extract_project_and_location_from_parent(parent)
 
 


### PR DESCRIPTION
 For nested resources like EntityType (Featurestore -> EntityType -> Feature), the project/location needs to be extracted from the full resource name and passed into the client constructor. Adding check to see if parent exists and utility method to extract project and location from the parent resource name.
 
Fixes [b/249363374](https://b.corp.google.com/issues/249363374) and https://github.com/googleapis/python-aiplatform/issues/1684 🦕
