### PR TITLE
Draft: add cpu and memory config

### DIFF
--- a/google/cloud/aiplatform/docker_utils/run.py
+++ b/google/cloud/aiplatform/docker_utils/run.py
@@ -19,7 +19,7 @@ import logging
 import os
 from pathlib import Path
 import re
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, List, Optional, Union, Sequence
 
 try:
     import docker
@@ -94,6 +94,8 @@ def run_prediction_container(
     gpu_count: Optional[int] = None,
     gpu_device_ids: Optional[List[str]] = None,
     gpu_capabilities: Optional[List[List[str]]] = None,
+    nano_cpus: Optional[int] = None,
+    mem_limit: Optional[Union[int, str]] = None,
 ) -> docker.models.containers.Container:
     """Runs a prediction container locally.
 
@@ -246,6 +248,8 @@ def run_prediction_container(
         volumes=volumes,
         device_requests=device_requests,
         detach=True,
+        nano_cpus=nano_cpus,
+        mem_limit=mem_limit,
     )
 
     return container

--- a/google/cloud/aiplatform/prediction/local_endpoint.py
+++ b/google/cloud/aiplatform/prediction/local_endpoint.py
@@ -19,7 +19,7 @@ import logging
 from pathlib import Path
 import requests
 import time
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Union, Sequence
 
 from google.auth.exceptions import GoogleAuthError
 
@@ -57,6 +57,8 @@ class LocalEndpoint:
         gpu_capabilities: Optional[List[List[str]]] = None,
         container_ready_timeout: Optional[int] = None,
         container_ready_check_interval: Optional[int] = None,
+        cpus: Optional[float] = None,
+        mem_limit: Optional[Union[int, str]] = None,
     ):
         """Creates a local endpoint instance.
 
@@ -171,6 +173,12 @@ class LocalEndpoint:
         self.gpu_device_ids = gpu_device_ids
         self.gpu_capabilities = gpu_capabilities
 
+        if cpus is None:
+            self.nano_cpus = None
+        else:
+            self.nano_cpus = int(cpus * 10**9)
+        self.mem_limit = mem_limit
+
         if self.gpu_count and self.gpu_device_ids:
             raise ValueError(
                 "At most one gpu_count or gpu_device_ids can be set but both are set."
@@ -262,6 +270,8 @@ class LocalEndpoint:
                 gpu_count=self.gpu_count,
                 gpu_device_ids=self.gpu_device_ids,
                 gpu_capabilities=self.gpu_capabilities,
+                nano_cpus=self.nano_cpus,
+                mem_limit=self.mem_limit,
             )
 
             # Retrieves the assigned host port.

--- a/tests/unit/aiplatform/test_prediction.py
+++ b/tests/unit/aiplatform/test_prediction.py
@@ -164,6 +164,8 @@ _TEST_GPU_DEVICE_IDS = ["1"]
 _TEST_GPU_CAPABILITIES = [["gpu"]]
 _TEST_MULTIPROCESSING_CPU_COUNT = 16
 _DEFAULT_WORKERS_PER_CORE = 1
+_TEST_CPUS = 0.8
+_TEST_MEM_LIMIT = 1 * 1000**3
 
 
 @pytest.fixture
