### PR TITLE
fix: Include negative prompt in parameters for Image Generation

### DIFF
--- a/vertexai/vision_models/_vision_models.py
+++ b/vertexai/vision_models/_vision_models.py
@@ -207,6 +207,8 @@ class ImageGenerationModel(
                 parameters["aspectRatio"] = f"{width}:{height}"
 
         parameters["sampleCount"] = number_of_images
+        if negative_prompt:
+            parameters["negativePrompt"] = negative_prompt
 
         if seed is not None:
             # Note: String seed and numerical seed give different results


### PR DESCRIPTION
Added negativePromt as part of parameters during image generation.

As per vertex AI Imagen [api reference](https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/image-generation) the negative prompt needs to be passed as a part of parameters