### PR TITLE
Fix: add scope to auth when uploading the ragfile.

### DIFF
--- a/vertexai/preview/rag/rag_data.py
+++ b/vertexai/preview/rag/rag_data.py
@@ -455,7 +455,7 @@ def upload_file(
         "metadata": (None, str(js_rag_file)),
         "file": open(path, "rb"),
     }
-    credentials, _ = auth.default()
+    credentials, _ = auth.default(scopes=['https://www.googleapis.com/auth/cloud-platform'])
     authorized_session = google_auth_requests.AuthorizedSession(credentials=credentials)
     try:
         response = authorized_session.post(


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-aiplatform/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Get the necessary approvals
- [ ] Once the last commit on the PR has been approved, add the "ready to pull" label to the Pull Request

Note: do not merge your PR from GitHub. Adding the "ready to pull" label is the final step in the review process.
After approvals, the changes in your PR will be committed to the `main` branch and this PR will be closed.

Fixes :
fixed the following error :
```
app-1      |     |   File "/usr/local/lib/python3.11/site-packages/vertexai/preview/rag/rag_data.py", line 467, in upload_file
app-1      |     |     raise RuntimeError("Failed in uploading the RagFile due to: ", e) from e
app-1      |     | RuntimeError: ('Failed in uploading the RagFile due to: ', RefreshError('invalid_scope: Invalid OAuth scope or ID token audience provided.', {'error': 'invalid_scope', 'error_description': 'Invalid OAuth scope or ID token audience provided.'}))
```
 🦕