@@ -1982,9 +1984,7 @@ class TestLocalModel:
             """
             Docker failed with error code {return_code}.
             Command: {command}
-            """.format(
-                return_code=return_code, command=" ".join(expected_command)
-            )
+            """.format(return_code=return_code, command=" ".join(expected_command))
         )
 
         with pytest.raises(errors.DockerError) as exception:
@@ -2020,6 +2020,8 @@ class TestLocalEndpoint:
             gpu_count=None,
             gpu_device_ids=None,
             gpu_capabilities=None,
+            nano_cpus=None,
+            mem_limit=None,
         )
         assert run_prediction_container_mock.return_value.stop.called
 
@@ -2071,6 +2073,8 @@ class TestLocalEndpoint:
             gpu_count=None,
             gpu_device_ids=None,
             gpu_capabilities=None,
+            nano_cpus=None,
+            mem_limit=None,
         )
         assert run_prediction_container_mock.return_value.stop.called
 
@@ -2099,6 +2103,8 @@ class TestLocalEndpoint:
             gpu_count=None,
             gpu_device_ids=None,
             gpu_capabilities=None,
+            nano_cpus=None,
+            mem_limit=None,
         )
         assert run_prediction_container_mock.return_value.stop.called
 
@@ -2129,6 +2135,8 @@ class TestLocalEndpoint:
             gpu_count=_TEST_GPU_COUNT,
             gpu_device_ids=None,
             gpu_capabilities=_TEST_GPU_CAPABILITIES,
+            nano_cpus=None,
+            mem_limit=None,
         )
         assert run_prediction_container_mock.return_value.stop.called
 
@@ -2159,6 +2167,8 @@ class TestLocalEndpoint:
             gpu_count=None,
             gpu_device_ids=_TEST_GPU_DEVICE_IDS,
             gpu_capabilities=_TEST_GPU_CAPABILITIES,
+            nano_cpus=None,
+            mem_limit=None,
         )
         assert run_prediction_container_mock.return_value.stop.called
 
@@ -2205,6 +2215,8 @@ class TestLocalEndpoint:
             gpu_count=_TEST_GPU_COUNT,
             gpu_device_ids=None,
             gpu_capabilities=prediction.DEFAULT_LOCAL_RUN_GPU_CAPABILITIES,
+            nano_cpus=None,
+            mem_limit=None,
         )
         assert run_prediction_container_mock.return_value.stop.called
 
@@ -2231,6 +2243,8 @@ class TestLocalEndpoint:
             gpu_count=None,
             gpu_device_ids=_TEST_GPU_DEVICE_IDS,
             gpu_capabilities=prediction.DEFAULT_LOCAL_RUN_GPU_CAPABILITIES,
+            nano_cpus=None,
+            mem_limit=None,
         )
         assert run_prediction_container_mock.return_value.stop.called
 
@@ -2257,6 +2271,8 @@ class TestLocalEndpoint:
             gpu_count=prediction.DEFAULT_LOCAL_RUN_GPU_COUNT,
             gpu_device_ids=None,
             gpu_capabilities=_TEST_GPU_CAPABILITIES,
+            nano_cpus=None,
+            mem_limit=None,
         )
         assert run_prediction_container_mock.return_value.stop.called
 
@@ -2288,6 +2304,8 @@ class TestLocalEndpoint:
             gpu_count=None,
             gpu_device_ids=None,
             gpu_capabilities=None,
+            nano_cpus=None,
+            mem_limit=None,
         )
         assert (
             run_prediction_container_container_not_running_mock.return_value.stop.called
@@ -2327,6 +2345,8 @@ class TestLocalEndpoint:
             gpu_count=None,
             gpu_device_ids=None,
             gpu_capabilities=None,
+            nano_cpus=None,
+            mem_limit=None,
         )
         local_endpoint_print_container_logs_mock.assert_called_once_with(
             show_all=True,
@@ -2368,6 +2388,8 @@ class TestLocalEndpoint:
             gpu_count=None,
             gpu_device_ids=None,
             gpu_capabilities=None,
+            nano_cpus=None,
+            mem_limit=None,
         )
         local_endpoint_print_container_logs_mock.assert_called_once_with(
             show_all=True,
@@ -2402,6 +2424,8 @@ class TestLocalEndpoint:
             gpu_count=None,
             gpu_device_ids=None,
             gpu_capabilities=None,
+            nano_cpus=None,
+            mem_limit=None,
         )
 
     def test_serve_with_all_parameters(
@@ -2452,6 +2476,8 @@ class TestLocalEndpoint:
             gpu_count=None,
             gpu_device_ids=None,
             gpu_capabilities=None,
+            nano_cpus=None,
+            mem_limit=None,
         )
 
     def test_serve_with_initializer_project(
@@ -2480,6 +2506,8 @@ class TestLocalEndpoint:
             gpu_count=None,
             gpu_device_ids=None,
             gpu_capabilities=None,
+            nano_cpus=None,
+            mem_limit=None,
         )
 
     def test_serve_with_gpu_count(
@@ -2510,6 +2538,8 @@ class TestLocalEndpoint:
             gpu_count=_TEST_GPU_COUNT,
             gpu_device_ids=None,
             gpu_capabilities=_TEST_GPU_CAPABILITIES,
+            nano_cpus=None,
+            mem_limit=None,
         )
 
     def test_serve_with_gpu_device_ids(
@@ -2540,6 +2570,74 @@ class TestLocalEndpoint:
             gpu_count=None,
             gpu_device_ids=_TEST_GPU_DEVICE_IDS,
             gpu_capabilities=_TEST_GPU_CAPABILITIES,
+            nano_cpus=None,
+            mem_limit=None,
+        )
+
+    def test_serve_with_cpus_limit(
+        self,
+        initializer_project_none_mock,
+        run_prediction_container_mock,
+        local_endpoint_run_health_check_mock,
+    ):
+        local_endpoint = LocalEndpoint(_TEST_IMAGE_URI, cpus=_TEST_CPUS)
+
+        local_endpoint.serve()
+
+        run_prediction_container_mock.assert_called_once_with(
+            _TEST_IMAGE_URI,
+            artifact_uri=None,
+            serving_container_predict_route=prediction.DEFAULT_LOCAL_PREDICT_ROUTE,
+            serving_container_health_route=prediction.DEFAULT_LOCAL_HEALTH_ROUTE,
+            serving_container_command=None,
+            serving_container_args=None,
+            serving_container_environment_variables={},
+            serving_container_ports=None,
+            credential_path=None,
+            host_port=None,
+            gpu_count=None,
+            gpu_device_ids=None,
+            gpu_capabilities=None,
+            nano_cpus=int(_TEST_CPUS * 10**9),
+            mem_limit=None,
+        )
+
+    @pytest.mark.parametrize(
+        "mem_limit",
+        [
+            _TEST_MEM_LIMIT,
+            f"{_TEST_MEM_LIMIT}",
+            f"{_TEST_MEM_LIMIT}b",
+            f"{int(_TEST_MEM_LIMIT / 1000**2)}m"
+        ],
+    )
+    def test_serve_with_memory_limit(
+        self,
+        initializer_project_none_mock,
+        run_prediction_container_mock,
+        local_endpoint_run_health_check_mock,
+        mem_limit
+    ):
+        local_endpoint = LocalEndpoint(_TEST_IMAGE_URI, mem_limit=mem_limit)
+
+        local_endpoint.serve()
+
+        run_prediction_container_mock.assert_called_once_with(
+            _TEST_IMAGE_URI,
+            artifact_uri=None,
+            serving_container_predict_route=prediction.DEFAULT_LOCAL_PREDICT_ROUTE,
+            serving_container_health_route=prediction.DEFAULT_LOCAL_HEALTH_ROUTE,
+            serving_container_command=None,
+            serving_container_args=None,
+            serving_container_environment_variables={},
+            serving_container_ports=None,
+            credential_path=None,
+            host_port=None,
+            gpu_count=None,
+            gpu_device_ids=None,
+            gpu_capabilities=None,
+            nano_cpus=None,
+            mem_limit=mem_limit,
         )
 
     def test_serve_serve_twice(
@@ -2569,6 +2667,8 @@ class TestLocalEndpoint:
             gpu_count=None,
             gpu_device_ids=None,
             gpu_capabilities=None,
+            nano_cpus=None,
+            mem_limit=None,
         )
 
     def test_stop(


### PR DESCRIPTION
This is a draft, as writing a code for this tiny change is much easier than explaining what i would like to change.

The main motivator of this one is being able to test / observe the OOM behavior of LocalModel-s when deploying locally with `LocalModel.deploy_to_local_endpoint`. Thus, ive added some flags the user can set to control `docker run` behavior. I have considered:
- passing arbitrary `**kwargs` to `docker run` as flags via the same mechanism im using in this PR
- passing a config object to `docker run` as flags via the same mechanism
- selecting the most useful subset of flags to expose to `deploy_to_local_endpoint` 
Ive chosen the third approach as it is the least sloppy and/or bloated and ive felt like this was the authors intention, even though it is the least flexible. Feel free to choose another approach