### PR TITLE
fix(deps): bump litellm cap to >=1.83.7 for additional CVE remediation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -183,9 +183,10 @@ evaluation_extra_require = [
     "jsonschema",
     "ruamel.yaml",
     "pyyaml",
-    "litellm>=1.75.5, <1.83.7, !=1.82.7, !=1.82.8",
-    # For LiteLLM tests. Upper bound pinned below latest version.
-    # Exclude 1.82.7 and 1.82.8 due to supply chain attack.
+    "litellm>=1.83.7, <1.83.15",
+    # For LiteLLM tests. Lower bound: CVE-2026-35030 plus 4 follow-on
+    # advisories patched in 1.83.7. Upper bound <1.83.15 admits current
+    # latest (1.83.14).
 ]
 
 langchain_extra_require = [


### PR DESCRIPTION
## Summary

Bumps the `litellm` cap in the `evaluation` extra from
`<1.83.7` to `<1.83.15`, and lifts the lower bound from `>=1.75.5` to
`>=1.83.7`. Drops the now-redundant `!=1.82.7, !=1.82.8` exclusions
(subsumed by the new lower bound; supply-chain history preserved in
git blame and #6617).

## Why

The current `<1.83.7` cap (set in #6617 to allow CVE-2026-35030
remediation in litellm 1.83.0) excludes four additional CVEs patched
in litellm 1.83.7, disclosed 2026-04-11 through 2026-04-24:

| Advisory | Severity | Patched in |
| --- | --- | --- |
| [GHSA-r75f-5x8p-qvmc](https://github.com/advisories/GHSA-r75f-5x8p-qvmc) | critical | 1.83.7 |
| [GHSA-jjhc-v7c2-5hh6](https://github.com/advisories/GHSA-jjhc-v7c2-5hh6) | critical | 1.83.7 |
| [GHSA-xqmj-j6mv-4862](https://github.com/advisories/GHSA-xqmj-j6mv-4862) | high | 1.83.7 |
| [GHSA-69x8-hrgq-fjj8](https://github.com/advisories/GHSA-69x8-hrgq-fjj8) | high | 1.83.7 |

(Plus [GHSA-53mr-6c8q-9789](https://github.com/advisories/GHSA-53mr-6c8q-9789),
high, patched in 1.83.0, already covered by the existing lower bound.)

## Trigger

`google/adk-python` PR
[#5489](https://github.com/google/adk-python/pull/5489) pins
`litellm>=1.83.7, <=1.83.14` to ship these CVE patches to ADK users.
Its CI currently fails with a pip resolver conflict because
`google-cloud-aiplatform[evaluation]` (pulled in via the `eval`
extra) caps `litellm<1.83.7`. The bump was requested in
[the ADK PR review by @sasha-gitg](https://github.com/google/adk-python/pull/5489#issuecomment).

## Code adaptation already shipped

The `vertexai/_genai/_evals_common.py` adaptation for litellm 1.83.x
(switch from `litellm.utils.get_valid_models()` to
`litellm.get_llm_provider()`) was merged in
[#6599](https://github.com/googleapis/python-aiplatform/pull/6599) as
`ac5a5e4`. So this PR is purely a version-pin change; no source or
test changes are needed.

## Verification

Run from a clean checkout against the new pin:

```
$ nox -s lint
nox > Session lint was successful in 39 seconds.

$ nox -s lint_setup_py
nox > Session lint_setup_py was successful.

$ pytest tests/unit/vertexai/genai/test_evals.py -k litellm -q
4 passed, 266 deselected, 1 warning in 1.98s    # litellm==1.83.7
4 passed, 266 deselected, 1 warning in 14.68s   # litellm==1.83.14
```

Resolver semantics for `>=1.83.7, <1.83.15`:
- Admits: 1.83.7, 1.83.7.post1, ..., 1.83.14, 1.83.14.post1
- Rejects: 1.83.6, 1.83.7rc1, 1.83.15, any pre-release of admitted versions

## Related

- Closes #6598
- Continues the work begun in #6617 (matthew29tang) and #6599 (quad2524)
- cc @matthew29tang for visibility — you set the prior conservative
  `<1.83.7` cap and explicitly cited "internal guidance ... stricter
  upper bound on a minor version" at the time. The four follow-on CVEs
  in 1.83.7 (and the ADK consumer needing them) is the new input.
- cc @sasha-gitg as the requester from the ADK side.

I understand this repo lands external dep changes via Copybara
re-author; this PR is intended primarily as a complete, ready-to-
re-land artifact for whichever path is most convenient.
