### PR TITLE
override __str__ and not __repr__

### DIFF
--- a/vertexai/language_models/_language_models.py
+++ b/vertexai/language_models/_language_models.py
@@ -219,7 +219,7 @@ class TextGenerationResponse:
     is_blocked: bool = False
     safety_attributes: Dict[str, float] = dataclasses.field(default_factory=dict)
 
-    def __repr__(self):
+    def __str__(self):
         return self.text
 
     @property


### PR DESCRIPTION
the __repr__ override in TextGenerationResponse goes against python coding guidelines and produces very surprising behaviour (I would argue that it's a bug), making it difficult to understand problems with the response from the API. The __str__ override is I believe what was originally intended.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-aiplatform/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Get the necessary approvals
- [ ] Once the last commit on the PR has been approved, add the "ready to pull" label to the Pull Request

Note: do not merge your PR from GitHub. Adding the "ready to pull" label is the final step in the review process.
After approvals, the changes in your PR will be committed to the `main` branch and this PR will be closed.

Fixes #2462  🦕