### PR TITLE
feat: regenerate with gapic-generator-python 1.4.4

### DIFF
--- a/google/cloud/aiplatform_v1/__init__.py
+++ b/google/cloud/aiplatform_v1/__init__.py
@@ -142,6 +142,9 @@ from .types.featurestore_online_service import FeatureValueList
 from .types.featurestore_online_service import ReadFeatureValuesRequest
 from .types.featurestore_online_service import ReadFeatureValuesResponse
 from .types.featurestore_online_service import StreamingReadFeatureValuesRequest
+from .types.featurestore_online_service import WriteFeatureValuesPayload
+from .types.featurestore_online_service import WriteFeatureValuesRequest
+from .types.featurestore_online_service import WriteFeatureValuesResponse
 from .types.featurestore_service import BatchCreateFeaturesOperationMetadata
 from .types.featurestore_service import BatchCreateFeaturesRequest
 from .types.featurestore_service import BatchCreateFeaturesResponse
@@ -986,6 +989,9 @@ __all__ = (
     "Value",
     "VizierServiceClient",
     "WorkerPoolSpec",
+    "WriteFeatureValuesPayload",
+    "WriteFeatureValuesRequest",
+    "WriteFeatureValuesResponse",
     "WriteTensorboardExperimentDataRequest",
     "WriteTensorboardExperimentDataResponse",
     "WriteTensorboardRunDataRequest",

--- a/google/cloud/aiplatform_v1/gapic_metadata.json
+++ b/google/cloud/aiplatform_v1/gapic_metadata.json
@@ -227,6 +227,11 @@
               "methods": [
                 "streaming_read_feature_values"
               ]
+            },
+            "WriteFeatureValues": {
+              "methods": [
+                "write_feature_values"
+              ]
             }
           }
         },
@@ -241,6 +246,11 @@
             "StreamingReadFeatureValues": {
               "methods": [
                 "streaming_read_feature_values"
+              ]
+            },
+            "WriteFeatureValues": {
+              "methods": [
+                "write_feature_values"
               ]
             }
           }

--- a/google/cloud/aiplatform_v1/services/featurestore_online_serving_service/async_client.py
+++ b/google/cloud/aiplatform_v1/services/featurestore_online_serving_service/async_client.py
@@ -471,6 +471,136 @@ class FeaturestoreOnlineServingServiceAsyncClient:
         # Done; return the response.
         return response
 
+    async def write_feature_values(
+        self,
+        request: Union[
+            featurestore_online_service.WriteFeatureValuesRequest, dict
+        ] = None,
+        *,
+        entity_type: str = None,
+        payloads: Sequence[
+            featurestore_online_service.WriteFeatureValuesPayload
+        ] = None,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = (),
+    ) -> featurestore_online_service.WriteFeatureValuesResponse:
+        r"""Writes Feature values of one or more entities of an
+        EntityType.
+        The Feature values are merged into existing entities if
+        any. The Feature values to be written must have
+        timestamp within the online storage retention.
+
+        .. code-block:: python
+
+            # This snippet has been automatically generated and should be regarded as a
+            # code template only.
+            # It will require modifications to work:
+            # - It may require correct/in-range values for request initialization.
+            # - It may require specifying regional endpoints when creating the service
+            #   client as shown in:
+            #   https://googleapis.dev/python/google-api-core/latest/client_options.html
+            from google.cloud import aiplatform_v1
+
+            async def sample_write_feature_values():
+                # Create a client
+                client = aiplatform_v1.FeaturestoreOnlineServingServiceAsyncClient()
+
+                # Initialize request argument(s)
+                payloads = aiplatform_v1.WriteFeatureValuesPayload()
+                payloads.entity_id = "entity_id_value"
+
+                request = aiplatform_v1.WriteFeatureValuesRequest(
+                    entity_type="entity_type_value",
+                    payloads=payloads,
+                )
+
+                # Make the request
+                response = await client.write_feature_values(request=request)
+
+                # Handle the response
+                print(response)
+
+        Args:
+            request (Union[google.cloud.aiplatform_v1.types.WriteFeatureValuesRequest, dict]):
+                The request object. Request message for
+                [FeaturestoreOnlineServingService.WriteFeatureValues][google.cloud.aiplatform.v1.FeaturestoreOnlineServingService.WriteFeatureValues].
+            entity_type (:class:`str`):
+                Required. The resource name of the EntityType for the
+                entities being written. Value format:
+                ``projects/{project}/locations/{location}/featurestores/ {featurestore}/entityTypes/{entityType}``.
+                For example, for a machine learning model predicting
+                user clicks on a website, an EntityType ID could be
+                ``user``.
+
+                This corresponds to the ``entity_type`` field
+                on the ``request`` instance; if ``request`` is provided, this
+                should not be set.
+            payloads (:class:`Sequence[google.cloud.aiplatform_v1.types.WriteFeatureValuesPayload]`):
+                Required. The entities to be written. Up to 100,000
+                feature values can be written across all ``payloads``.
+
+                This corresponds to the ``payloads`` field
+                on the ``request`` instance; if ``request`` is provided, this
+                should not be set.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, str]]): Strings which should be
+                sent along with the request as metadata.
+
+        Returns:
+            google.cloud.aiplatform_v1.types.WriteFeatureValuesResponse:
+                Response message for
+                [FeaturestoreOnlineServingService.WriteFeatureValues][google.cloud.aiplatform.v1.FeaturestoreOnlineServingService.WriteFeatureValues].
+
+        """
+        # Create or coerce a protobuf request object.
+        # Quick check: If we got a request object, we should *not* have
+        # gotten any keyword arguments that map to the request.
+        has_flattened_params = any([entity_type, payloads])
+        if request is not None and has_flattened_params:
+            raise ValueError(
+                "If the `request` argument is set, then none of "
+                "the individual field arguments should be set."
+            )
+
+        request = featurestore_online_service.WriteFeatureValuesRequest(request)
+
+        # If we have keyword arguments corresponding to fields on the
+        # request, apply these.
+        if entity_type is not None:
+            request.entity_type = entity_type
+        if payloads:
+            request.payloads.extend(payloads)
+
+        # Wrap the RPC method; this adds retry and timeout information,
+        # and friendly error handling.
+        rpc = gapic_v1.method_async.wrap_method(
+            self._client._transport.write_feature_values,
+            default_timeout=None,
+            client_info=DEFAULT_CLIENT_INFO,
+        )
+
+        # Certain fields should be provided within the metadata header;
+        # add these here.
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata(
+                (("entity_type", request.entity_type),)
+            ),
+        )
+
+        # Send the request.
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+
+        # Done; return the response.
+        return response
+
     async def list_operations(
         self,
         request: operations_pb2.ListOperationsRequest = None,

--- a/google/cloud/aiplatform_v1/services/featurestore_online_serving_service/client.py
+++ b/google/cloud/aiplatform_v1/services/featurestore_online_serving_service/client.py
@@ -685,6 +685,138 @@ class FeaturestoreOnlineServingServiceClient(
         # Done; return the response.
         return response
 
+    def write_feature_values(
+        self,
+        request: Union[
+            featurestore_online_service.WriteFeatureValuesRequest, dict
+        ] = None,
+        *,
+        entity_type: str = None,
+        payloads: Sequence[
+            featurestore_online_service.WriteFeatureValuesPayload
+        ] = None,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: float = None,
+        metadata: Sequence[Tuple[str, str]] = (),
+    ) -> featurestore_online_service.WriteFeatureValuesResponse:
+        r"""Writes Feature values of one or more entities of an
+        EntityType.
+        The Feature values are merged into existing entities if
+        any. The Feature values to be written must have
+        timestamp within the online storage retention.
+
+        .. code-block:: python
+
+            # This snippet has been automatically generated and should be regarded as a
+            # code template only.
+            # It will require modifications to work:
+            # - It may require correct/in-range values for request initialization.
+            # - It may require specifying regional endpoints when creating the service
+            #   client as shown in:
+            #   https://googleapis.dev/python/google-api-core/latest/client_options.html
+            from google.cloud import aiplatform_v1
+
+            def sample_write_feature_values():
+                # Create a client
+                client = aiplatform_v1.FeaturestoreOnlineServingServiceClient()
+
+                # Initialize request argument(s)
+                payloads = aiplatform_v1.WriteFeatureValuesPayload()
+                payloads.entity_id = "entity_id_value"
+
+                request = aiplatform_v1.WriteFeatureValuesRequest(
+                    entity_type="entity_type_value",
+                    payloads=payloads,
+                )
+
+                # Make the request
+                response = client.write_feature_values(request=request)
+
+                # Handle the response
+                print(response)
+
+        Args:
+            request (Union[google.cloud.aiplatform_v1.types.WriteFeatureValuesRequest, dict]):
+                The request object. Request message for
+                [FeaturestoreOnlineServingService.WriteFeatureValues][google.cloud.aiplatform.v1.FeaturestoreOnlineServingService.WriteFeatureValues].
+            entity_type (str):
+                Required. The resource name of the EntityType for the
+                entities being written. Value format:
+                ``projects/{project}/locations/{location}/featurestores/ {featurestore}/entityTypes/{entityType}``.
+                For example, for a machine learning model predicting
+                user clicks on a website, an EntityType ID could be
+                ``user``.
+
+                This corresponds to the ``entity_type`` field
+                on the ``request`` instance; if ``request`` is provided, this
+                should not be set.
+            payloads (Sequence[google.cloud.aiplatform_v1.types.WriteFeatureValuesPayload]):
+                Required. The entities to be written. Up to 100,000
+                feature values can be written across all ``payloads``.
+
+                This corresponds to the ``payloads`` field
+                on the ``request`` instance; if ``request`` is provided, this
+                should not be set.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, str]]): Strings which should be
+                sent along with the request as metadata.
+
+        Returns:
+            google.cloud.aiplatform_v1.types.WriteFeatureValuesResponse:
+                Response message for
+                [FeaturestoreOnlineServingService.WriteFeatureValues][google.cloud.aiplatform.v1.FeaturestoreOnlineServingService.WriteFeatureValues].
+
+        """
+        # Create or coerce a protobuf request object.
+        # Quick check: If we got a request object, we should *not* have
+        # gotten any keyword arguments that map to the request.
+        has_flattened_params = any([entity_type, payloads])
+        if request is not None and has_flattened_params:
+            raise ValueError(
+                "If the `request` argument is set, then none of "
+                "the individual field arguments should be set."
+            )
+
+        # Minor optimization to avoid making a copy if the user passes
+        # in a featurestore_online_service.WriteFeatureValuesRequest.
+        # There's no risk of modifying the input as we've already verified
+        # there are no flattened fields.
+        if not isinstance(
+            request, featurestore_online_service.WriteFeatureValuesRequest
+        ):
+            request = featurestore_online_service.WriteFeatureValuesRequest(request)
+            # If we have keyword arguments corresponding to fields on the
+            # request, apply these.
+            if entity_type is not None:
+                request.entity_type = entity_type
+            if payloads is not None:
+                request.payloads = payloads
+
+        # Wrap the RPC method; this adds retry and timeout information,
+        # and friendly error handling.
+        rpc = self._transport._wrapped_methods[self._transport.write_feature_values]
+
+        # Certain fields should be provided within the metadata header;
+        # add these here.
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata(
+                (("entity_type", request.entity_type),)
+            ),
+        )
+
+        # Send the request.
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+
+        # Done; return the response.
+        return response
+
     def __enter__(self):
         return self
 

--- a/google/cloud/aiplatform_v1/services/featurestore_online_serving_service/transports/base.py
+++ b/google/cloud/aiplatform_v1/services/featurestore_online_serving_service/transports/base.py
@@ -141,6 +141,11 @@ class FeaturestoreOnlineServingServiceTransport(abc.ABC):
                 default_timeout=None,
                 client_info=client_info,
             ),
