### PR TITLE
docs: document valid endpoint_id formats

### DIFF
--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -889,8 +889,12 @@ class Endpoint(base.VertexAiResourceNounWithFutureManager, base.PreviewMixin):
                 not provided, Vertex AI will generate a value for this
                 ID.
 
-                This value should be 1-10 characters, and valid
-                characters are /[0-9]/. When using HTTP/JSON, this field
+                This value can contain lowercase letters, digits, and hyphens.
+                If the first character is a letter, the last character must be
+                a letter or digit and the value can be up to 63 characters. If
+                the first character is a digit, all characters must be digits,
+                with no leading zeros, and the value can be up to 10 characters.
+                When using HTTP/JSON, this field
                 is populated based on a query string argument, such as
                 ``?endpoint_id=12345``. This is the fallback for fields
                 that are not included in either the URI or the body.
@@ -1049,8 +1053,12 @@ class Endpoint(base.VertexAiResourceNounWithFutureManager, base.PreviewMixin):
                 not provided, Vertex AI will generate a value for this
                 ID.
 
-                This value should be 1-10 characters, and valid
-                characters are /[0-9]/. When using HTTP/JSON, this field
+                This value can contain lowercase letters, digits, and hyphens.
+                If the first character is a letter, the last character must be
+                a letter or digit and the value can be up to 63 characters. If
+                the first character is a digit, all characters must be digits,
+                with no leading zeros, and the value can be up to 10 characters.
+                When using HTTP/JSON, this field
                 is populated based on a query string argument, such as
                 ``?endpoint_id=12345``. This is the fallback for fields
                 that are not included in either the URI or the body.


### PR DESCRIPTION
Fixes #2599

The endpoint_id documentation only describes numeric IDs with a maximum length of 10 characters. Update both duplicated docstring sections to document the actual accepted formats: lowercase letters, digits, hyphens, and the different length rules for letter- and digit-prefixed IDs.

Validation:
- [x] python -m py_compile google/cloud/aiplatform/models.py
- [x] git diff --check
- [x] One file changed: google/cloud/aiplatform/models.py