### PR TITLE
feat:  agent engine service_account argument support for `client.agent_engines.create()` and update

### DIFF
--- a/vertexai/_genai/agent_engines.py
+++ b/vertexai/_genai/agent_engines.py
@@ -57,6 +57,14 @@ def _ReasoningEngineSpec_to_vertex(
             getv(from_object, ["deployment_spec"]),
         )
 
+    if getv(from_object, ["service_account"]) is not None:
+        setv(
+            to_object,
+            ["serviceAccount"],
+            getv(from_object, ["service_account"]),
+        )
+
+
     if getv(from_object, ["package_spec"]) is not None:
         setv(to_object, ["packageSpec"], getv(from_object, ["package_spec"]))
 
@@ -2721,6 +2729,7 @@ class AgentEngines(_api_module.BaseModule):
             gcs_dir_name=config.gcs_dir_name,
             extra_packages=config.extra_packages,
             env_vars=config.env_vars,
+            service_account=config.service_account,
             context_spec=context_spec,
         )
         operation = self._create(config=api_config)
@@ -2768,6 +2777,7 @@ class AgentEngines(_api_module.BaseModule):
         gcs_dir_name: Optional[str] = None,
         extra_packages: Optional[Sequence[str]] = None,
         env_vars: Optional[dict[str, Union[str, Any]]] = None,
+        service_account: Optional[str] = None,
         context_spec: Optional[types.ReasoningEngineContextSpecDict] = None,
     ) -> types.UpdateAgentEngineConfigDict:
         import sys
@@ -2860,6 +2870,9 @@ class AgentEngines(_api_module.BaseModule):
                 ) = self._generate_deployment_spec_or_raise(env_vars=env_vars)
                 update_masks.extend(deployment_update_masks)
                 agent_engine_spec["deployment_spec"] = deployment_spec
+            if service_account is not None:
+                agent_engine_spec["service_account"] = service_account
+                update_masks.append("spec.service_account")
             class_methods = _agent_engines_utils._generate_class_methods_spec_or_raise(
                 agent_engine=agent_engine,
                 operations=_agent_engines_utils._get_registered_operations(
@@ -3071,6 +3084,7 @@ class AgentEngines(_api_module.BaseModule):
             description=config.description,
             gcs_dir_name=config.gcs_dir_name,
             extra_packages=config.extra_packages,
+            service_account=config.service_account,
             env_vars=config.env_vars,
             context_spec=context_spec,
         )

--- a/vertexai/_genai/types.py
+++ b/vertexai/_genai/types.py
@@ -7523,6 +7523,10 @@ class AgentEngineConfig(_common.BaseModel):
       If it is a dictionary, the keys are the environment variable names, and
       the values are the corresponding values.""",
     )
+    service_account: Optional[str] = Field(
+        default=None,
+        description="""The service account that the Agent Engine will run on."""
+    )
     context_spec: Optional[ReasoningEngineContextSpec] = Field(
         default=None,
         description="""The context spec to be used for the Agent Engine.""",
@@ -7569,6 +7573,9 @@ class AgentEngineConfigDict(TypedDict, total=False):
 
       If it is a dictionary, the keys are the environment variable names, and
       the values are the corresponding values."""
+    
+    service_account: Optional[str]
+    """The service account that the Agent Engine will run on."""
 
     context_spec: Optional[ReasoningEngineContextSpecDict]
     """The context spec to be used for the Agent Engine."""

--- a/vertexai/_genai/types.py
+++ b/vertexai/_genai/types.py
@@ -3518,6 +3518,10 @@ class ReasoningEngineSpec(_common.BaseModel):
         default=None,
         description="""Optional. User provided package spec of the ReasoningEngine. Ignored when users directly specify a deployment image through `deployment_spec.first_party_image_override`, but keeping the field_behavior to avoid introducing breaking changes.""",
     )
+    service_account: Optional[str] = Field(
+        default=None,
+        description="""Optional. The service account that the Agent Engine will run on. If none provided, the default service account will be used."""
+    )
 
 
 class ReasoningEngineSpecDict(TypedDict, total=False):
@@ -3534,7 +3538,9 @@ class ReasoningEngineSpecDict(TypedDict, total=False):
 
     package_spec: Optional[ReasoningEngineSpecPackageSpecDict]
     """Optional. User provided package spec of the ReasoningEngine. Ignored when users directly specify a deployment image through `deployment_spec.first_party_image_override`, but keeping the field_behavior to avoid introducing breaking changes."""
-
+    
+    service_account: Optional[str]
+    """Optional. The service account that the Agent Engine will run on. If none provided, the default service account will be used."""
 
 ReasoningEngineSpecOrDict = Union[ReasoningEngineSpec, ReasoningEngineSpecDict]
 
@@ -7525,7 +7531,9 @@ class AgentEngineConfig(_common.BaseModel):
     )
     service_account: Optional[str] = Field(
         default=None,
-        description="""The service account that the Agent Engine will run on."""
+        description="""The service account that the Agent Engine will run on. 
+
+        If none provided, the default service account will be used.""",
     )
     context_spec: Optional[ReasoningEngineContextSpec] = Field(
         default=None,
@@ -7575,7 +7583,9 @@ class AgentEngineConfigDict(TypedDict, total=False):
       the values are the corresponding values."""
     
     service_account: Optional[str]
-    """The service account that the Agent Engine will run on."""
+    """The service account that the Agent Engine will run on. 
+        
+      If none provided, the default service account will be used."""
 
     context_spec: Optional[ReasoningEngineContextSpecDict]
     """The context spec to be used for the Agent Engine."""


### PR DESCRIPTION
- Add the service_account parameter in types
- Add the service_account parameter in create/update in `_genai/agent_engines.py`
- Add tests to deploy with only service_account

Fixes #5698 🦕