+            self.write_feature_values: gapic_v1.method.wrap_method(
+                self.write_feature_values,
+                default_timeout=None,
+                client_info=client_info,
+            ),
         }
 
     def close(self):
@@ -172,6 +177,18 @@ class FeaturestoreOnlineServingServiceTransport(abc.ABC):
         Union[
             featurestore_online_service.ReadFeatureValuesResponse,
             Awaitable[featurestore_online_service.ReadFeatureValuesResponse],
+        ],
+    ]:
+        raise NotImplementedError()
+
+    @property
+    def write_feature_values(
+        self,
+    ) -> Callable[
+        [featurestore_online_service.WriteFeatureValuesRequest],
+        Union[
+            featurestore_online_service.WriteFeatureValuesResponse,
+            Awaitable[featurestore_online_service.WriteFeatureValuesResponse],
         ],
     ]:
         raise NotImplementedError()

--- a/google/cloud/aiplatform_v1/services/featurestore_online_serving_service/transports/grpc.py
+++ b/google/cloud/aiplatform_v1/services/featurestore_online_serving_service/transports/grpc.py
@@ -300,6 +300,39 @@ class FeaturestoreOnlineServingServiceGrpcTransport(
             )
         return self._stubs["streaming_read_feature_values"]
 
+    @property
+    def write_feature_values(
+        self,
+    ) -> Callable[
+        [featurestore_online_service.WriteFeatureValuesRequest],
+        featurestore_online_service.WriteFeatureValuesResponse,
+    ]:
+        r"""Return a callable for the write feature values method over gRPC.
+
+        Writes Feature values of one or more entities of an
+        EntityType.
+        The Feature values are merged into existing entities if
+        any. The Feature values to be written must have
+        timestamp within the online storage retention.
+
+        Returns:
+            Callable[[~.WriteFeatureValuesRequest],
+                    ~.WriteFeatureValuesResponse]:
+                A function that, when called, will call the underlying RPC
+                on the server.
+        """
+        # Generate a "stub function" on-the-fly which will actually make
+        # the request.
+        # gRPC handles serialization and deserialization, so we just need
+        # to pass in the functions for each.
+        if "write_feature_values" not in self._stubs:
+            self._stubs["write_feature_values"] = self.grpc_channel.unary_unary(
+                "/google.cloud.aiplatform.v1.FeaturestoreOnlineServingService/WriteFeatureValues",
+                request_serializer=featurestore_online_service.WriteFeatureValuesRequest.serialize,
+                response_deserializer=featurestore_online_service.WriteFeatureValuesResponse.deserialize,
+            )
+        return self._stubs["write_feature_values"]
+
     def close(self):
         self.grpc_channel.close()
 

--- a/google/cloud/aiplatform_v1/services/featurestore_online_serving_service/transports/grpc_asyncio.py
+++ b/google/cloud/aiplatform_v1/services/featurestore_online_serving_service/transports/grpc_asyncio.py
@@ -303,6 +303,39 @@ class FeaturestoreOnlineServingServiceGrpcAsyncIOTransport(
             )
         return self._stubs["streaming_read_feature_values"]
 
+    @property
+    def write_feature_values(
+        self,
+    ) -> Callable[
+        [featurestore_online_service.WriteFeatureValuesRequest],
+        Awaitable[featurestore_online_service.WriteFeatureValuesResponse],
+    ]:
+        r"""Return a callable for the write feature values method over gRPC.
+
+        Writes Feature values of one or more entities of an
+        EntityType.
+        The Feature values are merged into existing entities if
+        any. The Feature values to be written must have
+        timestamp within the online storage retention.
+
+        Returns:
+            Callable[[~.WriteFeatureValuesRequest],
+                    Awaitable[~.WriteFeatureValuesResponse]]:
+                A function that, when called, will call the underlying RPC
+                on the server.
+        """
+        # Generate a "stub function" on-the-fly which will actually make
+        # the request.
+        # gRPC handles serialization and deserialization, so we just need
+        # to pass in the functions for each.
+        if "write_feature_values" not in self._stubs:
+            self._stubs["write_feature_values"] = self.grpc_channel.unary_unary(
+                "/google.cloud.aiplatform.v1.FeaturestoreOnlineServingService/WriteFeatureValues",
+                request_serializer=featurestore_online_service.WriteFeatureValuesRequest.serialize,
+                response_deserializer=featurestore_online_service.WriteFeatureValuesResponse.deserialize,
+            )
+        return self._stubs["write_feature_values"]
+
     def close(self):
         return self.grpc_channel.close()
 

--- a/google/cloud/aiplatform_v1/services/tensorboard_service/async_client.py
+++ b/google/cloud/aiplatform_v1/services/tensorboard_service/async_client.py
@@ -330,8 +330,8 @@ class TensorboardServiceAsyncClient:
 
                 The result type for the operation will be :class:`google.cloud.aiplatform_v1.types.Tensorboard` Tensorboard is a physical database that stores users' training metrics.
                    A default Tensorboard is provided in each region of a
-                   GCP project. If needed users can also create extra
-                   Tensorboards in their projects.
+                   Google Cloud project. If needed users can also create
+                   extra Tensorboards in their projects.
 
         """
         # Create or coerce a protobuf request object.
@@ -445,9 +445,9 @@ class TensorboardServiceAsyncClient:
                 Tensorboard is a physical database
                 that stores users' training metrics. A
                 default Tensorboard is provided in each
-                region of a GCP project. If needed users
-                can also create extra Tensorboards in
-                their projects.
+                region of a Google Cloud project. If
+                needed users can also create extra
+                Tensorboards in their projects.
 
         """
         # Create or coerce a protobuf request object.
@@ -573,8 +573,8 @@ class TensorboardServiceAsyncClient:
 
                 The result type for the operation will be :class:`google.cloud.aiplatform_v1.types.Tensorboard` Tensorboard is a physical database that stores users' training metrics.
                    A default Tensorboard is provided in each region of a
-                   GCP project. If needed users can also create extra
-                   Tensorboards in their projects.
+                   Google Cloud project. If needed users can also create
+                   extra Tensorboards in their projects.
 
         """
         # Create or coerce a protobuf request object.

--- a/google/cloud/aiplatform_v1/services/tensorboard_service/client.py
+++ b/google/cloud/aiplatform_v1/services/tensorboard_service/client.py
@@ -606,8 +606,8 @@ class TensorboardServiceClient(metaclass=TensorboardServiceClientMeta):
 
                 The result type for the operation will be :class:`google.cloud.aiplatform_v1.types.Tensorboard` Tensorboard is a physical database that stores users' training metrics.
                    A default Tensorboard is provided in each region of a
-                   GCP project. If needed users can also create extra
-                   Tensorboards in their projects.
+                   Google Cloud project. If needed users can also create
+                   extra Tensorboards in their projects.
 
         """
         # Create or coerce a protobuf request object.
@@ -721,9 +721,9 @@ class TensorboardServiceClient(metaclass=TensorboardServiceClientMeta):
                 Tensorboard is a physical database
                 that stores users' training metrics. A
                 default Tensorboard is provided in each
-                region of a GCP project. If needed users
-                can also create extra Tensorboards in
-                their projects.
+                region of a Google Cloud project. If
+                needed users can also create extra
+                Tensorboards in their projects.
 
         """
         # Create or coerce a protobuf request object.
@@ -849,8 +849,8 @@ class TensorboardServiceClient(metaclass=TensorboardServiceClientMeta):
 
                 The result type for the operation will be :class:`google.cloud.aiplatform_v1.types.Tensorboard` Tensorboard is a physical database that stores users' training metrics.
                    A default Tensorboard is provided in each region of a
-                   GCP project. If needed users can also create extra
-                   Tensorboards in their projects.
+                   Google Cloud project. If needed users can also create
+                   extra Tensorboards in their projects.
 
         """
         # Create or coerce a protobuf request object.

