### PR TITLE
Fix: Missing embedding_metadata in MatchNeighbor returned by find_neighbors in Vertex AI Matching Engine.

### DIFF
--- a/google/cloud/aiplatform/matching_engine/matching_engine_index_endpoint.py
+++ b/google/cloud/aiplatform/matching_engine/matching_engine_index_endpoint.py
@@ -16,7 +16,7 @@
 #
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union, Any
 
 from google.auth import credentials as auth_credentials
 from google.cloud.aiplatform import base
@@ -208,7 +208,8 @@ class MatchNeighbor:
             For example, values [1,2,3] with dimensions [4,5,6] means value 1 is
             of the 4th dimension, value 2 is of the 4th dimension, and value 3 is
             of the 6th dimension.
-
+        embedding_metadata (Dict[str,Any]):
+            Optional. The embedding metadata of the matching datapoint.
     """
 
     id: str
@@ -220,6 +221,7 @@ class MatchNeighbor:
     numeric_restricts: Optional[List[NumericNamespace]] = None
     sparse_embedding_values: Optional[List[float]] = None
     sparse_embedding_dimensions: Optional[List[int]] = None
+    embedding_metadata: Optional[Dict[str,Any]] = None
 
     def from_index_datapoint(
         self, index_datapoint: gca_index_v1beta1.IndexDatapoint
@@ -276,6 +278,8 @@ class MatchNeighbor:
             self.sparse_embedding_dimensions = (
                 index_datapoint.sparse_embedding.dimensions
             )
+        if index_datapoint.embedding_metadata is not None:
+            self.embedding_metadata = dict(index_datapoint.embedding_metadata)
         return self
 
     def from_embedding(self, embedding: match_service_pb2.Embedding) -> "MatchNeighbor":


### PR DESCRIPTION
## Summary
The `aiplatform.MatchingEngineIndexEndpoint.find_neighbors()` method returns results as 
`List[List[aiplatform.matching_engine.matching_engine_index_endpoint.MatchNeighbor]]`.  
However, the current `MatchNeighbor` dataclass does not expose the `embedding_metadata` field, 
even when `return_full_datapoint=True` and the API response includes the `embeddingMetadata` attribute.

## Issue
When `return_full_datapoint=True` is set, the API correctly returns the full datapoint with 
`embeddingMetadata`, but this metadata is silently dropped because the 
`MatchNeighbor` class does not have a corresponding attribute to capture it.

## Fix
The `aiplatform_v1beta1.index.IndexDatapoint` class already supports `embedding_metadata`.  
This PR adds an `embedding_metadata` field to the `MatchNeighbor` dataclass and populates it 
within the `MatchNeighbor.from_index_datapoint()` method.

## Testing
Verified the fix locally by querying an index with `return_full_datapoint=True`.  
The `embedding_metadata` field now appears correctly in the returned `MatchNeighbor` objects 
and matches the data returned directly from the API.

## Impact
This change enables users to access `embedding_metadata` when using 
`find_neighbors()` through the Python SDK, bringing it to parity with the REST API behavior.
