### PR TITLE
chore: replace old vertexai teams with vertexai-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 # The Vertex SDK dev team is the default owner for approving PRs.
-*                                      @googleapis/cloud-aiplatform-model-builder-sdk
+*                                      @googleapis/vertexai-team


### PR DESCRIPTION
Replace old Vertex AI teams with the new vertexai-team.

b/478003109