--- a/google/cloud/aiplatform_v1/types/__init__.py
+++ b/google/cloud/aiplatform_v1/types/__init__.py
@@ -160,6 +160,9 @@ from .featurestore_online_service import (
     ReadFeatureValuesRequest,
     ReadFeatureValuesResponse,
     StreamingReadFeatureValuesRequest,
+    WriteFeatureValuesPayload,
+    WriteFeatureValuesRequest,
+    WriteFeatureValuesResponse,
 )
 from .featurestore_service import (
     BatchCreateFeaturesOperationMetadata,
@@ -695,6 +698,9 @@ __all__ = (
     "ReadFeatureValuesRequest",
     "ReadFeatureValuesResponse",
     "StreamingReadFeatureValuesRequest",
+    "WriteFeatureValuesPayload",
+    "WriteFeatureValuesRequest",
+    "WriteFeatureValuesResponse",
     "BatchCreateFeaturesOperationMetadata",
     "BatchCreateFeaturesRequest",
     "BatchCreateFeaturesResponse",

--- a/google/cloud/aiplatform_v1/types/annotation_spec.py
+++ b/google/cloud/aiplatform_v1/types/annotation_spec.py
@@ -37,7 +37,7 @@ class AnnotationSpec(proto.Message):
         display_name (str):
             Required. The user-defined name of the
             AnnotationSpec. The name can be up to 128
-            characters long and can be consist of any UTF-8
+            characters long and can consist of any UTF-8
             characters.
         create_time (google.protobuf.timestamp_pb2.Timestamp):
             Output only. Timestamp when this

--- a/google/cloud/aiplatform_v1/types/batch_prediction_job.py
+++ b/google/cloud/aiplatform_v1/types/batch_prediction_job.py
@@ -107,8 +107,8 @@ class BatchPredictionJob(proto.Message):
             The service account that the DeployedModel's container runs
             as. If not specified, a system generated one will be used,
             which has minimal permissions and the custom container, if
-            used, may not have enough permission to access other GCP
-            resources.
+            used, may not have enough permission to access other Google
+            Cloud resources.
 
             Users deploying the Model must have the
             ``iam.serviceAccounts.actAs`` permission on this service
@@ -170,8 +170,8 @@ class BatchPredictionJob(proto.Message):
             Output only. Partial failures encountered.
             For example, single files that can't be read.
             This field never exceeds 20 entries.
-            Status details fields contain standard GCP error
-            details.
+            Status details fields contain standard Google
+            Cloud error details.
         resources_consumed (google.cloud.aiplatform_v1.types.ResourcesConsumed):
             Output only. Information about resources that
             had been consumed by this job. Provided in real

--- a/google/cloud/aiplatform_v1/types/custom_job.py
+++ b/google/cloud/aiplatform_v1/types/custom_job.py
@@ -51,7 +51,7 @@ class CustomJob(proto.Message):
         display_name (str):
             Required. The display name of the CustomJob.
             The name can be up to 128 characters long and
-            can be consist of any UTF-8 characters.
+            can consist of any UTF-8 characters.
         job_spec (google.cloud.aiplatform_v1.types.CustomJobSpec):
             Required. Job spec.
         state (google.cloud.aiplatform_v1.types.JobState):

--- a/google/cloud/aiplatform_v1/types/data_labeling_job.py
+++ b/google/cloud/aiplatform_v1/types/data_labeling_job.py
@@ -45,7 +45,7 @@ class DataLabelingJob(proto.Message):
         display_name (str):
             Required. The user-defined name of the
             DataLabelingJob. The name can be up to 128
-            characters long and can be consist of any UTF-8
+            characters long and can consist of any UTF-8
             characters.
             Display name of a DataLabelingJob.
         datasets (Sequence[str]):

--- a/google/cloud/aiplatform_v1/types/dataset.py
+++ b/google/cloud/aiplatform_v1/types/dataset.py
@@ -41,9 +41,9 @@ class Dataset(proto.Message):
         display_name (str):
             Required. The user-defined name of the
             Dataset. The name can be up to 128 characters
-            long and can be consist of any UTF-8 characters.
+            long and can consist of any UTF-8 characters.
         description (str):
-            Optional. The description of the Dataset.
+            The description of the Dataset.
         metadata_schema_uri (str):
             Required. Points to a YAML file stored on
             Google Cloud Storage describing additional
@@ -88,6 +88,11 @@ class Dataset(proto.Message):
             Dataset. If set, this Dataset and all
             sub-resources of this Dataset will be secured by
             this key.
+        metadata_artifact (str):
+            Output only. The resource name of the Artifact that was
+            created in MetadataStore when creating the Dataset. The
+            Artifact resource name pattern is
+            ``projects/{project}/locations/{location}/metadataStores/{metadata_store}/artifacts/{artifact}``.
     """
 
     name = proto.Field(
@@ -134,6 +139,10 @@ class Dataset(proto.Message):
         proto.MESSAGE,
         number=11,
         message=gca_encryption_spec.EncryptionSpec,
+    )
+    metadata_artifact = proto.Field(
+        proto.STRING,
+        number=17,
     )
 
 

--- a/google/cloud/aiplatform_v1/types/endpoint.py
+++ b/google/cloud/aiplatform_v1/types/endpoint.py
@@ -44,7 +44,7 @@ class Endpoint(proto.Message):
         display_name (str):
             Required. The display name of the Endpoint.
             The name can be up to 128 characters long and
-            can be consist of any UTF-8 characters.
+            can consist of any UTF-8 characters.
         description (str):
             The description of the Endpoint.
         deployed_models (Sequence[google.cloud.aiplatform_v1.types.DeployedModel]):

--- a/google/cloud/aiplatform_v1/types/featurestore_online_service.py
+++ b/google/cloud/aiplatform_v1/types/featurestore_online_service.py
@@ -23,6 +23,9 @@ from google.protobuf import timestamp_pb2  # type: ignore
 __protobuf__ = proto.module(
     package="google.cloud.aiplatform.v1",
     manifest={
+        "WriteFeatureValuesRequest",
+        "WriteFeatureValuesPayload",
+        "WriteFeatureValuesResponse",
         "ReadFeatureValuesRequest",
         "ReadFeatureValuesResponse",
         "StreamingReadFeatureValuesRequest",
@@ -30,6 +33,66 @@ __protobuf__ = proto.module(
         "FeatureValueList",
     },
 )
+
+
+class WriteFeatureValuesRequest(proto.Message):
+    r"""Request message for
+    [FeaturestoreOnlineServingService.WriteFeatureValues][google.cloud.aiplatform.v1.FeaturestoreOnlineServingService.WriteFeatureValues].
+
+    Attributes:
+        entity_type (str):
+            Required. The resource name of the EntityType for the
+            entities being written. Value format:
+            ``projects/{project}/locations/{location}/featurestores/ {featurestore}/entityTypes/{entityType}``.
+            For example, for a machine learning model predicting user
+            clicks on a website, an EntityType ID could be ``user``.
+        payloads (Sequence[google.cloud.aiplatform_v1.types.WriteFeatureValuesPayload]):
+            Required. The entities to be written. Up to 100,000 feature
+            values can be written across all ``payloads``.
+    """
+
+    entity_type = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    payloads = proto.RepeatedField(
+        proto.MESSAGE,
+        number=2,
+        message="WriteFeatureValuesPayload",
+    )
+
+
+class WriteFeatureValuesPayload(proto.Message):
+    r"""Contains Feature values to be written for a specific entity.
+
+    Attributes:
+        entity_id (str):
+            Required. The ID of the entity.
+        feature_values (Mapping[str, google.cloud.aiplatform_v1.types.FeatureValue]):
+            Required. Feature values to be written, mapping from Feature
+            ID to value. Up to 100,000 ``feature_values`` entries may be
+            written across all payloads. The feature generation time,
+            aligned by days, must be no older than five years (1825
+            days) and no later than one year (366 days) in the future.
+    """
+
+    entity_id = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    feature_values = proto.MapField(
+        proto.STRING,
+        proto.MESSAGE,
+        number=2,
+        message="FeatureValue",
+    )
+
+
+class WriteFeatureValuesResponse(proto.Message):
+    r"""Response message for
+    [FeaturestoreOnlineServingService.WriteFeatureValues][google.cloud.aiplatform.v1.FeaturestoreOnlineServingService.WriteFeatureValues].
+
+    """
 
 
 class ReadFeatureValuesRequest(proto.Message):

--- a/google/cloud/aiplatform_v1/types/featurestore_service.py
+++ b/google/cloud/aiplatform_v1/types/featurestore_service.py
@@ -1575,6 +1575,9 @@ class ImportFeatureValuesOperationMetadata(proto.Message):
         imported_feature_value_count (int):
             Number of Feature values that have been
             imported by the operation.
+        source_uris (Sequence[str]):
+            The source URI from where Feature values are
+            imported.
         invalid_row_count (int):
             The number of rows in input source that weren't imported due
             to either
@@ -1601,6 +1604,10 @@ class ImportFeatureValuesOperationMetadata(proto.Message):
     imported_feature_value_count = proto.Field(
         proto.INT64,
         number=3,
+    )
+    source_uris = proto.RepeatedField(
+        proto.STRING,
+        number=4,
     )
     invalid_row_count = proto.Field(
         proto.INT64,

--- a/google/cloud/aiplatform_v1/types/hyperparameter_tuning_job.py
+++ b/google/cloud/aiplatform_v1/types/hyperparameter_tuning_job.py
@@ -43,8 +43,8 @@ class HyperparameterTuningJob(proto.Message):
         display_name (str):
             Required. The display name of the
             HyperparameterTuningJob. The name can be up to
-            128 characters long and can be consist of any
-            UTF-8 characters.
+            128 characters long and can consist of any UTF-8
+            characters.
         study_spec (google.cloud.aiplatform_v1.types.StudySpec):
             Required. Study configuration of the
             HyperparameterTuningJob.

--- a/google/cloud/aiplatform_v1/types/index.py
+++ b/google/cloud/aiplatform_v1/types/index.py
@@ -41,7 +41,7 @@ class Index(proto.Message):
         display_name (str):
             Required. The display name of the Index.
             The name can be up to 128 characters long and
-            can be consist of any UTF-8 characters.
+            can consist of any UTF-8 characters.
         description (str):
             The description of the Index.
         metadata_schema_uri (str):

--- a/google/cloud/aiplatform_v1/types/job_service.py
+++ b/google/cloud/aiplatform_v1/types/job_service.py
@@ -831,7 +831,7 @@ class SearchModelDeploymentMonitoringStatsAnomaliesRequest(proto.Message):
                 [SearchModelDeploymentMonitoringStatsAnomaliesRequest.start_time][google.cloud.aiplatform.v1.SearchModelDeploymentMonitoringStatsAnomaliesRequest.start_time]
                 and
                 [SearchModelDeploymentMonitoringStatsAnomaliesRequest.end_time][google.cloud.aiplatform.v1.SearchModelDeploymentMonitoringStatsAnomaliesRequest.end_time]
-                are fetched, and page token doesn't take affect in this
+                are fetched, and page token doesn't take effect in this
                 case. Only used to retrieve attribution score for the top
                 Features which has the highest attribution score in the
                 latest monitoring run.

--- a/google/cloud/aiplatform_v1/types/model.py
+++ b/google/cloud/aiplatform_v1/types/model.py
@@ -66,7 +66,7 @@ class Model(proto.Message):
         display_name (str):
             Required. The display name of the Model.
             The name can be up to 128 characters long and
-            can be consist of any UTF-8 characters.
+            can consist of any UTF-8 characters.
         description (str):
             The description of the Model.
         version_description (str):

--- a/google/cloud/aiplatform_v1/types/model_deployment_monitoring_job.py
+++ b/google/cloud/aiplatform_v1/types/model_deployment_monitoring_job.py
@@ -60,7 +60,7 @@ class ModelDeploymentMonitoringJob(proto.Message):
         display_name (str):
             Required. The user-defined name of the
             ModelDeploymentMonitoringJob. The name can be up
-            to 128 characters long and can be consist of any
+            to 128 characters long and can consist of any
             UTF-8 characters.
             Display name of a ModelDeploymentMonitoringJob.
         endpoint (str):

--- a/google/cloud/aiplatform_v1/types/operation.py
+++ b/google/cloud/aiplatform_v1/types/operation.py
@@ -36,8 +36,8 @@ class GenericOperationMetadata(proto.Message):
             Output only. Partial failures encountered.
             E.g. single files that couldn't be read.
             This field should never exceed 20 entries.
-            Status details field will contain standard GCP
-            error details.
+            Status details field will contain standard
+            Google Cloud error details.
         create_time (google.protobuf.timestamp_pb2.Timestamp):
             Output only. Time when the operation was
             created.

--- a/google/cloud/aiplatform_v1/types/pipeline_job.py
+++ b/google/cloud/aiplatform_v1/types/pipeline_job.py
@@ -49,7 +49,7 @@ class PipelineJob(proto.Message):
         display_name (str):
             The display name of the Pipeline.
             The name can be up to 128 characters long and
-            can be consist of any UTF-8 characters.
+            can consist of any UTF-8 characters.
         create_time (google.protobuf.timestamp_pb2.Timestamp):
             Output only. Pipeline creation time.
         start_time (google.protobuf.timestamp_pb2.Timestamp):
@@ -108,9 +108,9 @@ class PipelineJob(proto.Message):
 
             Private services access must already be configured for the
             network. Pipeline job will apply the network configuration
-            to the GCP resources being launched, if applied, such as
-            Vertex AI Training or Dataflow job. If left unspecified, the
-            workload is not peered with any network.
+            to the Google Cloud resources being launched, if applied,
+            such as Vertex AI Training or Dataflow job. If left
+            unspecified, the workload is not peered with any network.
         template_uri (str):
             A template uri from where the
             [PipelineJob.pipeline_spec][google.cloud.aiplatform.v1.PipelineJob.pipeline_spec],

--- a/google/cloud/aiplatform_v1/types/specialist_pool.py
+++ b/google/cloud/aiplatform_v1/types/specialist_pool.py
@@ -40,7 +40,7 @@ class SpecialistPool(proto.Message):
         display_name (str):
             Required. The user-defined name of the
             SpecialistPool. The name can be up to 128
-            characters long and can be consist of any UTF-8
+            characters long and can consist of any UTF-8
             characters.
             This field should be unique on project-level.
         specialist_managers_count (int):

--- a/google/cloud/aiplatform_v1/types/tensorboard.py
+++ b/google/cloud/aiplatform_v1/types/tensorboard.py
@@ -30,8 +30,8 @@ __protobuf__ = proto.module(
 class Tensorboard(proto.Message):
     r"""Tensorboard is a physical database that stores users'
     training metrics. A default Tensorboard is provided in each
-    region of a GCP project. If needed users can also create extra
-    Tensorboards in their projects.
+    region of a Google Cloud project. If needed users can also
+    create extra Tensorboards in their projects.
 
     Attributes:
         name (str):

--- a/google/cloud/aiplatform_v1beta1/services/featurestore_service/async_client.py
+++ b/google/cloud/aiplatform_v1beta1/services/featurestore_service/async_client.py
@@ -668,6 +668,7 @@ class FeaturestoreServiceAsyncClient:
                 -  ``labels``
                 -  ``online_serving_config.fixed_node_count``
                 -  ``online_serving_config.scaling``
+                -  ``online_storage_ttl_days``
 
                 This corresponds to the ``update_mask`` field
                 on the ``request`` instance; if ``request`` is provided, this
@@ -1319,6 +1320,7 @@ class FeaturestoreServiceAsyncClient:
                 -  ``monitoring_config.import_features_analysis.anomaly_detection_baseline``
                 -  ``monitoring_config.numerical_threshold_config.value``
                 -  ``monitoring_config.categorical_threshold_config.value``
+                -  ``offline_storage_ttl_days``
 
                 This corresponds to the ``update_mask`` field
                 on the ``request`` instance; if ``request`` is provided, this

--- a/google/cloud/aiplatform_v1beta1/services/featurestore_service/client.py
+++ b/google/cloud/aiplatform_v1beta1/services/featurestore_service/client.py
@@ -934,6 +934,7 @@ class FeaturestoreServiceClient(metaclass=FeaturestoreServiceClientMeta):
                 -  ``labels``
                 -  ``online_serving_config.fixed_node_count``
                 -  ``online_serving_config.scaling``
+                -  ``online_storage_ttl_days``
 
                 This corresponds to the ``update_mask`` field
                 on the ``request`` instance; if ``request`` is provided, this
@@ -1585,6 +1586,7 @@ class FeaturestoreServiceClient(metaclass=FeaturestoreServiceClientMeta):
                 -  ``monitoring_config.import_features_analysis.anomaly_detection_baseline``
                 -  ``monitoring_config.numerical_threshold_config.value``
                 -  ``monitoring_config.categorical_threshold_config.value``
+                -  ``offline_storage_ttl_days``
 
                 This corresponds to the ``update_mask`` field
                 on the ``request`` instance; if ``request`` is provided, this

--- a/google/cloud/aiplatform_v1beta1/services/migration_service/client.py
+++ b/google/cloud/aiplatform_v1beta1/services/migration_service/client.py
@@ -196,6 +196,23 @@ class MigrationServiceClient(metaclass=MigrationServiceClientMeta):
     @staticmethod
     def dataset_path(
         project: str,
+        dataset: str,
+    ) -> str:
+        """Returns a fully-qualified dataset string."""
+        return "projects/{project}/datasets/{dataset}".format(
+            project=project,
+            dataset=dataset,
+        )
+
+    @staticmethod
+    def parse_dataset_path(path: str) -> Dict[str, str]:
+        """Parses a dataset path into its component segments."""
+        m = re.match(r"^projects/(?P<project>.+?)/datasets/(?P<dataset>.+?)$", path)
+        return m.groupdict() if m else {}
+
+    @staticmethod
+    def dataset_path(
+        project: str,
         location: str,
         dataset: str,
     ) -> str:
@@ -213,23 +230,6 @@ class MigrationServiceClient(metaclass=MigrationServiceClientMeta):
             r"^projects/(?P<project>.+?)/locations/(?P<location>.+?)/datasets/(?P<dataset>.+?)$",
             path,
         )
-        return m.groupdict() if m else {}
-
-    @staticmethod
-    def dataset_path(
-        project: str,
-        dataset: str,
-    ) -> str:
-        """Returns a fully-qualified dataset string."""
-        return "projects/{project}/datasets/{dataset}".format(
-            project=project,
-            dataset=dataset,
-        )
-
-    @staticmethod
-    def parse_dataset_path(path: str) -> Dict[str, str]:
-        """Parses a dataset path into its component segments."""
-        m = re.match(r"^projects/(?P<project>.+?)/datasets/(?P<dataset>.+?)$", path)
         return m.groupdict() if m else {}
 
     @staticmethod

--- a/google/cloud/aiplatform_v1beta1/services/tensorboard_service/async_client.py
+++ b/google/cloud/aiplatform_v1beta1/services/tensorboard_service/async_client.py
@@ -330,8 +330,8 @@ class TensorboardServiceAsyncClient:
 
                 The result type for the operation will be :class:`google.cloud.aiplatform_v1beta1.types.Tensorboard` Tensorboard is a physical database that stores users' training metrics.
                    A default Tensorboard is provided in each region of a
-                   GCP project. If needed users can also create extra
-                   Tensorboards in their projects.
+                   Google Cloud project. If needed users can also create
+                   extra Tensorboards in their projects.
 
         """
         # Create or coerce a protobuf request object.
@@ -445,9 +445,9 @@ class TensorboardServiceAsyncClient:
                 Tensorboard is a physical database
                 that stores users' training metrics. A
                 default Tensorboard is provided in each
-                region of a GCP project. If needed users
-                can also create extra Tensorboards in
-                their projects.
+                region of a Google Cloud project. If
+                needed users can also create extra
+                Tensorboards in their projects.
 
         """
         # Create or coerce a protobuf request object.
@@ -573,8 +573,8 @@ class TensorboardServiceAsyncClient:
 
                 The result type for the operation will be :class:`google.cloud.aiplatform_v1beta1.types.Tensorboard` Tensorboard is a physical database that stores users' training metrics.
                    A default Tensorboard is provided in each region of a
-                   GCP project. If needed users can also create extra
-                   Tensorboards in their projects.
+                   Google Cloud project. If needed users can also create
+                   extra Tensorboards in their projects.
 
         """
         # Create or coerce a protobuf request object.

--- a/google/cloud/aiplatform_v1beta1/services/tensorboard_service/client.py
+++ b/google/cloud/aiplatform_v1beta1/services/tensorboard_service/client.py
@@ -606,8 +606,8 @@ class TensorboardServiceClient(metaclass=TensorboardServiceClientMeta):
 
                 The result type for the operation will be :class:`google.cloud.aiplatform_v1beta1.types.Tensorboard` Tensorboard is a physical database that stores users' training metrics.
                    A default Tensorboard is provided in each region of a
-                   GCP project. If needed users can also create extra
-                   Tensorboards in their projects.
+                   Google Cloud project. If needed users can also create
+                   extra Tensorboards in their projects.
 
         """
         # Create or coerce a protobuf request object.
@@ -721,9 +721,9 @@ class TensorboardServiceClient(metaclass=TensorboardServiceClientMeta):
                 Tensorboard is a physical database
                 that stores users' training metrics. A
                 default Tensorboard is provided in each
-                region of a GCP project. If needed users
-                can also create extra Tensorboards in
-                their projects.
+                region of a Google Cloud project. If
+                needed users can also create extra
+                Tensorboards in their projects.
 
         """
         # Create or coerce a protobuf request object.
@@ -849,8 +849,8 @@ class TensorboardServiceClient(metaclass=TensorboardServiceClientMeta):
 
                 The result type for the operation will be :class:`google.cloud.aiplatform_v1beta1.types.Tensorboard` Tensorboard is a physical database that stores users' training metrics.
                    A default Tensorboard is provided in each region of a
-                   GCP project. If needed users can also create extra
-                   Tensorboards in their projects.
+                   Google Cloud project. If needed users can also create
+                   extra Tensorboards in their projects.
 
         """
         # Create or coerce a protobuf request object.

--- a/google/cloud/aiplatform_v1beta1/types/annotation_spec.py
+++ b/google/cloud/aiplatform_v1beta1/types/annotation_spec.py
@@ -37,7 +37,7 @@ class AnnotationSpec(proto.Message):
         display_name (str):
             Required. The user-defined name of the
             AnnotationSpec. The name can be up to 128
-            characters long and can be consist of any UTF-8
+            characters long and can consist of any UTF-8
             characters.
         create_time (google.protobuf.timestamp_pb2.Timestamp):
             Output only. Timestamp when this

--- a/google/cloud/aiplatform_v1beta1/types/batch_prediction_job.py
+++ b/google/cloud/aiplatform_v1beta1/types/batch_prediction_job.py
@@ -115,8 +115,8 @@ class BatchPredictionJob(proto.Message):
             The service account that the DeployedModel's container runs
             as. If not specified, a system generated one will be used,
             which has minimal permissions and the custom container, if
-            used, may not have enough permission to access other GCP
-            resources.
+            used, may not have enough permission to access other Google
+            Cloud resources.
 
             Users deploying the Model must have the
             ``iam.serviceAccounts.actAs`` permission on this service
@@ -179,8 +179,8 @@ class BatchPredictionJob(proto.Message):
             Output only. Partial failures encountered.
             For example, single files that can't be read.
             This field never exceeds 20 entries.
-            Status details fields contain standard GCP error
-            details.
+            Status details fields contain standard Google
+            Cloud error details.
         resources_consumed (google.cloud.aiplatform_v1beta1.types.ResourcesConsumed):
             Output only. Information about resources that
             had been consumed by this job. Provided in real

--- a/google/cloud/aiplatform_v1beta1/types/custom_job.py
+++ b/google/cloud/aiplatform_v1beta1/types/custom_job.py
@@ -51,7 +51,7 @@ class CustomJob(proto.Message):
         display_name (str):
             Required. The display name of the CustomJob.
             The name can be up to 128 characters long and
-            can be consist of any UTF-8 characters.
+            can consist of any UTF-8 characters.
         job_spec (google.cloud.aiplatform_v1beta1.types.CustomJobSpec):
             Required. Job spec.
         state (google.cloud.aiplatform_v1beta1.types.JobState):

--- a/google/cloud/aiplatform_v1beta1/types/data_labeling_job.py
+++ b/google/cloud/aiplatform_v1beta1/types/data_labeling_job.py
@@ -45,7 +45,7 @@ class DataLabelingJob(proto.Message):
         display_name (str):
             Required. The user-defined name of the
             DataLabelingJob. The name can be up to 128
-            characters long and can be consist of any UTF-8
+            characters long and can consist of any UTF-8
             characters.
             Display name of a DataLabelingJob.
         datasets (Sequence[str]):

--- a/google/cloud/aiplatform_v1beta1/types/dataset.py
+++ b/google/cloud/aiplatform_v1beta1/types/dataset.py
@@ -41,9 +41,9 @@ class Dataset(proto.Message):
         display_name (str):
             Required. The user-defined name of the
             Dataset. The name can be up to 128 characters
-            long and can be consist of any UTF-8 characters.
+            long and can consist of any UTF-8 characters.
         description (str):
-            Optional. The description of the Dataset.
+            The description of the Dataset.
         metadata_schema_uri (str):
             Required. Points to a YAML file stored on
             Google Cloud Storage describing additional
@@ -88,6 +88,11 @@ class Dataset(proto.Message):
             Dataset. If set, this Dataset and all
             sub-resources of this Dataset will be secured by
             this key.
+        metadata_artifact (str):
+            Output only. The resource name of the Artifact that was
+            created in MetadataStore when creating the Dataset. The
+            Artifact resource name pattern is
+            ``projects/{project}/locations/{location}/metadataStores/{metadata_store}/artifacts/{artifact}``.
     """
 
     name = proto.Field(
@@ -134,6 +139,10 @@ class Dataset(proto.Message):
         proto.MESSAGE,
         number=11,
         message=gca_encryption_spec.EncryptionSpec,
+    )
+    metadata_artifact = proto.Field(
+        proto.STRING,
+        number=17,
     )
 
 

--- a/google/cloud/aiplatform_v1beta1/types/endpoint.py
+++ b/google/cloud/aiplatform_v1beta1/types/endpoint.py
@@ -44,7 +44,7 @@ class Endpoint(proto.Message):
         display_name (str):
             Required. The display name of the Endpoint.
             The name can be up to 128 characters long and
-            can be consist of any UTF-8 characters.
+            can consist of any UTF-8 characters.
         description (str):
             The description of the Endpoint.
         deployed_models (Sequence[google.cloud.aiplatform_v1beta1.types.DeployedModel]):

--- a/google/cloud/aiplatform_v1beta1/types/entity_type.py
+++ b/google/cloud/aiplatform_v1beta1/types/entity_type.py
@@ -79,6 +79,14 @@ class EntityType(proto.Message):
             [FeaturestoreMonitoringConfig.monitoring_interval]
             specified, snapshot analysis monitoring is enabled.
             Otherwise, snapshot analysis monitoring is disabled.
+        offline_storage_ttl_days (int):
+            Optional. Config for data retention policy in offline
+            storage. TTL in days for feature values that will be stored
+            in offline storage. The Feature Store offline storage
+            periodically removes obsolete feature values older than
+            ``offline_storage_ttl_days`` since the feature generation
+            time. If unset (or explicitly set to 0), default to 4000
+            days TTL.
     """
 
     name = proto.Field(
@@ -112,6 +120,10 @@ class EntityType(proto.Message):
         proto.MESSAGE,
         number=8,
         message=featurestore_monitoring.FeaturestoreMonitoringConfig,
+    )
+    offline_storage_ttl_days = proto.Field(
+        proto.INT32,
+        number=10,
     )
 
 

--- a/google/cloud/aiplatform_v1beta1/types/featurestore.py
+++ b/google/cloud/aiplatform_v1beta1/types/featurestore.py
@@ -69,6 +69,15 @@ class Featurestore(proto.Message):
             serving.
         state (google.cloud.aiplatform_v1beta1.types.Featurestore.State):
             Output only. State of the featurestore.
+        online_storage_ttl_days (int):
+            Optional. TTL in days for feature values that will be stored
+            in online serving storage. The Feature Store online storage
+            periodically removes obsolete feature values older than
+            ``online_storage_ttl_days`` since the feature generation
+            time. Note that ``online_storage_ttl_days`` should be less
+            than or equal to ``offline_storage_ttl_days`` for each
+            EntityType under a featurestore. If not set, default to 4000
+            days
         encryption_spec (google.cloud.aiplatform_v1beta1.types.EncryptionSpec):
             Optional. Customer-managed encryption key
             spec for data storage. If set, both of the
@@ -167,6 +176,10 @@ class Featurestore(proto.Message):
         proto.ENUM,
         number=8,
         enum=State,
+    )
+    online_storage_ttl_days = proto.Field(
+        proto.INT32,
+        number=13,
     )
     encryption_spec = proto.Field(
         proto.MESSAGE,

--- a/google/cloud/aiplatform_v1beta1/types/featurestore_service.py
+++ b/google/cloud/aiplatform_v1beta1/types/featurestore_service.py
@@ -266,6 +266,7 @@ class UpdateFeaturestoreRequest(proto.Message):
             -  ``labels``
             -  ``online_serving_config.fixed_node_count``
             -  ``online_serving_config.scaling``
+            -  ``online_storage_ttl_days``
     """
 
     featurestore = proto.Field(
@@ -1074,6 +1075,7 @@ class UpdateEntityTypeRequest(proto.Message):
             -  ``monitoring_config.import_features_analysis.anomaly_detection_baseline``
             -  ``monitoring_config.numerical_threshold_config.value``
             -  ``monitoring_config.categorical_threshold_config.value``
+            -  ``offline_storage_ttl_days``
     """
 
     entity_type = proto.Field(
@@ -1582,6 +1584,9 @@ class ImportFeatureValuesOperationMetadata(proto.Message):
         imported_feature_value_count (int):
             Number of Feature values that have been
             imported by the operation.
+        source_uris (Sequence[str]):
+            The source URI from where Feature values are
+            imported.
         invalid_row_count (int):
             The number of rows in input source that weren't imported due
             to either
@@ -1608,6 +1613,10 @@ class ImportFeatureValuesOperationMetadata(proto.Message):
     imported_feature_value_count = proto.Field(
         proto.INT64,
         number=3,
+    )
+    source_uris = proto.RepeatedField(
+        proto.STRING,
+        number=4,
     )
     invalid_row_count = proto.Field(
         proto.INT64,

--- a/google/cloud/aiplatform_v1beta1/types/hyperparameter_tuning_job.py
+++ b/google/cloud/aiplatform_v1beta1/types/hyperparameter_tuning_job.py
@@ -43,8 +43,8 @@ class HyperparameterTuningJob(proto.Message):
         display_name (str):
             Required. The display name of the
             HyperparameterTuningJob. The name can be up to
-            128 characters long and can be consist of any
-            UTF-8 characters.
+            128 characters long and can consist of any UTF-8
+            characters.
         study_spec (google.cloud.aiplatform_v1beta1.types.StudySpec):
             Required. Study configuration of the
             HyperparameterTuningJob.

--- a/google/cloud/aiplatform_v1beta1/types/index.py
+++ b/google/cloud/aiplatform_v1beta1/types/index.py
@@ -41,7 +41,7 @@ class Index(proto.Message):
         display_name (str):
             Required. The display name of the Index.
             The name can be up to 128 characters long and
-            can be consist of any UTF-8 characters.
+            can consist of any UTF-8 characters.
         description (str):
             The description of the Index.
         metadata_schema_uri (str):

--- a/google/cloud/aiplatform_v1beta1/types/job_service.py
+++ b/google/cloud/aiplatform_v1beta1/types/job_service.py
@@ -833,7 +833,7 @@ class SearchModelDeploymentMonitoringStatsAnomaliesRequest(proto.Message):
                 [SearchModelDeploymentMonitoringStatsAnomaliesRequest.start_time][google.cloud.aiplatform.v1beta1.SearchModelDeploymentMonitoringStatsAnomaliesRequest.start_time]
                 and
                 [SearchModelDeploymentMonitoringStatsAnomaliesRequest.end_time][google.cloud.aiplatform.v1beta1.SearchModelDeploymentMonitoringStatsAnomaliesRequest.end_time]
-                are fetched, and page token doesn't take affect in this
+                are fetched, and page token doesn't take effect in this
                 case. Only used to retrieve attribution score for the top
                 Features which has the highest attribution score in the
                 latest monitoring run.

--- a/google/cloud/aiplatform_v1beta1/types/model.py
+++ b/google/cloud/aiplatform_v1beta1/types/model.py
@@ -66,7 +66,7 @@ class Model(proto.Message):
         display_name (str):
             Required. The display name of the Model.
             The name can be up to 128 characters long and
-            can be consist of any UTF-8 characters.
+            can consist of any UTF-8 characters.
         description (str):
             The description of the Model.
         version_description (str):

--- a/google/cloud/aiplatform_v1beta1/types/model_deployment_monitoring_job.py
+++ b/google/cloud/aiplatform_v1beta1/types/model_deployment_monitoring_job.py
@@ -60,7 +60,7 @@ class ModelDeploymentMonitoringJob(proto.Message):
         display_name (str):
             Required. The user-defined name of the
             ModelDeploymentMonitoringJob. The name can be up
-            to 128 characters long and can be consist of any
+            to 128 characters long and can consist of any
             UTF-8 characters.
             Display name of a ModelDeploymentMonitoringJob.
         endpoint (str):

--- a/google/cloud/aiplatform_v1beta1/types/operation.py
+++ b/google/cloud/aiplatform_v1beta1/types/operation.py
@@ -36,8 +36,8 @@ class GenericOperationMetadata(proto.Message):
             Output only. Partial failures encountered.
             E.g. single files that couldn't be read.
             This field should never exceed 20 entries.
-            Status details field will contain standard GCP
-            error details.
+            Status details field will contain standard
+            Google Cloud error details.
         create_time (google.protobuf.timestamp_pb2.Timestamp):
             Output only. Time when the operation was
             created.

--- a/google/cloud/aiplatform_v1beta1/types/pipeline_job.py
+++ b/google/cloud/aiplatform_v1beta1/types/pipeline_job.py
@@ -49,7 +49,7 @@ class PipelineJob(proto.Message):
         display_name (str):
             The display name of the Pipeline.
             The name can be up to 128 characters long and
-            can be consist of any UTF-8 characters.
+            can consist of any UTF-8 characters.
         create_time (google.protobuf.timestamp_pb2.Timestamp):
             Output only. Pipeline creation time.
         start_time (google.protobuf.timestamp_pb2.Timestamp):
@@ -108,9 +108,9 @@ class PipelineJob(proto.Message):
 
             Private services access must already be configured for the
             network. Pipeline job will apply the network configuration
-            to the GCP resources being launched, if applied, such as
-            Vertex AI Training or Dataflow job. If left unspecified, the
-            workload is not peered with any network.
+            to the Google Cloud resources being launched, if applied,
+            such as Vertex AI Training or Dataflow job. If left
+            unspecified, the workload is not peered with any network.
         template_uri (str):
             A template uri from where the
             [PipelineJob.pipeline_spec][google.cloud.aiplatform.v1beta1.PipelineJob.pipeline_spec],

--- a/google/cloud/aiplatform_v1beta1/types/specialist_pool.py
+++ b/google/cloud/aiplatform_v1beta1/types/specialist_pool.py
@@ -40,7 +40,7 @@ class SpecialistPool(proto.Message):
         display_name (str):
             Required. The user-defined name of the
             SpecialistPool. The name can be up to 128
-            characters long and can be consist of any UTF-8
+            characters long and can consist of any UTF-8
             characters.
             This field should be unique on project-level.
         specialist_managers_count (int):

--- a/google/cloud/aiplatform_v1beta1/types/tensorboard.py
+++ b/google/cloud/aiplatform_v1beta1/types/tensorboard.py
@@ -30,8 +30,8 @@ __protobuf__ = proto.module(
 class Tensorboard(proto.Message):
     r"""Tensorboard is a physical database that stores users'
     training metrics. A default Tensorboard is provided in each
-    region of a GCP project. If needed users can also create extra
-    Tensorboards in their projects.
+    region of a Google Cloud project. If needed users can also
+    create extra Tensorboards in their projects.
 
     Attributes:
         name (str):

--- a/samples/generated_samples/aiplatform_v1_generated_featurestore_online_serving_service_write_feature_values_async.py
+++ b/samples/generated_samples/aiplatform_v1_generated_featurestore_online_serving_service_write_feature_values_async.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for WriteFeatureValues
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-aiplatform
+
+
+# [START aiplatform_v1_generated_FeaturestoreOnlineServingService_WriteFeatureValues_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import aiplatform_v1
+
+
+async def sample_write_feature_values():
+    # Create a client
+    client = aiplatform_v1.FeaturestoreOnlineServingServiceAsyncClient()
+
+    # Initialize request argument(s)
+    payloads = aiplatform_v1.WriteFeatureValuesPayload()
+    payloads.entity_id = "entity_id_value"
+
+    request = aiplatform_v1.WriteFeatureValuesRequest(
+        entity_type="entity_type_value",
+        payloads=payloads,
+    )
+
+    # Make the request
+    response = await client.write_feature_values(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END aiplatform_v1_generated_FeaturestoreOnlineServingService_WriteFeatureValues_async]

--- a/samples/generated_samples/aiplatform_v1_generated_featurestore_online_serving_service_write_feature_values_sync.py
+++ b/samples/generated_samples/aiplatform_v1_generated_featurestore_online_serving_service_write_feature_values_sync.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for WriteFeatureValues
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-aiplatform
+
+
+# [START aiplatform_v1_generated_FeaturestoreOnlineServingService_WriteFeatureValues_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import aiplatform_v1
+
+
+def sample_write_feature_values():
+    # Create a client
+    client = aiplatform_v1.FeaturestoreOnlineServingServiceClient()
+
+    # Initialize request argument(s)
+    payloads = aiplatform_v1.WriteFeatureValuesPayload()
+    payloads.entity_id = "entity_id_value"
+
+    request = aiplatform_v1.WriteFeatureValuesRequest(
+        entity_type="entity_type_value",
+        payloads=payloads,
+    )
+
+    # Make the request
+    response = client.write_feature_values(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END aiplatform_v1_generated_FeaturestoreOnlineServingService_WriteFeatureValues_sync]

--- a/samples/generated_samples/snippet_metadata_aiplatform_v1.json
+++ b/samples/generated_samples/snippet_metadata_aiplatform_v1.json
@@ -3323,6 +3323,175 @@
       "clientMethod": {
         "async": true,
         "client": {
+          "fullName": "google.cloud.aiplatform_v1.FeaturestoreOnlineServingServiceAsyncClient",
+          "shortName": "FeaturestoreOnlineServingServiceAsyncClient"
+        },
+        "fullName": "google.cloud.aiplatform_v1.FeaturestoreOnlineServingServiceAsyncClient.write_feature_values",
+        "method": {
+          "fullName": "google.cloud.aiplatform.v1.FeaturestoreOnlineServingService.WriteFeatureValues",
+          "service": {
+            "fullName": "google.cloud.aiplatform.v1.FeaturestoreOnlineServingService",
+            "shortName": "FeaturestoreOnlineServingService"
+          },
+          "shortName": "WriteFeatureValues"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.aiplatform_v1.types.WriteFeatureValuesRequest"
+          },
+          {
+            "name": "entity_type",
+            "type": "str"
+          },
+          {
+            "name": "payloads",
+            "type": "Sequence[google.cloud.aiplatform_v1.types.WriteFeatureValuesPayload]"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.aiplatform_v1.types.WriteFeatureValuesResponse",
+        "shortName": "write_feature_values"
+      },
+      "description": "Sample for WriteFeatureValues",
+      "file": "aiplatform_v1_generated_featurestore_online_serving_service_write_feature_values_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "aiplatform_v1_generated_FeaturestoreOnlineServingService_WriteFeatureValues_async",
+      "segments": [
+        {
+          "end": 55,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 55,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 49,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 52,
+          "start": 50,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 56,
+          "start": 53,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "aiplatform_v1_generated_featurestore_online_serving_service_write_feature_values_async.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "client": {
+          "fullName": "google.cloud.aiplatform_v1.FeaturestoreOnlineServingServiceClient",
+          "shortName": "FeaturestoreOnlineServingServiceClient"
+        },
+        "fullName": "google.cloud.aiplatform_v1.FeaturestoreOnlineServingServiceClient.write_feature_values",
+        "method": {
+          "fullName": "google.cloud.aiplatform.v1.FeaturestoreOnlineServingService.WriteFeatureValues",
+          "service": {
+            "fullName": "google.cloud.aiplatform.v1.FeaturestoreOnlineServingService",
+            "shortName": "FeaturestoreOnlineServingService"
+          },
+          "shortName": "WriteFeatureValues"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.aiplatform_v1.types.WriteFeatureValuesRequest"
+          },
+          {
+            "name": "entity_type",
+            "type": "str"
+          },
+          {
+            "name": "payloads",
+            "type": "Sequence[google.cloud.aiplatform_v1.types.WriteFeatureValuesPayload]"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, str]"
+          }
+        ],
+        "resultType": "google.cloud.aiplatform_v1.types.WriteFeatureValuesResponse",
+        "shortName": "write_feature_values"
+      },
+      "description": "Sample for WriteFeatureValues",
+      "file": "aiplatform_v1_generated_featurestore_online_serving_service_write_feature_values_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "aiplatform_v1_generated_FeaturestoreOnlineServingService_WriteFeatureValues_sync",
+      "segments": [
+        {
+          "end": 55,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 55,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 49,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 52,
+          "start": 50,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 56,
+          "start": 53,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "aiplatform_v1_generated_featurestore_online_serving_service_write_feature_values_sync.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "async": true,
+        "client": {
           "fullName": "google.cloud.aiplatform_v1.FeaturestoreServiceAsyncClient",
           "shortName": "FeaturestoreServiceAsyncClient"
         },

--- a/tests/unit/gapic/aiplatform_v1/test_dataset_service.py
+++ b/tests/unit/gapic/aiplatform_v1/test_dataset_service.py
@@ -965,6 +965,7 @@ def test_get_dataset(request_type, transport: str = "grpc"):
             description="description_value",
             metadata_schema_uri="metadata_schema_uri_value",
             etag="etag_value",
+            metadata_artifact="metadata_artifact_value",
         )
         response = client.get_dataset(request)
 
@@ -980,6 +981,7 @@ def test_get_dataset(request_type, transport: str = "grpc"):
     assert response.description == "description_value"
     assert response.metadata_schema_uri == "metadata_schema_uri_value"
     assert response.etag == "etag_value"
+    assert response.metadata_artifact == "metadata_artifact_value"
 
 
 def test_get_dataset_empty_call():
@@ -1021,6 +1023,7 @@ async def test_get_dataset_async(
                 description="description_value",
                 metadata_schema_uri="metadata_schema_uri_value",
                 etag="etag_value",
+                metadata_artifact="metadata_artifact_value",
             )
         )
         response = await client.get_dataset(request)
@@ -1037,6 +1040,7 @@ async def test_get_dataset_async(
     assert response.description == "description_value"
     assert response.metadata_schema_uri == "metadata_schema_uri_value"
     assert response.etag == "etag_value"
+    assert response.metadata_artifact == "metadata_artifact_value"
 
 
 @pytest.mark.asyncio
@@ -1209,6 +1213,7 @@ def test_update_dataset(request_type, transport: str = "grpc"):
             description="description_value",
             metadata_schema_uri="metadata_schema_uri_value",
             etag="etag_value",
+            metadata_artifact="metadata_artifact_value",
         )
         response = client.update_dataset(request)
 
@@ -1224,6 +1229,7 @@ def test_update_dataset(request_type, transport: str = "grpc"):
     assert response.description == "description_value"
     assert response.metadata_schema_uri == "metadata_schema_uri_value"
     assert response.etag == "etag_value"
+    assert response.metadata_artifact == "metadata_artifact_value"
 
 
 def test_update_dataset_empty_call():
@@ -1265,6 +1271,7 @@ async def test_update_dataset_async(
                 description="description_value",
                 metadata_schema_uri="metadata_schema_uri_value",
                 etag="etag_value",
+                metadata_artifact="metadata_artifact_value",
             )
         )
         response = await client.update_dataset(request)
@@ -1281,6 +1288,7 @@ async def test_update_dataset_async(
     assert response.description == "description_value"
     assert response.metadata_schema_uri == "metadata_schema_uri_value"
     assert response.etag == "etag_value"
+    assert response.metadata_artifact == "metadata_artifact_value"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/gapic/aiplatform_v1/test_featurestore_online_serving_service.py
+++ b/tests/unit/gapic/aiplatform_v1/test_featurestore_online_serving_service.py
@@ -48,12 +48,14 @@ from google.cloud.aiplatform_v1.services.featurestore_online_serving_service imp
 )
 from google.cloud.aiplatform_v1.types import feature_selector
 from google.cloud.aiplatform_v1.types import featurestore_online_service
+from google.cloud.aiplatform_v1.types import types
 from google.cloud.location import locations_pb2
 from google.iam.v1 import iam_policy_pb2  # type: ignore
 from google.iam.v1 import options_pb2  # type: ignore
 from google.iam.v1 import policy_pb2  # type: ignore
 from google.longrunning import operations_pb2
 from google.oauth2 import service_account
+from google.protobuf import timestamp_pb2  # type: ignore
 import google.auth
 
 
@@ -1235,6 +1237,281 @@ async def test_streaming_read_feature_values_flattened_error_async():
         )
 
 
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        featurestore_online_service.WriteFeatureValuesRequest,
+        dict,
+    ],
+)
+def test_write_feature_values(request_type, transport: str = "grpc"):
+    client = FeaturestoreOnlineServingServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
+    )
+
+    # Everything is optional in proto3 as far as the runtime is concerned,
+    # and we are mocking out the actual API, so just send an empty request.
+    request = request_type()
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.write_feature_values), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = featurestore_online_service.WriteFeatureValuesResponse()
+        response = client.write_feature_values(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls) == 1
+        _, args, _ = call.mock_calls[0]
+        assert args[0] == featurestore_online_service.WriteFeatureValuesRequest()
+
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, featurestore_online_service.WriteFeatureValuesResponse)
+
+
+def test_write_feature_values_empty_call():
+    # This test is a coverage failsafe to make sure that totally empty calls,
+    # i.e. request == None and no flattened fields passed, work.
+    client = FeaturestoreOnlineServingServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.write_feature_values), "__call__"
+    ) as call:
+        client.write_feature_values()
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        assert args[0] == featurestore_online_service.WriteFeatureValuesRequest()
+
+
+@pytest.mark.asyncio
+async def test_write_feature_values_async(
+    transport: str = "grpc_asyncio",
+    request_type=featurestore_online_service.WriteFeatureValuesRequest,
+):
+    client = FeaturestoreOnlineServingServiceAsyncClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
+    )
+
+    # Everything is optional in proto3 as far as the runtime is concerned,
+    # and we are mocking out the actual API, so just send an empty request.
+    request = request_type()
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.write_feature_values), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
+            featurestore_online_service.WriteFeatureValuesResponse()
+        )
+        response = await client.write_feature_values(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls)
+        _, args, _ = call.mock_calls[0]
+        assert args[0] == featurestore_online_service.WriteFeatureValuesRequest()
+
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, featurestore_online_service.WriteFeatureValuesResponse)
+
+
+@pytest.mark.asyncio
+async def test_write_feature_values_async_from_dict():
+    await test_write_feature_values_async(request_type=dict)
+
+
+def test_write_feature_values_field_headers():
+    client = FeaturestoreOnlineServingServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Any value that is part of the HTTP/1.1 URI should be sent as
+    # a field header. Set these to a non-empty value.
+    request = featurestore_online_service.WriteFeatureValuesRequest()
+
+    request.entity_type = "entity_type_value"
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.write_feature_values), "__call__"
+    ) as call:
+        call.return_value = featurestore_online_service.WriteFeatureValuesResponse()
+        client.write_feature_values(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls) == 1
+        _, args, _ = call.mock_calls[0]
+        assert args[0] == request
+
+    # Establish that the field header was sent.
+    _, _, kw = call.mock_calls[0]
+    assert (
+        "x-goog-request-params",
+        "entity_type=entity_type_value",
+    ) in kw["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_write_feature_values_field_headers_async():
+    client = FeaturestoreOnlineServingServiceAsyncClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Any value that is part of the HTTP/1.1 URI should be sent as
+    # a field header. Set these to a non-empty value.
+    request = featurestore_online_service.WriteFeatureValuesRequest()
+
+    request.entity_type = "entity_type_value"
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.write_feature_values), "__call__"
+    ) as call:
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
+            featurestore_online_service.WriteFeatureValuesResponse()
+        )
+        await client.write_feature_values(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls)
+        _, args, _ = call.mock_calls[0]
+        assert args[0] == request
+
+    # Establish that the field header was sent.
+    _, _, kw = call.mock_calls[0]
+    assert (
+        "x-goog-request-params",
+        "entity_type=entity_type_value",
+    ) in kw["metadata"]
+
+
+def test_write_feature_values_flattened():
+    client = FeaturestoreOnlineServingServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.write_feature_values), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = featurestore_online_service.WriteFeatureValuesResponse()
+        # Call the method with a truthy value for each flattened field,
+        # using the keyword arguments to the method.
+        client.write_feature_values(
+            entity_type="entity_type_value",
+            payloads=[
+                featurestore_online_service.WriteFeatureValuesPayload(
+                    entity_id="entity_id_value"
+                )
+            ],
+        )
+
+        # Establish that the underlying call was made with the expected
+        # request object values.
+        assert len(call.mock_calls) == 1
+        _, args, _ = call.mock_calls[0]
+        arg = args[0].entity_type
+        mock_val = "entity_type_value"
+        assert arg == mock_val
+        arg = args[0].payloads
+        mock_val = [
+            featurestore_online_service.WriteFeatureValuesPayload(
+                entity_id="entity_id_value"
+            )
+        ]
+        assert arg == mock_val
+
+
+def test_write_feature_values_flattened_error():
+    client = FeaturestoreOnlineServingServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Attempting to call a method with both a request object and flattened
+    # fields is an error.
+    with pytest.raises(ValueError):
+        client.write_feature_values(
+            featurestore_online_service.WriteFeatureValuesRequest(),
+            entity_type="entity_type_value",
+            payloads=[
+                featurestore_online_service.WriteFeatureValuesPayload(
+                    entity_id="entity_id_value"
+                )
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_write_feature_values_flattened_async():
+    client = FeaturestoreOnlineServingServiceAsyncClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.write_feature_values), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = featurestore_online_service.WriteFeatureValuesResponse()
+
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
+            featurestore_online_service.WriteFeatureValuesResponse()
+        )
+        # Call the method with a truthy value for each flattened field,
+        # using the keyword arguments to the method.
+        response = await client.write_feature_values(
+            entity_type="entity_type_value",
+            payloads=[
+                featurestore_online_service.WriteFeatureValuesPayload(
+                    entity_id="entity_id_value"
+                )
+            ],
+        )
+
+        # Establish that the underlying call was made with the expected
+        # request object values.
+        assert len(call.mock_calls)
+        _, args, _ = call.mock_calls[0]
+        arg = args[0].entity_type
+        mock_val = "entity_type_value"
+        assert arg == mock_val
+        arg = args[0].payloads
+        mock_val = [
+            featurestore_online_service.WriteFeatureValuesPayload(
+                entity_id="entity_id_value"
+            )
+        ]
+        assert arg == mock_val
+
+
+@pytest.mark.asyncio
+async def test_write_feature_values_flattened_error_async():
+    client = FeaturestoreOnlineServingServiceAsyncClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Attempting to call a method with both a request object and flattened
+    # fields is an error.
+    with pytest.raises(ValueError):
+        await client.write_feature_values(
+            featurestore_online_service.WriteFeatureValuesRequest(),
+            entity_type="entity_type_value",
+            payloads=[
+                featurestore_online_service.WriteFeatureValuesPayload(
+                    entity_id="entity_id_value"
+                )
+            ],
+        )
+
+
 def test_credentials_transport_error():
     # It is an error to provide credentials and a transport instance.
     transport = transports.FeaturestoreOnlineServingServiceGrpcTransport(
@@ -1376,6 +1653,7 @@ def test_featurestore_online_serving_service_base_transport():
     methods = (
         "read_feature_values",
         "streaming_read_feature_values",
+        "write_feature_values",
         "set_iam_policy",
         "get_iam_policy",
         "test_iam_permissions",

--- a/tests/unit/gapic/aiplatform_v1beta1/test_dataset_service.py
+++ b/tests/unit/gapic/aiplatform_v1beta1/test_dataset_service.py
@@ -967,6 +967,7 @@ def test_get_dataset(request_type, transport: str = "grpc"):
             description="description_value",
             metadata_schema_uri="metadata_schema_uri_value",
             etag="etag_value",
+            metadata_artifact="metadata_artifact_value",
         )
         response = client.get_dataset(request)
 
@@ -982,6 +983,7 @@ def test_get_dataset(request_type, transport: str = "grpc"):
     assert response.description == "description_value"
     assert response.metadata_schema_uri == "metadata_schema_uri_value"
     assert response.etag == "etag_value"
+    assert response.metadata_artifact == "metadata_artifact_value"
 
 
 def test_get_dataset_empty_call():
@@ -1023,6 +1025,7 @@ async def test_get_dataset_async(
                 description="description_value",
                 metadata_schema_uri="metadata_schema_uri_value",
                 etag="etag_value",
+                metadata_artifact="metadata_artifact_value",
             )
         )
         response = await client.get_dataset(request)
@@ -1039,6 +1042,7 @@ async def test_get_dataset_async(
     assert response.description == "description_value"
     assert response.metadata_schema_uri == "metadata_schema_uri_value"
     assert response.etag == "etag_value"
+    assert response.metadata_artifact == "metadata_artifact_value"
 
 
 @pytest.mark.asyncio
@@ -1211,6 +1215,7 @@ def test_update_dataset(request_type, transport: str = "grpc"):
             description="description_value",
             metadata_schema_uri="metadata_schema_uri_value",
             etag="etag_value",
+            metadata_artifact="metadata_artifact_value",
         )
         response = client.update_dataset(request)
 
@@ -1226,6 +1231,7 @@ def test_update_dataset(request_type, transport: str = "grpc"):
     assert response.description == "description_value"
     assert response.metadata_schema_uri == "metadata_schema_uri_value"
     assert response.etag == "etag_value"
+    assert response.metadata_artifact == "metadata_artifact_value"
 
 
 def test_update_dataset_empty_call():
@@ -1267,6 +1273,7 @@ async def test_update_dataset_async(
                 description="description_value",
                 metadata_schema_uri="metadata_schema_uri_value",
                 etag="etag_value",
+                metadata_artifact="metadata_artifact_value",
             )
         )
         response = await client.update_dataset(request)
@@ -1283,6 +1290,7 @@ async def test_update_dataset_async(
     assert response.description == "description_value"
     assert response.metadata_schema_uri == "metadata_schema_uri_value"
     assert response.etag == "etag_value"
+    assert response.metadata_artifact == "metadata_artifact_value"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/gapic/aiplatform_v1beta1/test_featurestore_service.py
+++ b/tests/unit/gapic/aiplatform_v1beta1/test_featurestore_service.py
@@ -1017,6 +1017,7 @@ def test_get_featurestore(request_type, transport: str = "grpc"):
             name="name_value",
             etag="etag_value",
             state=featurestore.Featurestore.State.STABLE,
+            online_storage_ttl_days=2460,
         )
         response = client.get_featurestore(request)
 
@@ -1030,6 +1031,7 @@ def test_get_featurestore(request_type, transport: str = "grpc"):
     assert response.name == "name_value"
     assert response.etag == "etag_value"
     assert response.state == featurestore.Featurestore.State.STABLE
+    assert response.online_storage_ttl_days == 2460
 
 
 def test_get_featurestore_empty_call():
@@ -1070,6 +1072,7 @@ async def test_get_featurestore_async(
                 name="name_value",
                 etag="etag_value",
                 state=featurestore.Featurestore.State.STABLE,
+                online_storage_ttl_days=2460,
             )
         )
         response = await client.get_featurestore(request)
@@ -1084,6 +1087,7 @@ async def test_get_featurestore_async(
     assert response.name == "name_value"
     assert response.etag == "etag_value"
     assert response.state == featurestore.Featurestore.State.STABLE
+    assert response.online_storage_ttl_days == 2460
 
 
 @pytest.mark.asyncio
@@ -2464,6 +2468,7 @@ def test_get_entity_type(request_type, transport: str = "grpc"):
             name="name_value",
             description="description_value",
             etag="etag_value",
+            offline_storage_ttl_days=2554,
         )
         response = client.get_entity_type(request)
 
@@ -2477,6 +2482,7 @@ def test_get_entity_type(request_type, transport: str = "grpc"):
     assert response.name == "name_value"
     assert response.description == "description_value"
     assert response.etag == "etag_value"
+    assert response.offline_storage_ttl_days == 2554
 
 
 def test_get_entity_type_empty_call():
@@ -2517,6 +2523,7 @@ async def test_get_entity_type_async(
                 name="name_value",
                 description="description_value",
                 etag="etag_value",
+                offline_storage_ttl_days=2554,
             )
         )
         response = await client.get_entity_type(request)
@@ -2531,6 +2538,7 @@ async def test_get_entity_type_async(
     assert response.name == "name_value"
     assert response.description == "description_value"
     assert response.etag == "etag_value"
+    assert response.offline_storage_ttl_days == 2554
 
 
 @pytest.mark.asyncio
@@ -3150,6 +3158,7 @@ def test_update_entity_type(request_type, transport: str = "grpc"):
             name="name_value",
             description="description_value",
             etag="etag_value",
+            offline_storage_ttl_days=2554,
         )
         response = client.update_entity_type(request)
 
@@ -3163,6 +3172,7 @@ def test_update_entity_type(request_type, transport: str = "grpc"):
     assert response.name == "name_value"
     assert response.description == "description_value"
     assert response.etag == "etag_value"
+    assert response.offline_storage_ttl_days == 2554
 
 
 def test_update_entity_type_empty_call():
@@ -3207,6 +3217,7 @@ async def test_update_entity_type_async(
                 name="name_value",
                 description="description_value",
                 etag="etag_value",
+                offline_storage_ttl_days=2554,
             )
         )
         response = await client.update_entity_type(request)
@@ -3221,6 +3232,7 @@ async def test_update_entity_type_async(
     assert response.name == "name_value"
     assert response.description == "description_value"
     assert response.etag == "etag_value"
+    assert response.offline_storage_ttl_days == 2554
 
 
 @pytest.mark.asyncio

--- a/tests/unit/gapic/aiplatform_v1beta1/test_migration_service.py
+++ b/tests/unit/gapic/aiplatform_v1beta1/test_migration_service.py
@@ -2006,8 +2006,31 @@ def test_parse_annotated_dataset_path():
 
 def test_dataset_path():
     project = "cuttlefish"
-    location = "mussel"
-    dataset = "winkle"
+    dataset = "mussel"
+    expected = "projects/{project}/datasets/{dataset}".format(
+        project=project,
+        dataset=dataset,
+    )
+    actual = MigrationServiceClient.dataset_path(project, dataset)
+    assert expected == actual
+
+
+def test_parse_dataset_path():
+    expected = {
+        "project": "winkle",
+        "dataset": "nautilus",
+    }
+    path = MigrationServiceClient.dataset_path(**expected)
+
+    # Check that the path construction is reversible.
+    actual = MigrationServiceClient.parse_dataset_path(path)
+    assert expected == actual
+
+
+def test_dataset_path():
+    project = "scallop"
+    location = "abalone"
+    dataset = "squid"
     expected = "projects/{project}/locations/{location}/datasets/{dataset}".format(
         project=project,
         location=location,
@@ -2019,31 +2042,8 @@ def test_dataset_path():
 
 def test_parse_dataset_path():
     expected = {
-        "project": "nautilus",
-        "location": "scallop",
-        "dataset": "abalone",
-    }
-    path = MigrationServiceClient.dataset_path(**expected)
-
-    # Check that the path construction is reversible.
-    actual = MigrationServiceClient.parse_dataset_path(path)
-    assert expected == actual
-
-
-def test_dataset_path():
-    project = "squid"
-    dataset = "clam"
-    expected = "projects/{project}/datasets/{dataset}".format(
-        project=project,
-        dataset=dataset,
-    )
-    actual = MigrationServiceClient.dataset_path(project, dataset)
-    assert expected == actual
-
-
-def test_parse_dataset_path():
-    expected = {
-        "project": "whelk",
+        "project": "clam",
+        "location": "whelk",
         "dataset": "octopus",
     }
     path = MigrationServiceClient.dataset_path(**expected)


### PR DESCRIPTION
This replaces https://github.com/googleapis/python-aiplatform/pull/1782.

Targeting 1.20.0 release.