### PR TITLE
fix: Escape HTML in display_explanations to prevent stored XSS

### DIFF
--- a/vertexai/evaluation/notebook_utils.py
+++ b/vertexai/evaluation/notebook_utils.py
@@ -16,6 +16,7 @@
 #
 """Python functions which run only within a Jupyter or Colab notebook."""
 
+import html as html_lib
 import random
 import string
 import sys
@@ -153,7 +154,9 @@ def display_explanations(
 
     for _, row in df.iterrows():
         for col in df.columns:
-            display(HTML(f"<div style='{style}'><h4>{col}:</h4>{row[col]}</div>"))
+            safe_col = html_lib.escape(str(col))
+            safe_val = html_lib.escape(str(row[col]))
+            display(HTML(f"<div style='{style}'><h4>{safe_col}:</h4>{safe_val}</div>"))
         display(HTML("<hr>"))
 
 

--- a/vertexai/preview/evaluation/notebook_utils.py
+++ b/vertexai/preview/evaluation/notebook_utils.py
@@ -16,6 +16,7 @@
 #
 """Python functions which run only within a Jupyter or Colab notebook."""
 
+import html as html_lib
 import random
 import string
 import sys
@@ -153,7 +154,9 @@ def display_explanations(
 
     for _, row in df.iterrows():
         for col in df.columns:
-            display(HTML(f"<div style='{style}'><h4>{col}:</h4>{row[col]}</div>"))
+            safe_col = html_lib.escape(str(col))
+            safe_val = html_lib.escape(str(row[col]))
+            display(HTML(f"<div style='{style}'><h4>{safe_col}:</h4>{safe_val}</div>"))
         display(HTML("<hr>"))
 
 


### PR DESCRIPTION
## Description

`display_explanations()` in `notebook_utils.py` renders column names and cell values from evaluation DataFrames directly into `IPython.display.HTML()` without escaping. If a DataFrame contains crafted HTML/JS payloads (e.g. from a shared dataset or model output), they execute in the user's Colab/Jupyter session.

This applies `html.escape()` to both column headers and cell values before interpolation, matching the pattern already used in `_evals_visualization.py`.

Fixes both `vertexai/evaluation` and `vertexai/preview/evaluation` paths.

## Reproducer

```python
import pandas as pd
from unittest.mock import MagicMock

evil_df = pd.DataFrame({
    '<img src=x onerror=alert("XSS")>': ['<script>alert(1)</script>']
})

eval_result = MagicMock()
eval_result.metrics_table = evil_df

from vertexai.evaluation.notebook_utils import display_explanations
display_explanations(eval_result=eval_result)
# Before fix: alert box fires
# After fix: escaped safely
```