### PR TITLE
Allow user to create Part from function_call

### DIFF
--- a/vertexai/generative_models/_generative_models.py
+++ b/vertexai/generative_models/_generative_models.py
@@ -1502,6 +1502,15 @@ class Part:
             )
         )
 
+    @staticmethod
+    def from_function_call(function_name: str, arguments: Dict):
+        return Part._from_gapic(
+            raw_part=gapic_tool_types.FunctionCall(
+                name=function_name,
+                argumnts=arguments
+            )
+        )
+
     def to_dict(self) -> Dict[str, Any]:
         return self._raw_part.to_dict()
 


### PR DESCRIPTION
This allows users to create Parts from function calls, making it possible to use the generate_content function instead of creating a chat session. 

Fixes [3194](https://github.com/googleapis/python-aiplatform/issues/3194) 🦕