### PR TITLE
fix: Error when only log confusion matrix or ROC curve through log_classification_metrics

### DIFF
--- a/google/cloud/aiplatform/metadata/experiment_run_resource.py
+++ b/google/cloud/aiplatform/metadata/experiment_run_resource.py
@@ -1045,6 +1045,8 @@ class ExperimentRun(
         if (fpr or tpr or threshold) and not (fpr and tpr and threshold):
             raise ValueError("fpr, tpr, and thresholds must be set together.")
 
+        confusion_matrix = confidence_metrics = None
+
         if labels and matrix:
             if len(matrix) != len(labels):
                 raise ValueError(


### PR DESCRIPTION
Fix bug: Get error if users only log confusion matrix or ROC curve through `log_classification_metrics`
