### PR TITLE
fix: PipelineJob should only pass bearer tokens for AR URIs

### DIFF
--- a/google/cloud/aiplatform/utils/yaml_utils.py
+++ b/google/cloud/aiplatform/utils/yaml_utils.py
@@ -52,8 +52,10 @@ def load_yaml(
     if path.startswith("gs://"):
         return _load_yaml_from_gs_uri(path, project, credentials)
     elif path.startswith("http://") or path.startswith("https://"):
-        if _VALID_AR_URL.match(path) or _VALID_HTTPS_URL.match(path):
+        if _VALID_AR_URL.match(path):
             return _load_yaml_from_https_uri(path, credentials)
+        elif _VALID_HTTPS_URL.match(path):
+            return _load_yaml_from_https_uri(path)
         else:
             raise ValueError(
                 "Invalid HTTPS URI. If not using Artifact Registry, please "

--- a/tests/unit/aiplatform/test_utils.py
+++ b/tests/unit/aiplatform/test_utils.py
@@ -812,7 +812,7 @@ class TestYamlUtils:
         actual = yaml_utils.load_yaml(url, credentials=mock_credentials)
         expected = {"key": "val", "list": ["1", 2, 3.0]}
         assert actual == expected
-        assert mock_urlopen.call_args.args[0].headers == {
+        assert mock_urlopen.call_args[0][0].headers == {
                 'Authorization': 'Bearer some_token'}
 
     @pytest.mark.parametrize(
@@ -833,8 +833,7 @@ class TestYamlUtils:
         actual = yaml_utils.load_yaml(url, credentials=mock_credentials)
         expected = {"key": "val", "list": ["1", 2, 3.0]}
         assert actual == expected
-        raise RuntimeError(mock_urlopen.call_args.args)
-        assert mock_urlopen.call_args.args[0].headers == {}
+        assert mock_urlopen.call_args[0][0].headers == {}
 
     @pytest.mark.parametrize(
         "uri",

--- a/tests/unit/aiplatform/test_utils.py
+++ b/tests/unit/aiplatform/test_utils.py
@@ -805,15 +805,15 @@ class TestYamlUtils:
     )
     def test_load_yaml_from_ar_uri_passes_creds(self, mock_request_urlopen):
         url, mock_urlopen = mock_request_urlopen
-        mock_credentials = mock.create_autospec(
-            credentials.Credentials, instance=True)
+        mock_credentials = mock.create_autospec(credentials.Credentials, instance=True)
         mock_credentials.valid = True
-        mock_credentials.token = 'some_token'
+        mock_credentials.token = "some_token"
         actual = yaml_utils.load_yaml(url, credentials=mock_credentials)
         expected = {"key": "val", "list": ["1", 2, 3.0]}
         assert actual == expected
         assert mock_urlopen.call_args[0][0].headers == {
-                'Authorization': 'Bearer some_token'}
+            "Authorization": "Bearer some_token"
+        }
 
     @pytest.mark.parametrize(
         "mock_request_urlopen",
@@ -826,10 +826,9 @@ class TestYamlUtils:
     )
     def test_load_yaml_from_https_uri_ignores_creds(self, mock_request_urlopen):
         url, mock_urlopen = mock_request_urlopen
-        mock_credentials = mock.create_autospec(
-            credentials.Credentials, instance=True)
+        mock_credentials = mock.create_autospec(credentials.Credentials, instance=True)
         mock_credentials.valid = True
-        mock_credentials.token = 'some_token'
+        mock_credentials.token = "some_token"
         actual = yaml_utils.load_yaml(url, credentials=mock_credentials)
         expected = {"key": "val", "list": ["1", 2, 3.0]}
         assert actual == expected


### PR DESCRIPTION
When downloading compiled KFP pipelines over HTTPS, we only need to pass a bearer token when we need to authenticate for services like Artifact Registry. We may get unexpected behavior passing this token in all HTTPS requests, which is the current behavior.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-aiplatform/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes b/251143831 🦕
