### PR TITLE
make SafetySettingsType for gemini model available outside

### DIFF
--- a/vertexai/preview/generative_models.py
+++ b/vertexai/preview/generative_models.py
@@ -30,6 +30,7 @@ from vertexai.generative_models._generative_models import (
     Image,
     Part,
     ResponseBlockedError,
+    SafetySettingsType,
     Tool,
 )
 
@@ -49,5 +50,6 @@ __all__ = [
     "Image",
     "Part",
     "ResponseBlockedError",
+    "SafetySettingsType",
     "Tool",
 ]


### PR DESCRIPTION
I'd like to expose the above type to outer packages - #3154

Fixes #3154