### PR TITLE
feat: extend image formats and mime types

### DIFF
--- a/vertexai/generative_models/_generative_models.py
+++ b/vertexai/generative_models/_generative_models.py
@@ -2765,13 +2765,6 @@ def _dict_to_pretty_string(d: dict) -> str:
     return json.dumps(d, indent=2)
 
 
-_FORMAT_TO_MIME_TYPE = {
-    "png": "image/png",
-    "jpeg": "image/jpeg",
-    "gif": "image/gif",
-}
-
-
 class Image:
     """The image that can be sent to a generative model."""
 
@@ -2821,7 +2814,7 @@ class Image:
     def _mime_type(self) -> str:
         """Returns the MIME type of the image."""
         if PIL_Image:
-            return _FORMAT_TO_MIME_TYPE[self._pil_image.format.lower()]
+            return PIL_Image.MIME[self._pil_image.format.upper()]
         else:
             # Fall back to jpeg
             return "image/jpeg"


### PR DESCRIPTION
- This allows calling `vertexai.generative_models.Image.load_from_file()` with all formats supported by Pillow, which are also supported by Gemini, e.g. WEBP/BMP/TIFF/...
- This removes the PNG/JPEG/GIF limitation and makes format support more future-proof
- Dependency calls:
  - PIL_Image.MIME <- \_mime_type <- \_pil_image <- PIL_Image.open
  - PIL_Image.MIME is filled once PIL_Image.open is called
  - So, \_mime_type is always valid as the image is loaded first
- Note that, for formats potentially supported by Gemini and not Pillow, users can do the following: ``` image_bytes = pathlib.Path(image_path).read_bytes() mime_type = "image/..." image = vertexai.generative_models.Part.from_data(image_bytes, mime_type) ```