### PR TITLE
chore: adding SDK team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# @googleapis/cdpe-cloudai and yoshi-python are the default owners
+# @googleapis/cdpe-cloudai, yoshi-python, and the Vertex SDK dev team are the default owners
 *                                      @googleapis/cdpe-cloudai @googleapis/yoshi-python @googleapis/cloud-aiplatform-model-builder-sdk
 
 # The AI Platform GAPIC libraries are owned by Cloud AI DPE

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# @googleapis/cdpe-cloudai, yoshi-python, and the Vertex SDK dev team are the default owners
+# The Clous AI DPE team, Yoshi Python team, and the Vertex SDK dev team are the default owners
 *                                      @googleapis/cdpe-cloudai @googleapis/yoshi-python @googleapis/cloud-aiplatform-model-builder-sdk
 
 # The AI Platform GAPIC libraries are owned by Cloud AI DPE

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The Clous AI DPE team, Yoshi Python team, and the Vertex SDK dev team are the default owners
+# The Cloud AI DPE team, Yoshi Python team, and the Vertex SDK dev team are the default owners
 *                                      @googleapis/cdpe-cloudai @googleapis/yoshi-python @googleapis/cloud-aiplatform-model-builder-sdk
 
 # The AI Platform GAPIC libraries are owned by Cloud AI DPE

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 # @googleapis/cdpe-cloudai and yoshi-python are the default owners
-*                                      @googleapis/cdpe-cloudai @googleapis/yoshi-python
+*                                      @googleapis/cdpe-cloudai @googleapis/yoshi-python @googleapis/cloud-aiplatform-model-builder-sdk
 
 # The AI Platform GAPIC libraries are owned by Cloud AI DPE
 /google/cloud/aiplatform_*/**          @googleapis/cdpe-cloudai


### PR DESCRIPTION
Adding SDK eng team to default owners of codebase. Files without explicit ownership in the repo will require all three parties to approve.