### PR TITLE
fix: change the parameters to fit the current sklearn predict module

### DIFF
--- a/samples/snippets/prediction_service/predict_custom_trained_model_sample.py
+++ b/samples/snippets/prediction_service/predict_custom_trained_model_sample.py
@@ -41,8 +41,6 @@ def predict_custom_trained_model_sample(
     instances = [
         json_format.ParseDict(instance_dict, Value()) for instance_dict in instances
     ]
-    parameters_dict = {}
-    parameters = json_format.ParseDict(parameters_dict, Value())
     endpoint = client.endpoint_path(
         project=project, location=location, endpoint=endpoint_id
     )
@@ -53,8 +51,8 @@ def predict_custom_trained_model_sample(
     print(" deployed_model_id:", response.deployed_model_id)
     # The predictions are a google.protobuf.Value representation of the model's predictions.
     predictions = response.predictions
-    for prediction in predictions:
-        print(" prediction:", dict(prediction))
+    
+    return predictions
 
 
 # [END aiplatform_predict_custom_trained_model_sample]

--- a/samples/snippets/prediction_service/predict_custom_trained_model_sample.py
+++ b/samples/snippets/prediction_service/predict_custom_trained_model_sample.py
@@ -45,7 +45,7 @@ def predict_custom_trained_model_sample(
         project=project, location=location, endpoint=endpoint_id
     )
     response = client.predict(
-        endpoint=endpoint, instances=instances, parameters=parameters
+        endpoint=endpoint, instances=instances
     )
     print("response")
     print(" deployed_model_id:", response.deployed_model_id)


### PR DESCRIPTION
This code snippet was giving me an error:

"google.api_core.exceptions.FailedPrecondition: 400 Prediction failed: Exception during sklearn prediction: predict() got an unexpected keyword argument 'parameters'."

After removing the parameters step, I was able to use the endpoint to predict from a local model. Additionally, I suggest returning the predictions rather than printing them, so that the user can decide what to do with the response. With these changes, I can perform the following code:

```
pred = predict_custom_trained_model_sample(
    project=project,
    endpoint_id=endrpoind_id,
    location=location,
    instances=[[5.1, 3.5, 1.4, 0.2], [5.1, 3.5, 1.4, 0.2]]
)
```