### PR TITLE
feat: include metadata for LLM models

### DIFF
--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -143,6 +143,8 @@ class Prediction(NamedTuple):
             [PredictSchemata's][google.cloud.aiplatform.v1beta1.Model.predict_schemata]
         deployed_model_id:
             ID of the Endpoint's DeployedModel that served this prediction.
+        metadata:
+            The metadata that are the output of the predictions call.
         model_version_id:
             ID of the DeployedModel's version that served this prediction.
         model_resource_name:
@@ -154,6 +156,7 @@ class Prediction(NamedTuple):
 
     predictions: List[Any]
     deployed_model_id: str
+    metadata: Optional[Any] = None
     model_version_id: Optional[str] = None
     model_resource_name: Optional[str] = None
     explanations: Optional[Sequence[gca_explanation_compat.Explanation]] = None
@@ -1566,12 +1569,14 @@ class Endpoint(base.VertexAiResourceNounWithFutureManager, base.PreviewMixin):
                 parameters=parameters,
                 timeout=timeout,
             )
+            metadata = json_format.MessageToDict(prediction_response._pb)["metadata"]
 
             return Prediction(
                 predictions=[
                     json_format.MessageToDict(item)
                     for item in prediction_response.predictions.pb
                 ],
+                metadata=metadata,
                 deployed_model_id=prediction_response.deployed_model_id,
                 model_version_id=prediction_response.model_version_id,
                 model_resource_name=prediction_response.model,

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1552,6 +1552,7 @@ class Endpoint(base.VertexAiResourceNounWithFutureManager, base.PreviewMixin):
             json_response = raw_predict_response.json()
             return Prediction(
                 predictions=json_response["predictions"],
+                metadata=json_response["metadata"],
                 deployed_model_id=raw_predict_response.headers[
                     _RAW_PREDICT_DEPLOYED_MODEL_ID_KEY
                 ],
@@ -1630,12 +1631,14 @@ class Endpoint(base.VertexAiResourceNounWithFutureManager, base.PreviewMixin):
             parameters=parameters,
             timeout=timeout,
         )
+        metadata = json_format.MessageToDict(prediction_response._pb.metadata)
 
         return Prediction(
             predictions=[
                 json_format.MessageToDict(item)
                 for item in prediction_response.predictions.pb
             ],
+            metadata=metadata,
             deployed_model_id=prediction_response.deployed_model_id,
             model_version_id=prediction_response.model_version_id,
             model_resource_name=prediction_response.model,
@@ -2281,6 +2284,7 @@ class PrivateEndpoint(Endpoint):
 
         return Prediction(
             predictions=prediction_response.get("predictions"),
+            metadata=prediction_response.get("metadata"),
             deployed_model_id=self._gca_resource.deployed_models[0].id,
         )
 

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -1569,7 +1569,7 @@ class Endpoint(base.VertexAiResourceNounWithFutureManager, base.PreviewMixin):
                 parameters=parameters,
                 timeout=timeout,
             )
-            metadata = json_format.MessageToDict(prediction_response._pb)["metadata"]
+            metadata = json_format.MessageToDict(prediction_response._pb.metadata)
 
             return Prediction(
                 predictions=[

--- a/tests/unit/aiplatform/test_endpoints.py
+++ b/tests/unit/aiplatform/test_endpoints.py
@@ -91,6 +91,7 @@ _TEST_VERSION_ID = test_constants.EndpointConstants._TEST_VERSION_ID
 _TEST_NETWORK = f"projects/{_TEST_PROJECT}/global/networks/{_TEST_ID}"
 
 _TEST_MODEL_ID = test_constants.EndpointConstants._TEST_MODEL_ID
+_TEST_METADATA = {"foo": "bar"}
 _TEST_PREDICTION = test_constants.EndpointConstants._TEST_PREDICTION
 _TEST_INSTANCES = [[1.0, 2.0, 3.0], [1.0, 3.0, 4.0]]
 _TEST_CREDENTIALS = mock.Mock(spec=auth_credentials.AnonymousCredentials())
@@ -458,6 +459,7 @@ def predict_client_predict_mock():
     ) as predict_mock:
         predict_mock.return_value = gca_prediction_service.PredictResponse(
             deployed_model_id=_TEST_MODEL_ID,
+            metadata=_TEST_METADATA,
             model_version_id=_TEST_VERSION_ID,
             model=_TEST_MODEL_NAME,
         )
@@ -469,6 +471,7 @@ def predict_client_predict_mock():
 def predict_async_client_predict_mock():
     response = gca_prediction_service.PredictResponse(
         deployed_model_id=_TEST_MODEL_ID,
+        metadata=_TEST_METADATA,
         model_version_id=_TEST_VERSION_ID,
         model=_TEST_MODEL_NAME,
     )
@@ -1851,6 +1854,7 @@ class TestEndpoint:
         true_prediction = models.Prediction(
             predictions=_TEST_PREDICTION,
             deployed_model_id=_TEST_ID,
+            metadata=_TEST_METADATA,
             model_version_id=_TEST_VERSION_ID,
             model_resource_name=_TEST_MODEL_NAME,
         )
@@ -1875,6 +1879,7 @@ class TestEndpoint:
         true_prediction = models.Prediction(
             predictions=_TEST_PREDICTION,
             deployed_model_id=_TEST_ID,
+            metadata=_TEST_METADATA,
             model_version_id=_TEST_VERSION_ID,
             model_resource_name=_TEST_MODEL_NAME,
         )

--- a/tests/unit/aiplatform/test_endpoints.py
+++ b/tests/unit/aiplatform/test_endpoints.py
@@ -607,7 +607,11 @@ def get_private_endpoint_with_model_mock():
 def predict_private_endpoint_mock():
     with mock.patch.object(urllib3.PoolManager, "request") as predict_mock:
         predict_mock.return_value = urllib3.response.HTTPResponse(
-            status=200, body=json.dumps({"predictions": _TEST_PREDICTION})
+            status=200,
+            body=json.dumps({
+                "predictions": _TEST_PREDICTION,
+                "metadata": _TEST_METADATA,
+            }),
         )
         yield predict_mock
 
@@ -2180,7 +2184,9 @@ class TestPrivateEndpoint:
         )
 
         true_prediction = models.Prediction(
-            predictions=_TEST_PREDICTION, deployed_model_id=_TEST_ID
+            predictions=_TEST_PREDICTION,
+            deployed_model_id=_TEST_ID,
+            metadata=_TEST_METADATA,
         )
 
         assert true_prediction == test_prediction


### PR DESCRIPTION
Hi,

This PR includes the metadata output field from Vertex AI Endpoints in `aiplatform.models.Prediction`.
Fixes #2639.