### PR TITLE
fix: skip ADK toolsets in AgentConfig tool declaration extraction

### DIFF
--- a/agentplatform/_genai/types/evals.py
+++ b/agentplatform/_genai/types/evals.py
@@ -96,6 +96,15 @@ class AgentConfig(_common.BaseModel):
                     tool_declarations.append({"function_declarations": [declaration]})
                 continue
 
+            # ADK toolsets (e.g. McpToolset, OpenAPIToolset) are containers
+            # whose tools are resolved asynchronously via get_tools(); they
+            # have no _get_declaration() and are not plain callables. The
+            # fallback below would call inspect.signature() on the toolset
+            # instance and raise TypeError, so skip them — their tool
+            # declarations cannot be resolved synchronously here.
+            if hasattr(tool, "get_tools") and callable(tool.get_tools):
+                continue
+
             tool_declarations.append(
                 {
                     "function_declarations": [

--- a/tests/unit/agentplatform/genai/test_evals.py
+++ b/tests/unit/agentplatform/genai/test_evals.py
@@ -9733,3 +9733,48 @@ class TestAllowCrossRegionModel:
             request_body.get("evaluationConfig", {}).get("allowCrossRegionModel")
             is True
         )
+
+
+class TestAgentConfigToolDeclarations:
+    """Tests for AgentConfig._get_tool_declarations_from_agent."""
+
+    def test_skips_toolsets_without_declaration(self):
+        """ADK toolsets (McpToolset etc.) must be skipped, not introspected.
+
+        Regression test: toolsets have no _get_declaration() and are not
+        plain callables, so the inspect.signature() fallback raised
+        TypeError("<...McpToolset object...> is not a callable object").
+        """
+
+        class _FakeToolset:
+            """Mimics google.adk.tools.BaseToolset: exposes get_tools()."""
+
+            async def get_tools(self, readonly_context=None):
+                return []
+
+        class _FakeDeclarationTool:
+            """Mimics an ADK BaseTool with an explicit declaration."""
+
+            def _get_declaration(self):
+                return genai_types.FunctionDeclaration(name="decl_tool")
+
+        def plain_callable_tool(city: str) -> str:
+            """Returns the weather for a city."""
+            return city
+
+        agent = mock.Mock()
+        agent.tools = [_FakeToolset(), _FakeDeclarationTool(), plain_callable_tool]
+
+        declarations = agentplatform_genai_types.evals.AgentConfig._get_tool_declarations_from_agent(
+            agent
+        )
+
+        # The toolset is skipped; the declaration-bearing tool and the plain
+        # callable are both extracted.
+        assert len(declarations) == 2
+        names = {
+            getattr(fd, "name", None)
+            for decl in declarations
+            for fd in decl["function_declarations"]
+        }
+        assert names == {"decl_tool", "plain_callable_tool"}

--- a/vertexai/_genai/types/evals.py
+++ b/vertexai/_genai/types/evals.py
@@ -96,6 +96,15 @@ class AgentConfig(_common.BaseModel):
                     tool_declarations.append({"function_declarations": [declaration]})
                 continue
 
+            # ADK toolsets (e.g. McpToolset, OpenAPIToolset) are containers
+            # whose tools are resolved asynchronously via get_tools(); they
+            # have no _get_declaration() and are not plain callables. The
+            # fallback below would call inspect.signature() on the toolset
+            # instance and raise TypeError, so skip them — their tool
+            # declarations cannot be resolved synchronously here.
+            if hasattr(tool, "get_tools") and callable(tool.get_tools):
+                continue
+
             tool_declarations.append(
                 {
                     "function_declarations": [


### PR DESCRIPTION
Fixes #6861

`AgentConfig._get_tool_declarations_from_agent` raises `TypeError` for any ADK agent whose `tools` include a toolset (`BaseToolset` — e.g. `McpToolset`, `OpenAPIToolset`): toolsets have no `_get_declaration()` and are not plain callables, so they fall through to `FunctionDeclaration.from_callable_with_api_option` → `inspect.signature()` → `TypeError: <McpToolset object ...> is not a callable object`. This breaks client-side eval inference (`client.evals.run_inference`) for every MCP-tooled ADK agent.

This change skips toolsets in the extraction loop (detected by their `get_tools()` interface), in **both** SDK copies — `vertexai/_genai/types/evals.py` and `agentplatform/_genai/types/evals.py` — mirroring the existing skip for declaration-less ADK tools. Toolset tool declarations cannot be resolved synchronously (async + context-dependent), and the declarations here are descriptive agent metadata.

#### Testing
- New unit test `TestAgentConfigToolDeclarations::test_skips_toolsets_without_declaration` (regression: fake toolset no longer raises; declaration-bearing tool and plain callable still extracted).
- `pytest tests/unit/agentplatform/genai/test_evals.py -k "Transformers or DropEmptyColumns or AgentConfig"` → 10 passed.
- Verified end-to-end against a real ADK agent with `McpToolset` (previously failed with the exact traceback in the issue; with this patch, inference runs and tool calls execute normally).