### PR TITLE
fix: Do not call _append_gapic_content() on empty content

### DIFF
--- a/vertexai/generative_models/_generative_models.py
+++ b/vertexai/generative_models/_generative_models.py
@@ -1829,8 +1829,8 @@ def _append_gapic_candidate(
         raise ValueError(
             f"Incorrect candidate indexes: {base_candidate.index} != {new_candidate.index}"
         )
-
-    _append_gapic_content(base_candidate.content, new_candidate.content)
+    if new_candidate.content:
+        _append_gapic_content(base_candidate.content, new_candidate.content)
 
     # For these attributes, the last value wins
     if new_candidate.finish_reason:


### PR DESCRIPTION
This allows a new chunk with an empty content to be merged into a base chunk with non-empty content.

Fixes #3507