### PR TITLE
fix: always create TreeAhConfig in create_tree_ah_index()

### DIFF
--- a/google/cloud/aiplatform/matching_engine/matching_engine_index.py
+++ b/google/cloud/aiplatform/matching_engine/matching_engine_index.py
@@ -596,15 +596,10 @@ class MatchingEngineIndex(base.VertexAiResourceNounWithFutureManager):
 
         """
 
-        algorithm_config = None
-        if (
-            leaf_node_embedding_count is not None
-            or leaf_nodes_to_search_percent is not None
-        ):
-            algorithm_config = matching_engine_index_config.TreeAhConfig(
-                leaf_node_embedding_count=leaf_node_embedding_count,
-                leaf_nodes_to_search_percent=leaf_nodes_to_search_percent,
-            )
+        algorithm_config = matching_engine_index_config.TreeAhConfig(
+            leaf_node_embedding_count=leaf_node_embedding_count,
+            leaf_nodes_to_search_percent=leaf_nodes_to_search_percent,
+        )
 
         config = matching_engine_index_config.MatchingEngineIndexConfig(
             dimensions=dimensions,

--- a/tests/unit/aiplatform/test_matching_engine_index.py
+++ b/tests/unit/aiplatform/test_matching_engine_index.py
@@ -637,7 +637,12 @@ class TestMatchingEngineIndex:
             display_name=_TEST_INDEX_DISPLAY_NAME,
             metadata={
                 "config": {
-                    "algorithmConfig": None,
+                    "algorithmConfig": {
+                        "treeAhConfig": {
+                            "leafNodeEmbeddingCount": None,
+                            "leafNodesToSearchPercent": None,
+                        }
+                    },
                     "dimensions": _TEST_INDEX_CONFIG_DIMENSIONS,
                     "approximateNeighborsCount": _TEST_INDEX_APPROXIMATE_NEIGHBORS_COUNT,
                     "distanceMeasureType": _TEST_INDEX_DISTANCE_MEASURE_TYPE,


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-aiplatform/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
- [ ] Get the necessary approvals
- [ ] Once the last commit on the PR has been approved, add the "ready to pull" label to the Pull Request

Note: do not merge your PR from GitHub. Adding the "ready to pull" label is the final step in the review process.
After approvals, the changes in your PR will be committed to the `main` branch and this PR will be closed.

Fixes #6222 🦕

---

## Summary

PR #5954 introduced a regression where `create_tree_ah_index()` fails when `leaf_node_embedding_count` and `leaf_nodes_to_search_percent` are not specified, because `algorithmConfig` is set to `None` instead of `{"treeAhConfig": {}}`.

According to the [official documentation](https://cloud.google.com/vertex-ai/docs/vector-search/configuring-indexes), `algorithmConfig` is a **required** field.

## Changes

Reverts the conditional logic in `create_tree_ah_index()` to always create a `TreeAhConfig`:

```python
# Before (buggy - after PR #5954)
algorithm_config = None
if (
    leaf_node_embedding_count is not None
    or leaf_nodes_to_search_percent is not None
):
    algorithm_config = TreeAhConfig(...)

# After (fixed)
algorithm_config = TreeAhConfig(
    leaf_node_embedding_count=leaf_node_embedding_count,
    leaf_nodes_to_search_percent=leaf_nodes_to_search_percent,
)
```

## Test

Updated `test_create_tree_ah_index_empty_algorithm_config` to expect `{"treeAhConfig": {...}}` instead of `None`.

All 66 tree-AH related tests pass.