### PR TITLE
Security: Missing import for base64 module

### DIFF
--- a/.sample_configs/implementations.py
+++ b/.sample_configs/implementations.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 #
 
+import base64
+
+
 def read_file(filename):
     with open(filename, 'rb') as f:
         file_content = f.read()


### PR DESCRIPTION
## Summary

Security: Missing import for base64 module

## Problem

**Severity**: `High` | **File**: `.sample_configs/implementations.py:L13`

The b64_encode function uses base64.b64encode() but base64 is not imported in the file. This will cause a NameError at runtime.

## Solution

Add 'import base64' at the top of the file.

## Changes

- `.sample_configs/implementations.py` (modified)