### PR TITLE
fix: Execution.create() 503 from credentials annotation typo and missing metadata store init

### DIFF
--- a/google/cloud/aiplatform/metadata/execution.py
+++ b/google/cloud/aiplatform/metadata/execution.py
@@ -100,7 +100,7 @@ class Execution(resource._Resource):
         metadata_store_id: str = "default",
         project: Optional[str] = None,
         location: Optional[str] = None,
-        credentials=Optional[auth_credentials.Credentials],
+        credentials: Optional[auth_credentials.Credentials] = None,
     ) -> "Execution":
         """
         Creates a new Metadata Execution.
@@ -149,6 +149,11 @@ class Execution(resource._Resource):
                 "aiplatform.metadata.execution.Execution.create"
             )
 
+        if metadata_store_id == "default":
+            metadata_store._MetadataStore.ensure_default_metadata_store_exists(
+                project=project, location=location, credentials=credentials
+            )
+
         return cls._create(
             resource_id=resource_id,
             schema_title=schema_title,
@@ -178,7 +183,7 @@ class Execution(resource._Resource):
         metadata_store_id: str = "default",
         project: Optional[str] = None,
         location: Optional[str] = None,
-        credentials=Optional[auth_credentials.Credentials],
+        credentials: Optional[auth_credentials.Credentials] = None,
     ) -> "Execution":
         """
         Creates a new Metadata Execution.

--- a/tests/unit/aiplatform/test_metadata_resources.py
+++ b/tests/unit/aiplatform/test_metadata_resources.py
@@ -28,6 +28,7 @@ from google.cloud.aiplatform.compat.types import event as gca_event
 from google.cloud.aiplatform.metadata import artifact
 from google.cloud.aiplatform.metadata import context
 from google.cloud.aiplatform.metadata import execution
+from google.cloud.aiplatform.metadata import metadata_store
 from google.cloud.aiplatform.metadata import utils as metadata_utils
 from google.cloud.aiplatform_v1 import (
     MetadataServiceClient,
@@ -1004,6 +1005,77 @@ class TestExecution:
         )
         assert len(artifact_list) == 1
         assert artifact_list[0]._gca_resource == expected_artifact
+
+    def test_create_credentials_default_is_none(self):
+        """Verify the credentials parameter defaults to None, not a type object.
+
+        Regression test for https://github.com/googleapis/python-aiplatform/issues/6610.
+        The original code used ``credentials=Optional[...]`` (assignment) instead of
+        ``credentials: Optional[...] = None`` (annotation with default). The ``=`` form
+        makes the default the ``typing.Optional`` type object itself, which causes a
+        503 "Getting metadata from plugin failed with error: before_request" when the
+        gRPC auth stack tries to call ``.before_request()`` on it.
+        """
+        import inspect
+
+        sig = inspect.signature(execution.Execution.create)
+        default = sig.parameters["credentials"].default
+        assert default is None, (
+            f"Execution.create() credentials default should be None, got {default!r}. "
+            "Check that the annotation uses ':' (not '=') with a '= None' default."
+        )
+
+        sig_internal = inspect.signature(execution.Execution._create)
+        default_internal = sig_internal.parameters["credentials"].default
+        assert default_internal is None, (
+            f"Execution._create() credentials default should be None, got {default_internal!r}. "
+            "Check that the annotation uses ':' (not '=') with a '= None' default."
+        )
+
+    @pytest.mark.usefixtures("create_execution_mock", "get_execution_mock")
+    def test_create_calls_ensure_default_metadata_store_exists(
+        self, create_execution_mock
+    ):
+        """Verify Execution.create() initializes the default metadata store.
+
+        Regression test for https://github.com/googleapis/python-aiplatform/issues/6610.
+        Artifact.create() calls ensure_default_metadata_store_exists() before creating
+        the resource, but Execution.create() originally skipped this call, causing 503
+        credential plugin errors when no prior Artifact.create() or aiplatform.init()
+        had warmed up the metadata store.
+        """
+        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
+
+        with patch.object(
+            metadata_store._MetadataStore,
+            "ensure_default_metadata_store_exists",
+        ) as ensure_store_mock:
+            execution.Execution.create(
+                schema_title=_TEST_SCHEMA_TITLE,
+                display_name=_TEST_DISPLAY_NAME,
+                metadata_store_id="default",
+            )
+            ensure_store_mock.assert_called_once_with(
+                project=None, location=None, credentials=None
+            )
+
+    @pytest.mark.usefixtures("create_execution_mock", "get_execution_mock")
+    def test_create_skips_ensure_for_non_default_metadata_store(
+        self, create_execution_mock
+    ):
+        """Verify ensure_default_metadata_store_exists is not called for non-default stores."""
+        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
+
+        with patch.object(
+            metadata_store._MetadataStore,
+            "ensure_default_metadata_store_exists",
+        ) as ensure_store_mock:
+            execution.Execution.create(
+                schema_title=_TEST_SCHEMA_TITLE,
+                display_name=_TEST_DISPLAY_NAME,
+                metadata_store_id=_TEST_METADATA_STORE,
+            )
+            ensure_store_mock.assert_not_called()
 
 
 @pytest.mark.usefixtures("google_auth_mock")


### PR DESCRIPTION
## Summary

Fixes #6610.

Two bugs in `metadata/execution.py` caused `Execution.create()` to fail with `503 Getting metadata from plugin failed with error: before_request`:

1. **Credentials annotation typo** (`create()` line 103, `_create()` line 181): Used `credentials=Optional[auth_credentials.Credentials]` (assignment, `=`) instead of `credentials: Optional[auth_credentials.Credentials] = None` (annotation with default, `:`). The `=` form makes the default value the `typing.Optional` type object itself (a `_UnionGenericAlias`), not `None`. This non-None object is passed to the gRPC auth stack, which calls `.before_request()` on it, producing the 503. Present since PR #1410 (June 2022). `artifact.py` and `context.py` both have the correct `: ... = None` syntax.

2. **Missing `ensure_default_metadata_store_exists()` call**: `Artifact.create()` calls `metadata_store._MetadataStore.ensure_default_metadata_store_exists()` before delegating to `_create()`, but `Execution.create()` skipped this. Standalone `Execution.create()` (without a prior `Artifact.create()` or `aiplatform.init(experiment=...)` warming the store) would fail.

## Changes

- `google/cloud/aiplatform/metadata/execution.py`: Fix `credentials` annotation on both `create()` and `_create()`. Add `ensure_default_metadata_store_exists()` call in `create()` matching `Artifact.create()`.
- `tests/unit/aiplatform/test_metadata_resources.py`: 3 regression tests:
  - `test_create_credentials_default_is_none` -- verifies both `create()` and `_create()` default to `None`
  - `test_create_calls_ensure_default_metadata_store_exists` -- verifies the store init is called for default store
  - `test_create_skips_ensure_for_non_default_metadata_store` -- verifies it's skipped for non-default stores

## Test plan

- [x] 3 new tests FAIL against unfixed code (2 FAILED, 1 PASSED as expected)
- [x] 3 new tests PASS against fixed code
- [x] All 13 existing `TestExecution` tests pass (zero regressions)

## CLA

Signed.