### PR TITLE
Draft: extract serving container env vars to localmodel

### DIFF
--- a/google/cloud/aiplatform/prediction/local_model.py
+++ b/google/cloud/aiplatform/prediction/local_model.py
@@ -411,6 +411,7 @@ class LocalModel:
         gpu_capabilities: Optional[List[List[str]]] = None,
         container_ready_timeout: Optional[int] = None,
         container_ready_check_interval: Optional[int] = None,
+        container_environment_variables: Optional[dict[str, str]] = None,
     ) -> LocalEndpoint:
         """Deploys the local model instance to a local endpoint.
 
@@ -504,6 +505,8 @@ class LocalModel:
             A the local endpoint object.
         """
         envs = {env.name: env.value for env in self.serving_container_spec.env}
+        if container_environment_variables is not None:
+            envs.update(container_environment_variables)
         ports = [port.container_port for port in self.serving_container_spec.ports]
 
         return LocalEndpoint(

--- a/tests/unit/aiplatform/test_prediction.py
+++ b/tests/unit/aiplatform/test_prediction.py
@@ -1751,6 +1751,7 @@ class TestLocalModel:
             host_port=host_port,
             container_ready_timeout=container_ready_timeout,
             container_ready_check_interval=container_ready_check_interval,
+            container_environment_variables=_TEST_SERVING_CONTAINER_ENVIRONMENT_VARIABLES,
         ):
             pass
 
@@ -1761,7 +1762,7 @@ class TestLocalModel:
             serving_container_health_route="",
             serving_container_command=[],
             serving_container_args=[],
-            serving_container_environment_variables={},
+            serving_container_environment_variables=_TEST_SERVING_CONTAINER_ENVIRONMENT_VARIABLES,
             serving_container_ports=[],
             credential_path=credential_path,
             host_port=host_port,
@@ -1982,9 +1983,7 @@ class TestLocalModel:
             """
             Docker failed with error code {return_code}.
             Command: {command}
-            """.format(
-                return_code=return_code, command=" ".join(expected_command)
-            )
+            """.format(return_code=return_code, command=" ".join(expected_command))
         )
 
         with pytest.raises(errors.DockerError) as exception:


### PR DESCRIPTION
This is a draft, as writing a code for this tiny change is much easier than explaining what i would like to change.

It is a quality of life improvement that allows to set env variables for testing the local model with `LocalModel.deploy_to_local_endpoint` without the need to understand the internals of `LocalModel`, namely `serving_container_spec`. The reason it is annoying to deal with `serving_container_spec` is that the type checker doesnt see the `gca_model_compat` definition, so fixing `from google.cloud.aiplatform.compat.types import model as gca_model_compat` is another solution for improving quality of life.

Please feel free to change the course of this PR as im not sure what i want to see in the end apart from usability improvements