### PR TITLE
Use a daemon thread for tensorboard uploading.

### DIFF
--- a/google/cloud/aiplatform/tensorboard/uploader_tracker.py
+++ b/google/cloud/aiplatform/tensorboard/uploader_tracker.py
@@ -143,7 +143,7 @@ class _TensorBoardTracker:
             description=description,
             verbosity=0,
         )
-        threading.Thread(target=self._tensorboard_uploader.start_uploading).start()
+        threading.Thread(target=self._tensorboard_uploader.start_uploading, daemon=True).start()
 
     def end_upload_tb_log(self):
         """Ends the current TensorBoard uploader


### PR DESCRIPTION
A daemon thread does not keep the program alive when the main thread exits. Without this, the main thread can throw an exception which will leave the program hung because nothing ever calls end_upload_tb_log().

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-aiplatform/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Get the necessary approvals
- [ ] Once the last commit on the PR has been approved, add the "ready to pull" label to the Pull Request

Note: do not merge your PR from GitHub. Adding the "ready to pull" label is the final step in the review process.
After approvals, the changes in your PR will be committed to the `main` branch and this PR will be closed.

Fixes #3130 🦕