### PR TITLE
fix(deps): Require proto-plus 1.22.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -246,7 +246,7 @@ setuptools.setup(
             " <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*"
         ),
         "google-auth >= 2.14.1, <3.0.0dev",
-        "proto-plus >= 1.22.0, <2.0.0dev",
+        "proto-plus >= 1.22.3, <2.0.0dev",
         "protobuf>=4.25.3,<5.0.0dev",
         "packaging >= 14.3",
         "google-cloud-storage >= 1.32.0, < 3.0.0dev",

--- a/testing/constraints-3.10.txt
+++ b/testing/constraints-3.10.txt
@@ -2,7 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
-proto-plus==1.22.0
+proto-plus==1.22.3
 protobuf
 mock==4.0.2
 google-cloud-storage==2.2.1 # Increased for kfp 2.0 compatibility

--- a/testing/constraints-3.8.txt
+++ b/testing/constraints-3.8.txt
@@ -4,7 +4,7 @@
 # List *all* library dependencies and extras in this file.
 google-api-core==2.17.1 # Increased for gapic owlbot presubmit tests
 google-auth==2.14.1
-proto-plus==1.22.0
+proto-plus==1.22.3
 protobuf
 mock==4.0.2
 google-cloud-storage==2.2.1 # Increased for kfp 2.0 compatibility

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -2,7 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
-proto-plus==1.22.0
+proto-plus==1.22.3
 protobuf
 mock==4.0.2
 google-cloud-storage==2.2.1 # Increased for kfp 2.0 compatibility

--- a/testing/constraints-ray-2.4.0.txt
+++ b/testing/constraints-ray-2.4.0.txt
@@ -1,7 +1,7 @@
 ray==2.4.0
 # Below constraints are inherited from constraints-3.10.txt
 google-api-core
-proto-plus==1.22.0
+proto-plus==1.22.3
 protobuf
 mock==4.0.2
 google-cloud-storage==2.2.1 # Increased for kfp 2.0 compatibility

--- a/testing/constraints-ray-2.9.3.txt
+++ b/testing/constraints-ray-2.9.3.txt
@@ -1,7 +1,7 @@
 ray==2.9.3
 # Below constraints are inherited from constraints-3.10.txt
 google-api-core
-proto-plus==1.22.0
+proto-plus==1.22.3
 protobuf
 mock==4.0.2
 google-cloud-storage==2.2.1 # Increased for kfp 2.0 compatibility


### PR DESCRIPTION
Update the minimum version of `proto-plus` to 1.22.3 to match [gapic-generator-python](https://github.com/googleapis/gapic-generator-python/blob/6fc3d22b697ed14ef2daa18bbd0964026caed850/gapic/templates/setup.py.j2#L37) similar to https://github.com/googleapis/gapic-generator-python/pull/1863. This will prevent issues like https://github.com/googleapis/proto-plus-python/issues/469.