### PR TITLE
feat: Add ThinkingConfig support to GenerationConfig

### DIFF
--- a/tests/unit/vertexai/test_generative_models.py
+++ b/tests/unit/vertexai/test_generative_models.py
@@ -1537,6 +1537,73 @@ class TestGenerativeModels:
         )
         assert config.to_dict()["response_schema"] == _RENAMING_EXPECTED_SCHEMA
 
+    def test_generation_config_with_thinking_budget(self):
+        config = generative_models.GenerationConfig(
+            thinking_config=generative_models.GenerationConfig.ThinkingConfig(
+                thinking_budget=1024,
+            ),
+        )
+        config_dict = config.to_dict()
+        assert config_dict["thinking_config"]["thinking_budget"] == 1024
+
+    def test_generation_config_with_include_thoughts(self):
+        config = generative_models.GenerationConfig(
+            thinking_config=generative_models.GenerationConfig.ThinkingConfig(
+                include_thoughts=True,
+            ),
+        )
+        config_dict = config.to_dict()
+        assert config_dict["thinking_config"]["include_thoughts"] is True
+
+    def test_generation_config_with_thinking_level(self):
+        ThinkingConfig = generative_models.GenerationConfig.ThinkingConfig
+        config = generative_models.GenerationConfig(
+            thinking_config=ThinkingConfig(
+                thinking_level=ThinkingConfig.ThinkingLevel.HIGH,
+            ),
+        )
+        # thinking_level is a v1-only field; verify it survives the
+        # v1 → v1beta1 → v1 binary serialization round-trip.
+        raw = config._raw_generation_config
+        serialized = type(raw).serialize(raw)
+        deserialized_v1 = types_v1.GenerationConfig.deserialize(serialized)
+        assert deserialized_v1.thinking_config.thinking_level == (
+            types_v1.GenerationConfig.ThinkingConfig.ThinkingLevel.HIGH
+        )
+
+    def test_generation_config_with_thinking_config_combined(self):
+        ThinkingConfig = generative_models.GenerationConfig.ThinkingConfig
+        config = generative_models.GenerationConfig(
+            thinking_config=ThinkingConfig(
+                thinking_budget=4096,
+                include_thoughts=True,
+                thinking_level=ThinkingConfig.ThinkingLevel.MEDIUM,
+            ),
+        )
+        config_dict = config.to_dict()
+        assert config_dict["thinking_config"]["thinking_budget"] == 4096
+        assert config_dict["thinking_config"]["include_thoughts"] is True
+        # Verify thinking_level survives binary round-trip
+        raw = config._raw_generation_config
+        serialized = type(raw).serialize(raw)
+        deserialized_v1 = types_v1.GenerationConfig.deserialize(serialized)
+        assert deserialized_v1.thinking_config.thinking_level == (
+            types_v1.GenerationConfig.ThinkingConfig.ThinkingLevel.MEDIUM
+        )
+
+    def test_generation_config_thinking_config_from_dict(self):
+        config = generative_models.GenerationConfig.from_dict(
+            {
+                "thinking_config": {
+                    "thinking_budget": 2048,
+                    "include_thoughts": True,
+                },
+            }
+        )
+        config_dict = config.to_dict()
+        assert config_dict["thinking_config"]["thinking_budget"] == 2048
+        assert config_dict["thinking_config"]["include_thoughts"] is True
+
     def test_tool_schema_dict_renaming(self):
         # The `Tool` constructor does not take a dict so we don't test it here.
         tool = generative_models.Tool.from_dict(

--- a/vertexai/generative_models/_generative_models.py
+++ b/vertexai/generative_models/_generative_models.py
@@ -1764,6 +1764,7 @@ class GenerationConfig:
 
     Modality = gapic_content_types.GenerationConfig.Modality
     ModelConfig = gapic_content_types.GenerationConfig.ModelConfig
+    ThinkingConfig = types_v1.GenerationConfig.ThinkingConfig
 
     def __init__(
         self,
@@ -1785,6 +1786,7 @@ class GenerationConfig:
         response_logprobs: Optional[bool] = None,
         response_modalities: Optional[List["GenerationConfig.Modality"]] = None,
         model_config: Optional["GenerationConfig.ModelConfig"] = None,
+        thinking_config: Optional["GenerationConfig.ThinkingConfig"] = None,
     ):
         r"""Constructs a GenerationConfig object.
 
@@ -1817,6 +1819,11 @@ class GenerationConfig:
             logprobs: Logit probabilities.
             reponse_logprobs: If true, export the logprobs results in response.
             model_config: Sets cost vs quality preference for model routing requests.
+            thinking_config: Configuration for thinking features
+                (thinking_level, thinking_budget, include_thoughts). Use
+                ``GenerationConfig.ThinkingConfig`` to construct. Note:
+                ``thinking_level`` is not preserved by ``to_dict()``/``from_dict()``
+                due to v1beta1 proto limitations.
 
         Usage:
 
@@ -1863,6 +1870,15 @@ class GenerationConfig:
         if routing_config is not None:
             self._raw_generation_config.routing_config = (
                 routing_config._gapic_routing_config
+            )
+        if thinking_config is not None:
+            # Convert v1 ThinkingConfig to v1beta1 via binary serialization.
+            # This preserves thinking_level (field 4) as an unknown field in
+            # v1beta1, which survives the v1beta1 → v1 conversion in GA model.
+            self._raw_generation_config.thinking_config = (
+                gapic_content_types.GenerationConfig.ThinkingConfig.deserialize(
+                    type(thinking_config).serialize(thinking_config)
+                )
             )
 
     @classmethod


### PR DESCRIPTION
## Summary

- Expose `ThinkingConfig` (`thinking_level`, `thinking_budget`, `include_thoughts`) in the high-level `vertexai.generative_models.GenerationConfig` wrapper
- Alias `types_v1.GenerationConfig.ThinkingConfig` on the `GenerationConfig` class, following the existing `ModelConfig` pattern
- Convert v1 ThinkingConfig → v1beta1 via binary serialization to preserve `thinking_level` through the v1beta1 → v1 round-trip in GA `GenerativeModel`

### Motivation

The GAPIC v1 proto layer already defines `ThinkingConfig` with `thinking_level` (enum: LOW/MEDIUM/HIGH/MINIMAL), `thinking_budget`, and `include_thoughts` for Gemini 2.5+ and 3.x models. However, the high-level `GenerationConfig` wrapper does not expose these, forcing users to work with raw GAPIC types or dict-based configs.

### Usage

```python
from vertexai.generative_models import GenerativeModel, GenerationConfig

model = GenerativeModel("gemini-2.5-flash")

# Using thinking_level (Gemini 3+)
response = model.generate_content(
    "Explain quantum entanglement",
    generation_config=GenerationConfig(
        thinking_config=GenerationConfig.ThinkingConfig(
            thinking_level=GenerationConfig.ThinkingConfig.ThinkingLevel.HIGH,
        )
    ),
)

# Using thinking_budget (Gemini 2.5)
response = model.generate_content(
    "Solve this problem",
    generation_config=GenerationConfig(
        thinking_config=GenerationConfig.ThinkingConfig(
            thinking_budget=2048,
        )
    ),
)
```

### Known limitation

`thinking_level` is not preserved by `to_dict()`/`from_dict()` because the wrapper internally stores config as v1beta1 proto (which lacks the `thinking_level` field). The value is preserved through binary serialization for `generate_content()` calls. This is documented in the docstring.

## Test plan

- [x] Unit test: `test_generation_config_with_thinking_budget`
- [x] Unit test: `test_generation_config_with_include_thoughts`
- [x] Unit test: `test_generation_config_with_thinking_level` (verifies binary serialization round-trip)
- [x] Unit test: `test_generation_config_with_thinking_config_combined` (all 3 fields together)
- [x] Unit test: `test_generation_config_thinking_config_from_dict`
- [x] Full test suite regression check: 131/131 passed