### PR TITLE
feat: Bump KFP template version for text-bison to latest (v3.0.0)

### DIFF
--- a/vertexai/_model_garden/_model_garden_models.py
+++ b/vertexai/_model_garden/_model_garden_models.py
@@ -31,7 +31,7 @@ from google.cloud.aiplatform.compat.types import (
 _SUPPORTED_PUBLISHERS = ["google"]
 
 _SHORT_MODEL_ID_TO_TUNING_PIPELINE_MAP = {
-    "text-bison": "https://us-kfp.pkg.dev/ml-pipeline/large-language-model-pipelines/tune-large-model/v2.0.0",
+    "text-bison": "https://us-kfp.pkg.dev/ml-pipeline/large-language-model-pipelines/tune-large-model/v3.0.0",
     "code-bison": "https://us-kfp.pkg.dev/ml-pipeline/large-language-model-pipelines/tune-large-model/v3.0.0",
     "chat-bison": "https://us-kfp.pkg.dev/ml-pipeline/large-language-model-pipelines/tune-large-chat-model/v3.0.0",
     "codechat-bison": "https://us-kfp.pkg.dev/ml-pipeline/large-language-model-pipelines/tune-large-chat-model/v3.0.0",


### PR DESCRIPTION
Set the text-bison KFP template to v3.0.0 as this is the template being used by the console based training jobs for text-bison

Test run:
- [X] Fine tuned a text-bison successfully from the SDK
