### PR TITLE
fix: remove predictable GCS bucket names to prevent bucket squatting

### DIFF
--- a/google/cloud/aiplatform/utils/gcs_utils.py
+++ b/google/cloud/aiplatform/utils/gcs_utils.py
@@ -185,6 +185,8 @@ def stage_local_data_in_gcs(
 
     Raises:
         RuntimeError: When source_path does not exist.
+        RuntimeError: When staging_gcs_dir is not provided and staging_bucket
+            is not configured via aiplatform.init().
         GoogleCloudError: When the upload process fails.
     """
     data_path_obj = pathlib.Path(data_path)
@@ -225,14 +227,20 @@ def generate_gcs_directory_for_pipeline_artifacts(
     project: Optional[str] = None,
     location: Optional[str] = None,
 ):
-    """Gets or creates the GCS directory for Vertex Pipelines artifacts.
+    """Gets the GCS directory for Vertex Pipelines artifacts.
+
+    Requires staging_bucket to be configured via aiplatform.init().
+    The project and location parameters are deprecated and ignored.
 
     Args:
-        project: Optional. Google Cloud Project that contains the staging bucket.
-        location: Optional. Google Cloud location to use for the staging bucket.
+        project: Deprecated. No longer used.
+        location: Deprecated. No longer used.
 
     Returns:
-        Google Cloud Storage URI of the staged data.
+        Google Cloud Storage URI for pipeline artifacts.
+
+    Raises:
+        RuntimeError: When staging_bucket is not configured via aiplatform.init().
     """
     pipeline_root = initializer.global_config.staging_bucket
     if not pipeline_root:
@@ -242,6 +250,7 @@ def generate_gcs_directory_for_pipeline_artifacts(
             "This is required to prevent the use of predictable bucket names "
             "which could be exploited via bucket squatting attacks."
         )
+    validate_gcs_path(pipeline_root)
 
     output_artifacts_gcs_dir = pipeline_root.rstrip("/") + "/output_artifacts/"
     return output_artifacts_gcs_dir

--- a/google/cloud/aiplatform/utils/gcs_utils.py
+++ b/google/cloud/aiplatform/utils/gcs_utils.py
@@ -194,26 +194,12 @@ def stage_local_data_in_gcs(
 
     staging_gcs_dir = staging_gcs_dir or initializer.global_config.staging_bucket
     if not staging_gcs_dir:
-        project = project or initializer.global_config.project
-        location = location or initializer.global_config.location
-        credentials = credentials or initializer.global_config.credentials
-        # Creating the bucket if it does not exist.
-        # Currently we only do this when staging_gcs_dir is not specified.
-        # The buckets that we create are regional.
-        # This prevents errors when some service required regional bucket.
-        # E.g. "FailedPrecondition: 400 The Cloud Storage bucket of `gs://...` is in location `us`. It must be in the same regional location as the service location `us-central1`."
-        # We are making the bucket name region-specific since the bucket is regional.
-        staging_bucket_name = project + "-vertex-staging-" + location
-        client = storage.Client(project=project, credentials=credentials)
-        staging_bucket = storage.Bucket(client=client, name=staging_bucket_name)
-        if not staging_bucket.exists():
-            _logger.info(f'Creating staging GCS bucket "{staging_bucket_name}"')
-            staging_bucket = client.create_bucket(
-                bucket_or_name=staging_bucket,
-                project=project,
-                location=location,
-            )
-        staging_gcs_dir = "gs://" + staging_bucket_name
+        raise RuntimeError(
+            "staging_gcs_dir should be passed to stage_local_data_in_gcs or "
+            "should be set using aiplatform.init(staging_bucket='gs://my-bucket'). "
+            "This is required to prevent the use of predictable bucket names "
+            "which could be exploited via bucket squatting attacks."
+        )
 
     timestamp = datetime.datetime.now().isoformat(sep="-", timespec="milliseconds")
     staging_gcs_subdir = (
@@ -248,11 +234,16 @@ def generate_gcs_directory_for_pipeline_artifacts(
     Returns:
         Google Cloud Storage URI of the staged data.
     """
-    project = project or initializer.global_config.project
-    location = location or initializer.global_config.location
+    pipeline_root = initializer.global_config.staging_bucket
+    if not pipeline_root:
+        raise RuntimeError(
+            "pipeline_root should be passed to PipelineJob or "
+            "should be set using aiplatform.init(staging_bucket='gs://my-bucket'). "
+            "This is required to prevent the use of predictable bucket names "
+            "which could be exploited via bucket squatting attacks."
+        )
 
-    pipelines_bucket_name = project + "-vertex-pipelines-" + location
-    output_artifacts_gcs_dir = "gs://" + pipelines_bucket_name + "/output_artifacts/"
+    output_artifacts_gcs_dir = pipeline_root.rstrip("/") + "/output_artifacts/"
     return output_artifacts_gcs_dir
 
 

--- a/google/cloud/aiplatform/utils/gcs_utils.py
+++ b/google/cloud/aiplatform/utils/gcs_utils.py
@@ -187,6 +187,7 @@ def stage_local_data_in_gcs(
         RuntimeError: When source_path does not exist.
         RuntimeError: When staging_gcs_dir is not provided and staging_bucket
             is not configured via aiplatform.init().
+        ValueError: When staging_gcs_dir does not have a 'gs://' prefix.
         GoogleCloudError: When the upload process fails.
     """
     data_path_obj = pathlib.Path(data_path)
@@ -202,6 +203,7 @@ def stage_local_data_in_gcs(
             "This is required to prevent the use of predictable bucket names "
             "which could be exploited via bucket squatting attacks."
         )
+    validate_gcs_path(staging_gcs_dir)
 
     timestamp = datetime.datetime.now().isoformat(sep="-", timespec="milliseconds")
     staging_gcs_subdir = (

--- a/tests/unit/aiplatform/test_utils.py
+++ b/tests/unit/aiplatform/test_utils.py
@@ -577,11 +577,27 @@ class TestGcsUtils:
             == f"{staging_gcs_dir}/vertex_ai_auto_staging/{timestamp}/test.json"
         )
 
-    def test_generate_gcs_directory_for_pipeline_artifacts(self):
-        output = gcs_utils.generate_gcs_directory_for_pipeline_artifacts(
-            "project", "us-central1"
-        )
-        assert output == "gs://project-vertex-pipelines-us-central1/output_artifacts/"
+    def test_generate_gcs_directory_for_pipeline_artifacts_with_staging_bucket(self):
+        with patch.object(
+            gcs_utils.initializer.global_config,
+            "staging_bucket",
+            "gs://my-staging-bucket",
+        ):
+            output = gcs_utils.generate_gcs_directory_for_pipeline_artifacts(
+                "project", "us-central1"
+            )
+            assert output == "gs://my-staging-bucket/output_artifacts/"
+
+    def test_generate_gcs_directory_for_pipeline_artifacts_raises_without_staging_bucket(
+        self,
+    ):
+        with patch.object(
+            gcs_utils.initializer.global_config, "staging_bucket", None
+        ):
+            with pytest.raises(RuntimeError, match="pipeline_root should be passed"):
+                gcs_utils.generate_gcs_directory_for_pipeline_artifacts(
+                    "project", "us-central1"
+                )
 
     @patch.object(storage.Bucket, "exists", return_value=False)
     @patch.object(storage, "Client")
@@ -593,15 +609,14 @@ class TestGcsUtils:
     ):
         output = (
             gcs_utils.create_gcs_bucket_for_pipeline_artifacts_if_it_does_not_exist(
-                project="test-project", location="us-central1"
+                output_artifacts_gcs_dir="gs://my-bucket/output_artifacts/",
+                project="test-project",
+                location="us-central1",
             )
         )
         assert mock_storage_client.called
         assert mock_bucket_not_exist.called
-        assert mock_get_project_number.called
-        assert (
-            output == "gs://test-project-vertex-pipelines-us-central1/output_artifacts/"
-        )
+        assert output == "gs://my-bucket/output_artifacts/"
 
     def test_download_from_gcs_dir(
         self, mock_storage_client_list_blobs, mock_storage_blob_download_to_filename


### PR DESCRIPTION
## Summary

The fix for CVE-2026-2473 (GHSA-wh2j-26j7-9728) in v1.133.0 patched `metadata/_models.py` but missed two other locations in `utils/gcs_utils.py` that construct GCS bucket names from predictable inputs (project ID + region):

- `stage_local_data_in_gcs()` line 206: `"{project}-vertex-staging-{location}"`
- `generate_gcs_directory_for_pipeline_artifacts()` line 254: `"{project}-vertex-pipelines-{location}"`

An attacker who knows a victim's project ID and region can pre-register these globally-unique bucket names in their own GCP project and configure public write access. When the victim's SDK auto-generates the same predictable name, `Bucket.exists()` returns True for the attacker's bucket, and the SDK silently uploads model artifacts, training data, and pipeline outputs to attacker-controlled storage.

## Changes

Apply the same fix pattern as CVE-2026-2473:

- **`stage_local_data_in_gcs()`**: Require explicit `staging_gcs_dir` or `aiplatform.init(staging_bucket=...)`. Raise `RuntimeError` if neither is provided, instead of auto-generating a predictable bucket name.
- **`generate_gcs_directory_for_pipeline_artifacts()`**: Use `staging_bucket` from global config. Raise `RuntimeError` if not set. Add `validate_gcs_path()` to ensure proper `gs://` prefix.
- Updated docstrings with `Raises` sections and deprecated parameter notes.
- Updated unit tests to match new behavior.

## Affected entry points

- `Model.upload()` when `staging_bucket` is not provided (calls `stage_local_data_in_gcs`)
- `PipelineJob()` when `pipeline_root` is not provided (calls `generate_gcs_directory_for_pipeline_artifacts`)

## Test plan

- [x] Updated `test_generate_gcs_directory_for_pipeline_artifacts` — tests both success path (with staging_bucket) and RuntimeError path
- [x] Updated `test_create_gcs_bucket_for_pipeline_artifacts_if_it_does_not_exist` — passes explicit `output_artifacts_gcs_dir`
- [ ] Verify no regressions in `vertexai/` callers (distillation, language models)