### PR TITLE
Added max_tokens in successful finish reasons list

### DIFF
--- a/vertexai/generative_models/_generative_models.py
+++ b/vertexai/generative_models/_generative_models.py
@@ -634,6 +634,7 @@ class _GenerativeModel:
 
 _SUCCESSFUL_FINISH_REASONS = [
     gapic_content_types.Candidate.FinishReason.STOP,
+    gapic_content_types.Candidate.FinishReason.MAX_TOKENS,
     # Many responses have this finish reason
     gapic_content_types.Candidate.FinishReason.FINISH_REASON_UNSPECIFIED,
 ]


### PR DESCRIPTION
max_tokens should be a successful response type. If not, the code throws a [ResponseValidationError exception](https://github.com/googleapis/python-aiplatform/blob/main/vertexai/generative_models/_generative_models.py#L648)

