### PR TITLE
 fix: removing the parameters to fit the current sklearn predict module

### DIFF
--- a/samples/snippets/prediction_service/predict_custom_trained_model_sample.py
+++ b/samples/snippets/prediction_service/predict_custom_trained_model_sample.py
@@ -41,20 +41,18 @@ def predict_custom_trained_model_sample(
     instances = [
         json_format.ParseDict(instance_dict, Value()) for instance_dict in instances
     ]
-    parameters_dict = {}
-    parameters = json_format.ParseDict(parameters_dict, Value())
+
     endpoint = client.endpoint_path(
         project=project, location=location, endpoint=endpoint_id
     )
     response = client.predict(
-        endpoint=endpoint, instances=instances, parameters=parameters
+        endpoint=endpoint, instances=instances
     )
     print("response")
     print(" deployed_model_id:", response.deployed_model_id)
     # The predictions are a google.protobuf.Value representation of the model's predictions.
     predictions = response.predictions
-    for prediction in predictions:
-        print(" prediction:", dict(prediction))
+    return predictions
 
 
 # [END aiplatform_predict_custom_trained_model_sample]

--- a/samples/snippets/prediction_service/predict_custom_trained_model_sample.py
+++ b/samples/snippets/prediction_service/predict_custom_trained_model_sample.py
@@ -41,7 +41,6 @@ def predict_custom_trained_model_sample(
     instances = [
         json_format.ParseDict(instance_dict, Value()) for instance_dict in instances
     ]
-
     endpoint = client.endpoint_path(
         project=project, location=location, endpoint=endpoint_id
     )

--- a/samples/snippets/prediction_service/predict_custom_trained_model_sample.py
+++ b/samples/snippets/prediction_service/predict_custom_trained_model_sample.py
@@ -51,6 +51,7 @@ def predict_custom_trained_model_sample(
     print(" deployed_model_id:", response.deployed_model_id)
     # The predictions are a google.protobuf.Value representation of the model's predictions.
     predictions = response.predictions
+    
     return predictions
 
 


### PR DESCRIPTION
This snippet of code were giving me this error:

google.api_core.exceptions.FailedPrecondition: 400 "Prediction failed: Exception during sklearn prediction: predict() got an unexpected keyword argument 'parameters'"

Deleting the step of parameters, I was able to use the endpoint as I'm predicting a local model, for example. I'm also suggesting return the predictions instead of a print to let the user decide what to do with the response.

With these changes I'm able to perform this following code:

```
pred = predict_custom_trained_model_sample(
    project=project,
    endpoint_id=endrpoind_id,
    location=location,
    instances=[[5.1, 3.5, 1.4, 0.2], [5.1, 3.5, 1.4, 0.2]]
)

```
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-aiplatform/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Get the necessary approvals
- [ ] Once the last commit on the PR has been approved, add the "ready to pull" label to the Pull Request

Note: do not merge your PR from GitHub. Adding the "ready to pull" label is the final step in the review process.
After approvals, the changes in your PR will be committed to the `main` branch and this PR will be closed.

Fixes #<issue_number_goes_here> 🦕