### PR TITLE
fix: fix aiplatform import issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ setuptools.setup(
         "google-cloud-storage >= 1.32.0, < 3.0.0dev",
         "google-cloud-bigquery >= 1.15.0, < 3.0.0dev",
         "google-cloud-resource-manager >= 1.3.3, < 3.0.0dev",
-        "shapely < 2",
+        "shapely < 2.0.0",
     ),
     extras_require={
         "endpoint": endpoint_extra_require,

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,7 @@ setuptools.setup(
         "google-cloud-storage >= 1.32.0, < 3.0.0dev",
         "google-cloud-bigquery >= 1.15.0, < 3.0.0dev",
         "google-cloud-resource-manager >= 1.3.3, < 3.0.0dev",
+        "shapely < 2",
     ),
     extras_require={
         "endpoint": endpoint_extra_require,


### PR DESCRIPTION
In Colab, shapely is used by imgaug, anyone using imgaug alongside with aiplatform will run into an error `AttributeError: module 'shapely.geos' has no attribute 'WKTReader'` when importing aiplatform.

Adding a constraint with `shapely<2.0.0` in `google-cloud-aiplatform` will fix this.

Fixes #1852 🦕